### PR TITLE
Fix incorrect condition in waitForTransaction function

### DIFF
--- a/.changeset/vast-pandas-check.md
+++ b/.changeset/vast-pandas-check.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+fix incorrect condition in waitForExecution function

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -39,6 +39,7 @@ import {
   BUNDLE_STATUS_FAILED,
   BUNDLE_STATUS_FILLED,
   BUNDLE_STATUS_PRECONFIRMED,
+  BUNDLE_STATUS_UNKNOWN,
   getEmptyUserOp,
   getOrchestrator,
   getOrderBundleHash,
@@ -392,22 +393,19 @@ async function waitForExecution(
   result: TransactionResult,
   acceptsPreconfirmations: boolean,
 ) {
-  const validStatuses: BundleStatus[] = [
+  const validStatuses: Set<BundleStatus> = new Set([
     BUNDLE_STATUS_FAILED,
     BUNDLE_STATUS_COMPLETED,
     BUNDLE_STATUS_FILLED,
-  ]
+  ])
   if (acceptsPreconfirmations) {
-    validStatuses.push(BUNDLE_STATUS_PRECONFIRMED)
+    validStatuses.add(BUNDLE_STATUS_PRECONFIRMED)
   }
 
   switch (result.type) {
     case 'bundle': {
-      let bundleResult: BundleResult | null = null
-      while (
-        bundleResult === null ||
-        validStatuses.includes(bundleResult.status)
-      ) {
+      let bundleResult: BundleResult = { status: BUNDLE_STATUS_UNKNOWN, claims: [] }
+      while (!validStatuses.has(bundleResult.status)) {
         const orchestrator = getOrchestratorByChain(
           result.targetChain,
           config.rhinestoneApiKey,


### PR DESCRIPTION
## Description

In the `result.type === bundle` path of the `waitForTransaction` function, the right hand side of the expression should be negated. The function assigns bundleResult to the first invocation of `orchestrator.getBundleStatus()` which will be `PENDING` at first invocation. The bug in the while loop condition makes it not actually wait for the transaction to reach one of the `validStatuses`

The correct logic is the following:  "The while loop should run while the bundle.status is **not** equal to one of the valid statuses".

What was happening is that the following: 

1st run: 
* left-hand-side: `bundleStatus === null` => true
* right-hand-side: `validStatuses.includes(bundleResult.status)` => false
* `lhs || rhs` => true
* `bundleResult = await orchestrator.getBundleStatus(result.id)` => bundleResult gets assigned and is no longer null

2nd run:
* lsh: `bundleStatus === null` => false
* rhs: `validStatuses.includes(bundleResult.status)` => false
* `lhs || rhs` => **false!**

I also opted to remove the `null` initialisation of the bundle result in favour of being initialised with a status of "unknown". Better readability and directly addresses one of the root causes of the bug. 

## Checklist
- [✅ ] Changeset
