### PR TITLE
Add required tokenPrices, gasPrices and opGasParams on POST /bundles

### DIFF
--- a/.changeset/clever-houses-follow.md
+++ b/.changeset/clever-houses-follow.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Pass tokenPrices, gasPrices and opGasParams on POST /bundles

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -310,21 +310,15 @@ async function sendTransactionAsUserOp(
       packedSig,
     ),
     targetSignature: packedSig,
+    tokenPrices: orderPath[0].orderBundle.tokenPrices,
+    gasPrices: orderPath[0].orderBundle.gasPrices,
+    opGasParams: orderPath[0].orderBundle.opGasParams
   }
-
-  const { 
-    tokenPrices,
-    gasPrices,
-    opGasParams
-  } = orderPath[0]
 
   const bundleResults = await orchestrator.postSignedOrderBundle([
     {
       signedOrderBundle,
       userOp,
-      tokenPrices,
-      gasPrices,
-      opGasParams
     },
   ])
 
@@ -395,13 +389,10 @@ async function sendTransactionAsIntent(
       packedSig,
     ),
     targetSignature: packedSig,
+    tokenPrices: orderPath[0].orderBundle.tokenPrices,
+    gasPrices: orderPath[0].orderBundle.gasPrices,
+    opGasParams: orderPath[0].orderBundle.opGasParams
   }
-
-  const { 
-    tokenPrices, 
-    gasPrices, 
-    opGasParams 
-  } = orderPath[0]
 
   await deployTarget(targetChain, config, false)
   const initCode = getBundleInitCode(config)
@@ -409,9 +400,6 @@ async function sendTransactionAsIntent(
     {
       signedOrderBundle,
       initCode,
-      tokenPrices,
-      gasPrices,
-      opGasParams
     },
   ])
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -310,9 +310,6 @@ async function sendTransactionAsUserOp(
       packedSig,
     ),
     targetSignature: packedSig,
-    tokenPrices: orderPath[0].orderBundle.tokenPrices,
-    gasPrices: orderPath[0].orderBundle.gasPrices,
-    opGasParams: orderPath[0].orderBundle.opGasParams,
   }
 
   const bundleResults = await orchestrator.postSignedOrderBundle([
@@ -389,9 +386,6 @@ async function sendTransactionAsIntent(
       packedSig,
     ),
     targetSignature: packedSig,
-    tokenPrices: orderPath[0].orderBundle.tokenPrices,
-    gasPrices: orderPath[0].orderBundle.gasPrices,
-    opGasParams: orderPath[0].orderBundle.opGasParams,
   }
 
   await deployTarget(targetChain, config, false)

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -312,10 +312,19 @@ async function sendTransactionAsUserOp(
     targetSignature: packedSig,
   }
 
+  const { 
+    tokenPrices,
+    gasPrices,
+    opGasParams
+  } = orderPath[0]
+
   const bundleResults = await orchestrator.postSignedOrderBundle([
     {
       signedOrderBundle,
       userOp,
+      tokenPrices,
+      gasPrices,
+      opGasParams
     },
   ])
 
@@ -388,12 +397,21 @@ async function sendTransactionAsIntent(
     targetSignature: packedSig,
   }
 
+  const { 
+    tokenPrices, 
+    gasPrices, 
+    opGasParams 
+  } = orderPath[0]
+
   await deployTarget(targetChain, config, false)
   const initCode = getBundleInitCode(config)
   const bundleResults = await orchestrator.postSignedOrderBundle([
     {
       signedOrderBundle,
       initCode,
+      tokenPrices,
+      gasPrices,
+      opGasParams
     },
   ])
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -312,7 +312,7 @@ async function sendTransactionAsUserOp(
     targetSignature: packedSig,
     tokenPrices: orderPath[0].orderBundle.tokenPrices,
     gasPrices: orderPath[0].orderBundle.gasPrices,
-    opGasParams: orderPath[0].orderBundle.opGasParams
+    opGasParams: orderPath[0].orderBundle.opGasParams,
   }
 
   const bundleResults = await orchestrator.postSignedOrderBundle([
@@ -391,7 +391,7 @@ async function sendTransactionAsIntent(
     targetSignature: packedSig,
     tokenPrices: orderPath[0].orderBundle.tokenPrices,
     gasPrices: orderPath[0].orderBundle.gasPrices,
-    opGasParams: orderPath[0].orderBundle.opGasParams
+    opGasParams: orderPath[0].orderBundle.opGasParams,
   }
 
   await deployTarget(targetChain, config, false)

--- a/src/execution/smart-session.test.ts
+++ b/src/execution/smart-session.test.ts
@@ -105,7 +105,7 @@ describe('Smart Session', () => {
                 ],
                 tokenPrices: {},
                 gasPrices: {},
-                opGasParams: {}
+                opGasParams: {},
               },
               injectedExecutions: [
                 {

--- a/src/execution/smart-session.test.ts
+++ b/src/execution/smart-session.test.ts
@@ -141,6 +141,9 @@ describe('Smart Session', () => {
                   },
                 ],
               },
+              tokenPrices: {},
+              gasPrices: {},
+              opGasParams: {}
             },
           ],
           '0x306651f0849c673fdd047e02b12876c3f3a0ea7f',

--- a/src/execution/smart-session.test.ts
+++ b/src/execution/smart-session.test.ts
@@ -103,6 +103,9 @@ describe('Smart Session', () => {
                     },
                   },
                 ],
+                tokenPrices: {},
+                gasPrices: {},
+                opGasParams: {}
               },
               injectedExecutions: [
                 {
@@ -141,9 +144,6 @@ describe('Smart Session', () => {
                   },
                 ],
               },
-              tokenPrices: {},
-              gasPrices: {},
-              opGasParams: {}
             },
           ],
           '0x306651f0849c673fdd047e02b12876c3f3a0ea7f',

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -6,12 +6,15 @@ import { OrchestratorError } from './error'
 import type {
   BundleEvent,
   BundleResult,
+  GasPrices,
   MetaIntent,
+  OPNetworkParams,
   OrderCostResult,
   OrderFeeInput,
   OrderPath,
   PostOrderBundleResult,
   SignedMultiChainCompact,
+  TokenPrices,
   UserTokenBalance,
 } from './types'
 import {
@@ -167,6 +170,9 @@ export class Orchestrator {
             }
           }),
           intentCost: parseOrderCost(orderPath.intentCost),
+          tokenPrices: orderPath.tokenPrices,
+          gasPrices: orderPath.gasPrices,
+          opGasParams: orderPath.opGasParams
         }
       })
     } catch (error: any) {
@@ -177,7 +183,10 @@ export class Orchestrator {
 
   async postSignedOrderBundle(
     signedOrderBundles: {
-      signedOrderBundle: SignedMultiChainCompact
+      signedOrderBundle: SignedMultiChainCompact,
+      tokenPrices: TokenPrices,
+      gasPrices: GasPrices,
+      opGasParams: OPNetworkParams,
       initCode?: Hex
       userOp?: UserOperation
     }[],
@@ -186,6 +195,9 @@ export class Orchestrator {
       const bundles = signedOrderBundles.map(
         (signedOrderBundle: {
           signedOrderBundle: SignedMultiChainCompact
+          tokenPrices: TokenPrices
+          gasPrices: GasPrices
+          opGasParams: OPNetworkParams
           initCode?: Hex
           userOp?: UserOperation
         }) => {
@@ -197,6 +209,9 @@ export class Orchestrator {
             userOp: signedOrderBundle.userOp
               ? convertBigIntFields(signedOrderBundle.userOp)
               : undefined,
+            tokenPrices: signedOrderBundle.tokenPrices,
+            gasPrices: signedOrderBundle.gasPrices,
+            opGasParams: signedOrderBundle.opGasParams,
           }
         },
       )

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -170,9 +170,6 @@ export class Orchestrator {
             }
           }),
           intentCost: parseOrderCost(orderPath.intentCost),
-          tokenPrices: orderPath.tokenPrices,
-          gasPrices: orderPath.gasPrices,
-          opGasParams: orderPath.opGasParams
         }
       })
     } catch (error: any) {
@@ -184,9 +181,6 @@ export class Orchestrator {
   async postSignedOrderBundle(
     signedOrderBundles: {
       signedOrderBundle: SignedMultiChainCompact,
-      tokenPrices: TokenPrices,
-      gasPrices: GasPrices,
-      opGasParams: OPNetworkParams,
       initCode?: Hex
       userOp?: UserOperation
     }[],
@@ -195,9 +189,6 @@ export class Orchestrator {
       const bundles = signedOrderBundles.map(
         (signedOrderBundle: {
           signedOrderBundle: SignedMultiChainCompact
-          tokenPrices: TokenPrices
-          gasPrices: GasPrices
-          opGasParams: OPNetworkParams
           initCode?: Hex
           userOp?: UserOperation
         }) => {
@@ -209,9 +200,6 @@ export class Orchestrator {
             userOp: signedOrderBundle.userOp
               ? convertBigIntFields(signedOrderBundle.userOp)
               : undefined,
-            tokenPrices: signedOrderBundle.tokenPrices,
-            gasPrices: signedOrderBundle.gasPrices,
-            opGasParams: signedOrderBundle.opGasParams,
           }
         },
       )

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -180,7 +180,7 @@ export class Orchestrator {
 
   async postSignedOrderBundle(
     signedOrderBundles: {
-      signedOrderBundle: SignedMultiChainCompact,
+      signedOrderBundle: SignedMultiChainCompact
       initCode?: Hex
       userOp?: UserOperation
     }[],

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -205,9 +205,9 @@ interface MultiChainCompact {
   nonce: bigint
   expires: bigint
   segments: Segment[]
-  tokenPrices: object
-  gasPrices: object
-  opGasParams: object
+  tokenPrices: TokenPrices
+  gasPrices: GasPrices
+  opGasParams: OPNetworkParams
 }
 
 interface SignedMultiChainCompact extends MultiChainCompact {
@@ -316,16 +316,18 @@ export type GasPrices = {
   [key in MainnetNetwork | TestnetNetwork]?: bigint
 }
 
-export type OPNetworkParams = {
-  [key in MainnetNetwork | TestnetNetwork]?: {
-    l1BaseFee: bigint
-    l1BlobBaseFee: bigint
-    baseFeeScalar: bigint
-    blobFeeScalar: bigint
-  }
-} | { 
-  estimatedCalldataSize: number 
-}
+export type OPNetworkParams =
+  | {
+      [key in MainnetNetwork | TestnetNetwork]?: {
+        l1BaseFee: bigint
+        l1BlobBaseFee: bigint
+        baseFeeScalar: bigint
+        blobFeeScalar: bigint
+      }
+    }
+  | {
+      estimatedCalldataSize: number
+    }
 
 const BUNDLE_STATUS_PENDING = 'PENDING'
 const BUNDLE_STATUS_FAILED = 'FAILED'

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -144,9 +144,6 @@ type OrderPath = {
   orderBundle: MultiChainCompact
   injectedExecutions: Execution[]
   intentCost: OrderCost
-  tokenPrices: TokenPrices
-  gasPrices: GasPrices
-  opGasParams: OPNetworkParams
 }[]
 
 type MetaIntentEmpty = MetaIntentBase & WithoutOperation
@@ -208,6 +205,9 @@ interface MultiChainCompact {
   nonce: bigint
   expires: bigint
   segments: Segment[]
+  tokenPrices: object
+  gasPrices: object
+  opGasParams: object
 }
 
 interface SignedMultiChainCompact extends MultiChainCompact {

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -25,6 +25,8 @@ type SupportedMainnet =
   | typeof arbitrum.id
   | typeof optimism.id
   | typeof polygon.id
+type SupportedOPStackMainnet = typeof optimism.id | typeof base.id
+type SupportedOPStackTestnet = typeof optimismSepolia.id | typeof baseSepolia.id
 type SupportedChain = SupportedMainnet | SupportedTestnet
 type SupportedTokenSymbol = 'ETH' | 'WETH' | 'USDC'
 type SupportedToken = SupportedTokenSymbol | Address
@@ -285,40 +287,17 @@ interface TokenConfig {
   balanceSlot: (address: Address) => Hex
 }
 
-export enum MainnetNetwork {
-  ETHEREUM = 1,
-  OPTIMISM = 10,
-  POLYGON = 137,
-  BASE = 8453,
-  ARBITRUM = 42161,
-}
-
-export enum TestnetNetwork {
-  POLYGON_AMOY = 80002,
-  BASE_SEPOLIA = 84532,
-  ARBITRUM_SEPOLIA = 421614,
-  ETHEREUM_SEPOLIA = 11155111,
-  OPTIMISM_SEPOLIA = 11155420,
-}
-
-export enum TokenSymbol {
-  ETH = 'ETH',
-  WETH = 'WETH',
-  USDC = 'USDC',
-  POL = 'POL',
-}
-
 export type TokenPrices = {
-  [key in TokenSymbol]?: number
+  [key in SupportedTokenSymbol]?: number
 }
 
 export type GasPrices = {
-  [key in MainnetNetwork | TestnetNetwork]?: bigint
+  [key in SupportedMainnet | SupportedTestnet]?: bigint
 }
 
 export type OPNetworkParams =
   | {
-      [key in MainnetNetwork | TestnetNetwork]?: {
+      [key in SupportedOPStackMainnet | SupportedOPStackTestnet]?: {
         l1BaseFee: bigint
         l1BlobBaseFee: bigint
         baseFeeScalar: bigint

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -144,6 +144,9 @@ type OrderPath = {
   orderBundle: MultiChainCompact
   injectedExecutions: Execution[]
   intentCost: OrderCost
+  tokenPrices: TokenPrices
+  gasPrices: GasPrices
+  opGasParams: OPNetworkParams
 }[]
 
 type MetaIntentEmpty = MetaIntentBase & WithoutOperation
@@ -280,6 +283,48 @@ interface TokenConfig {
   address: Address
   decimals: number
   balanceSlot: (address: Address) => Hex
+}
+
+export enum MainnetNetwork {
+  ETHEREUM = 1,
+  OPTIMISM = 10,
+  POLYGON = 137,
+  BASE = 8453,
+  ARBITRUM = 42161,
+}
+
+export enum TestnetNetwork {
+  POLYGON_AMOY = 80002,
+  BASE_SEPOLIA = 84532,
+  ARBITRUM_SEPOLIA = 421614,
+  ETHEREUM_SEPOLIA = 11155111,
+  OPTIMISM_SEPOLIA = 11155420,
+}
+
+export enum TokenSymbol {
+  ETH = 'ETH',
+  WETH = 'WETH',
+  USDC = 'USDC',
+  POL = 'POL',
+}
+
+export type TokenPrices = {
+  [key in TokenSymbol]?: number
+}
+
+export type GasPrices = {
+  [key in MainnetNetwork | TestnetNetwork]?: bigint
+}
+
+export type OPNetworkParams = {
+  [key in MainnetNetwork | TestnetNetwork]?: {
+    l1BaseFee: bigint
+    l1BlobBaseFee: bigint
+    baseFeeScalar: bigint
+    blobFeeScalar: bigint
+  }
+} | { 
+  estimatedCalldataSize: number 
 }
 
 const BUNDLE_STATUS_PENDING = 'PENDING'

--- a/src/orchestrator/utils.ts
+++ b/src/orchestrator/utils.ts
@@ -134,6 +134,9 @@ function parseCompactResponse(response: any): MultiChainCompact {
         },
       } as Segment
     }),
+    tokenPrices: response.tokenPrices,
+    gasPrices: response.gasPrices,
+    opGasParams: response.opGasParams
   } as MultiChainCompact
 }
 

--- a/src/orchestrator/utils.ts
+++ b/src/orchestrator/utils.ts
@@ -136,7 +136,7 @@ function parseCompactResponse(response: any): MultiChainCompact {
     }),
     tokenPrices: response.tokenPrices,
     gasPrices: response.gasPrices,
-    opGasParams: response.opGasParams
+    opGasParams: response.opGasParams,
   } as MultiChainCompact
 }
 


### PR DESCRIPTION
## Description
This PR is to match the changes on the order path and bundle posting endpoints to correctly pass token and gas pricing information to these calls, as stated on ticket [RHI-1927](https://linear.app/rhinestone/issue/RHI-1927/add-gas-price-and-gas-cost-estimation-logs-to-orch).

## Checklist
- [x] Changeset
