### PR TITLE
Granularize API

### DIFF
--- a/.changeset/proud-bugs-care.md
+++ b/.changeset/proud-bugs-care.md
@@ -1,0 +1,10 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Expose low-level APIs:
+
+- deploy
+- prepareTransaction
+- signTransaction
+- submitTransaction

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -43,6 +43,7 @@ import {
   getSmartAccount as getSafeSmartAccount,
 } from './safe'
 import { getBundlerClient } from './utils'
+import { enableSmartSession } from '../execution/smart-session'
 
 function getDeployArgs(config: RhinestoneAccountConfig) {
   const account = getAccount(config)
@@ -91,6 +92,17 @@ async function isDeployed(chain: Chain, config: RhinestoneAccountConfig) {
     throw new Error('Existing EIP-7702 accounts are not yet supported')
   }
   return size(code) > 0
+}
+
+async function deploy(
+  config: RhinestoneAccountConfig,
+  chain: Chain,
+  session?: Session,
+) {
+  await deploySource(chain, config)
+  if (session) {
+    await enableSmartSession(chain, config, session)
+  }
 }
 
 async function deploySource(chain: Chain, config: RhinestoneAccountConfig) {
@@ -409,6 +421,7 @@ export {
   getBundleInitCode,
   getAddress,
   isDeployed,
+  deploy,
   deploySource,
   deployTarget,
   getSmartAccount,

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -14,6 +14,7 @@ import {
   zeroHash,
 } from 'viem'
 import type { WebAuthnAccount } from 'viem/account-abstraction'
+import { enableSmartSession } from '../execution/smart-session'
 import {
   getWebauthnValidatorSignature,
   isRip7212SupportedNetwork,
@@ -43,7 +44,6 @@ import {
   getSmartAccount as getSafeSmartAccount,
 } from './safe'
 import { getBundlerClient } from './utils'
-import { enableSmartSession } from '../execution/smart-session'
 
 function getDeployArgs(config: RhinestoneAccountConfig) {
   const account = getAccount(config)

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -67,6 +67,7 @@ import {
   getSessionSignature,
   hashErc7739,
 } from './smart-session'
+import type { BundleData } from './modular'
 
 const POLLING_INTERVAL = 500
 
@@ -489,4 +490,4 @@ export {
   getMaxSpendableAmount,
   getPortfolio,
 }
-export type { TransactionResult }
+export type { BundleData, TransactionResult }

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -2,14 +2,9 @@ import {
   type Address,
   type Chain,
   createPublicClient,
-  type Hex,
   http,
   zeroAddress,
 } from 'viem'
-import {
-  entryPoint07Address,
-  getUserOperationHash,
-} from 'viem/account-abstraction'
 import { mainnet, sepolia } from 'viem/chains'
 
 import {
@@ -41,7 +36,7 @@ import type {
   TokenRequest,
   Transaction,
 } from '../types'
-
+import { enableSmartSession } from './smart-session'
 import type { BundleData, TransactionResult } from './utils'
 import {
   getOrchestratorByChain,
@@ -52,11 +47,6 @@ import {
   submitIntentInternal,
   submitUserOp,
 } from './utils'
-import {
-  enableSmartSession,
-  getSessionSignature,
-  hashErc7739,
-} from './smart-session'
 
 const POLLING_INTERVAL = 500
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -2,13 +2,8 @@ import {
   type Address,
   type Chain,
   createPublicClient,
-  encodeAbiParameters,
-  encodePacked,
   type Hex,
   http,
-  keccak256,
-  pad,
-  toHex,
   zeroAddress,
 } from 'viem'
 import {
@@ -21,39 +16,23 @@ import {
   deploySource,
   deployTarget,
   getAddress,
-  getBundleInitCode,
   getSmartSessionSmartAccount,
   isDeployed,
   sign,
 } from '../accounts'
 import { getBundlerClient } from '../accounts/utils'
-import { getOwnerValidator } from '../modules'
-import { getSmartSessionValidator } from '../modules/validators'
-import type {
-  BundleResult,
-  MetaIntent,
-  SignedMultiChainCompact,
-} from '../orchestrator'
+import type { BundleResult } from '../orchestrator'
 import {
   BUNDLE_STATUS_COMPLETED,
   BUNDLE_STATUS_FAILED,
   BUNDLE_STATUS_FILLED,
   BUNDLE_STATUS_PRECONFIRMED,
-  getEmptyUserOp,
-  getOrchestrator,
-  getOrderBundleHash,
-  getTokenRootBalanceSlot,
 } from '../orchestrator'
-import {
-  DEV_ORCHESTRATOR_URL,
-  PROD_ORCHESTRATOR_URL,
-} from '../orchestrator/consts'
 import {
   getChainById,
   getDefaultAccountAccessList,
-  isTestnet,
 } from '../orchestrator/registry'
-import { BundleStatus, SupportedChain } from '../orchestrator/types'
+import { BundleStatus } from '../orchestrator/types'
 import type {
   Call,
   RhinestoneAccountConfig,
@@ -62,28 +41,24 @@ import type {
   TokenRequest,
   Transaction,
 } from '../types'
+
+import type { BundleData, TransactionResult } from './utils'
+import {
+  getOrchestratorByChain,
+  getUserOp,
+  getUserOpOrderPath,
+  prepareTransactionAsIntent,
+  signUserOp,
+  submitIntentInternal,
+  submitUserOp,
+} from './utils'
 import {
   enableSmartSession,
   getSessionSignature,
   hashErc7739,
 } from './smart-session'
-import type { BundleData } from './modular'
 
 const POLLING_INTERVAL = 500
-
-type TransactionResult =
-  | {
-      type: 'userop'
-      hash: Hex
-      sourceChain: number
-      targetChain: number
-    }
-  | {
-      type: 'bundle'
-      id: bigint
-      sourceChain?: number
-      targetChain: number
-    }
 
 async function sendTransaction(
   config: RhinestoneAccountConfig,
@@ -195,17 +170,6 @@ async function sendTransactionAsUserOp(
     withSession,
   )
   const bundlerClient = getBundlerClient(config, publicClient)
-  const targetPublicClient = createPublicClient({
-    chain: targetChain,
-    transport: http(),
-  })
-  const targetSessionAccount = await getSmartSessionSmartAccount(
-    config,
-    targetPublicClient,
-    targetChain,
-    withSession,
-  )
-  const targetBundlerClient = getBundlerClient(config, targetPublicClient)
 
   if (sourceChain.id === targetChain.id) {
     await enableSmartSession(targetChain, config, withSession)
@@ -220,112 +184,44 @@ async function sendTransactionAsUserOp(
       targetChain: targetChain.id,
     } as TransactionResult
   }
-
-  const accountAccessList = sourceChain
-    ? {
-        chainIds: [sourceChain.id as SupportedChain],
-      }
-    : getDefaultAccountAccessList()
-
-  const metaIntent: MetaIntent = {
-    targetChainId: targetChain.id,
-    tokenTransfers: tokenRequests.map((tokenRequest) => ({
-      tokenAddress: tokenRequest.address,
-      amount: tokenRequest.amount,
-    })),
-    targetAccount: accountAddress,
-    targetGasUnits: gasLimit,
-    userOp: getEmptyUserOp(),
-    accountAccessList,
-  }
-
-  const orchestrator = getOrchestratorByChain(
-    targetChain.id,
+  const orderPath = await getUserOpOrderPath(
+    sourceChain,
+    targetChain,
+    tokenRequests,
+    accountAddress,
+    gasLimit,
     config.rhinestoneApiKey,
   )
-  const orderPath = await orchestrator.getOrderPath(metaIntent, accountAddress)
   // Deploy the account on the target chain
   await deployTarget(targetChain, config, true)
   await enableSmartSession(targetChain, config, withSession)
 
-  const userOp = await targetBundlerClient.prepareUserOperation({
-    account: targetSessionAccount,
-    calls: [...orderPath[0].injectedExecutions, ...calls],
-    stateOverride: [
-      ...tokenRequests.map((request) => {
-        const rootBalanceSlot = getTokenRootBalanceSlot(
-          targetChain,
-          request.address,
-        )
-        const balanceSlot = rootBalanceSlot
-          ? keccak256(
-              encodeAbiParameters(
-                [{ type: 'address' }, { type: 'uint256' }],
-                [accountAddress, rootBalanceSlot],
-              ),
-            )
-          : '0x'
-        return {
-          address: request.address,
-          stateDiff: [
-            {
-              slot: balanceSlot,
-              value: pad(toHex(request.amount)),
-            },
-          ],
-        }
-      }),
-    ],
-  })
-  userOp.signature = await targetSessionAccount.signUserOperation(userOp)
-  const userOpHash = getUserOperationHash({
-    userOperation: userOp,
-    chainId: targetChain.id,
-    entryPointAddress: entryPoint07Address,
-    entryPointVersion: '0.7',
-  })
-  orderPath[0].orderBundle.segments[0].witness.userOpHash = userOpHash
-
-  const { hash, appDomainSeparator, contentsType, structHash } =
-    await hashErc7739(sourceChain, orderPath, accountAddress)
-  const signature = await sign(withSession.owners, targetChain, hash)
-  const sessionSignature = getSessionSignature(
-    signature,
-    appDomainSeparator,
-    structHash,
-    contentsType,
+  const userOp = await getUserOp(
+    config,
+    targetChain,
     withSession,
+    orderPath,
+    calls,
+    tokenRequests,
+    accountAddress,
   )
-
-  const smartSessionValidator = getSmartSessionValidator(config)
-  if (!smartSessionValidator) {
-    throw new Error('Smart session validator not available')
-  }
-  const packedSig = encodePacked(
-    ['address', 'bytes'],
-    [smartSessionValidator.address, sessionSignature],
+  const sessionSignature = await signUserOp(
+    config,
+    sourceChain,
+    targetChain,
+    accountAddress,
+    withSession,
+    userOp,
+    orderPath,
   )
-  const signedOrderBundle: SignedMultiChainCompact = {
-    ...orderPath[0].orderBundle,
-    originSignatures: Array(orderPath[0].orderBundle.segments.length).fill(
-      packedSig,
-    ),
-    targetSignature: packedSig,
-  }
-
-  const bundleResults = await orchestrator.postSignedOrderBundle([
-    {
-      signedOrderBundle,
-      userOp,
-    },
-  ])
-
-  return {
-    type: 'bundle',
-    id: bundleResults[0].bundleId,
-    sourceChain: sourceChain.id,
-    targetChain: targetChain.id,
-  } as TransactionResult
+  return await submitUserOp(
+    config,
+    sourceChain,
+    targetChain,
+    userOp,
+    orderPath,
+    sessionSignature,
+  )
 }
 
 async function sendTransactionAsIntent(
@@ -337,73 +233,28 @@ async function sendTransactionAsIntent(
   tokenRequests: TokenRequest[],
   accountAddress: Address,
 ) {
-  const accountAccessList = sourceChain
-    ? {
-        chainIds: [sourceChain.id as SupportedChain],
-      }
-    : getDefaultAccountAccessList()
-
-  const metaIntent: MetaIntent = {
-    targetChainId: targetChain.id,
-    tokenTransfers: tokenRequests.map((tokenRequest) => ({
-      tokenAddress: tokenRequest.address,
-      amount: tokenRequest.amount,
-    })),
-    targetAccount: accountAddress,
-    targetExecutions: calls.map((call) => ({
-      value: call.value ?? 0n,
-      to: call.to,
-      data: call.data ?? '0x',
-    })),
-    targetGasUnits: gasLimit,
-    accountAccessList,
-  }
-
-  const orchestrator = getOrchestratorByChain(
-    targetChain.id,
-    config.rhinestoneApiKey,
+  const { orderPath, hash: orderBundleHash } = await prepareTransactionAsIntent(
+    config,
+    sourceChain,
+    targetChain,
+    calls,
+    gasLimit,
+    tokenRequests,
+    accountAddress,
   )
-  const orderPath = await orchestrator.getOrderPath(metaIntent, accountAddress)
-  orderPath[0].orderBundle.segments[0].witness.execs = [
-    ...orderPath[0].injectedExecutions,
-    ...metaIntent.targetExecutions,
-  ]
-
-  const orderBundleHash = getOrderBundleHash(orderPath[0].orderBundle)
   const bundleSignature = await sign(
     config.owners,
     sourceChain || targetChain,
     orderBundleHash,
   )
-  const validatorModule = getOwnerValidator(config)
-  const packedSig = encodePacked(
-    ['address', 'bytes'],
-    [validatorModule.address, bundleSignature],
+  return await submitIntentInternal(
+    config,
+    sourceChain,
+    targetChain,
+    orderPath,
+    bundleSignature,
+    true,
   )
-
-  const signedOrderBundle: SignedMultiChainCompact = {
-    ...orderPath[0].orderBundle,
-    originSignatures: Array(orderPath[0].orderBundle.segments.length).fill(
-      packedSig,
-    ),
-    targetSignature: packedSig,
-  }
-
-  await deployTarget(targetChain, config, false)
-  const initCode = getBundleInitCode(config)
-  const bundleResults = await orchestrator.postSignedOrderBundle([
-    {
-      signedOrderBundle,
-      initCode,
-    },
-  ])
-
-  return {
-    type: 'bundle',
-    id: bundleResults[0].bundleId,
-    sourceChain: sourceChain?.id,
-    targetChain: targetChain.id,
-  } as TransactionResult
 }
 
 async function waitForExecution(
@@ -475,13 +326,6 @@ async function getPortfolio(
   const chainId = onTestnets ? sepolia.id : mainnet.id
   const orchestrator = getOrchestratorByChain(chainId, config.rhinestoneApiKey)
   return orchestrator.getPortfolio(address, getDefaultAccountAccessList())
-}
-
-function getOrchestratorByChain(chainId: number, apiKey: string) {
-  const orchestratorUrl = isTestnet(chainId)
-    ? DEV_ORCHESTRATOR_URL
-    : PROD_ORCHESTRATOR_URL
-  return getOrchestrator(apiKey, orchestratorUrl)
 }
 
 export {

--- a/src/execution/modular.ts
+++ b/src/execution/modular.ts
@@ -1,0 +1,489 @@
+import {
+  Address,
+  Chain,
+  createPublicClient,
+  encodeAbiParameters,
+  encodePacked,
+  Hex,
+  http,
+  keccak256,
+  pad,
+  toHex,
+  zeroAddress,
+} from 'viem'
+import {
+  Call,
+  RhinestoneAccountConfig,
+  Session,
+  TokenRequest,
+  Transaction,
+} from '../types'
+import {
+  getAddress,
+  getBundleInitCode,
+  getSmartSessionSmartAccount,
+  sign,
+} from '../accounts'
+import {
+  MetaIntent,
+  OrderPath,
+  SignedMultiChainCompact,
+  SupportedChain,
+} from '../orchestrator/types'
+import {
+  getDefaultAccountAccessList,
+  getTokenRootBalanceSlot,
+  isTestnet,
+} from '../orchestrator/registry'
+import {
+  getEmptyUserOp,
+  getOrchestrator,
+  getOrderBundleHash,
+} from '../orchestrator'
+import {
+  DEV_ORCHESTRATOR_URL,
+  PROD_ORCHESTRATOR_URL,
+} from '../orchestrator/consts'
+import { getSessionSignature, hashErc7739 } from './smart-session'
+import {
+  entryPoint07Address,
+  getUserOperationHash,
+  UserOperation,
+} from 'viem/account-abstraction'
+import { getBundlerClient } from '../accounts/utils'
+import {
+  getOwnerValidator,
+  getSmartSessionValidator,
+} from '../modules/validators'
+import type { TransactionResult } from '.'
+
+interface BundleData {
+  hash: Hex
+  orderPath: OrderPath
+  userOp?: UserOperation
+}
+
+async function prepareTransaction(
+  config: RhinestoneAccountConfig,
+  transaction: Transaction,
+) {
+  const sourceChain =
+    'chain' in transaction ? transaction.chain : transaction.sourceChain
+  const targetChain =
+    'chain' in transaction ? transaction.chain : transaction.targetChain
+  const initialTokenRequests = transaction.tokenRequests
+  const withSession =
+    transaction.signers?.type === 'session' ? transaction.signers.session : null
+  const accountAddress = getAddress(config)
+
+  // Across requires passing some value to repay the solvers
+  const tokenRequests =
+    initialTokenRequests.length === 0
+      ? [
+          {
+            address: zeroAddress,
+            amount: 1n,
+          },
+        ]
+      : initialTokenRequests
+
+  if (withSession) {
+    if (!sourceChain) {
+      throw new Error(
+        `Specifying source chain is required when using smart sessions`,
+      )
+    }
+    // Smart sessions require a UserOp flow
+    return await prepareTransactionAsUserOp(
+      config,
+      sourceChain,
+      targetChain,
+      transaction.calls,
+      transaction.gasLimit,
+      tokenRequests,
+      accountAddress,
+      withSession,
+    )
+  } else {
+    return await prepareTransactionAsIntent(
+      config,
+      sourceChain,
+      targetChain,
+      transaction.calls,
+      transaction.gasLimit,
+      tokenRequests,
+      accountAddress,
+    )
+  }
+}
+
+async function signTransaction(
+  config: RhinestoneAccountConfig,
+  transaction: Transaction,
+  bundleData: BundleData,
+) {
+  const sourceChain =
+    'chain' in transaction ? transaction.chain : transaction.sourceChain
+  const targetChain =
+    'chain' in transaction ? transaction.chain : transaction.targetChain
+  const withSession =
+    transaction.signers?.type === 'session' ? transaction.signers.session : null
+  const accountAddress = getAddress(config)
+
+  if (withSession) {
+    if (!sourceChain) {
+      throw new Error(
+        `Specifying source chain is required when using smart sessions`,
+      )
+    }
+    const userOp = bundleData.userOp
+    if (!userOp) {
+      throw new Error(`User operation is required when using smart sessions`)
+    }
+    // Smart sessions require a UserOp flow
+    return await signUserOp(
+      config,
+      sourceChain,
+      targetChain,
+      accountAddress,
+      withSession,
+      userOp,
+      bundleData.orderPath,
+    )
+  } else {
+    return await signIntent(config, sourceChain, targetChain, bundleData.hash)
+  }
+}
+
+async function submitTransaction(
+  config: RhinestoneAccountConfig,
+  transaction: Transaction,
+  bundleData: BundleData,
+  signature: Hex,
+) {
+  const sourceChain =
+    'chain' in transaction ? transaction.chain : transaction.sourceChain
+  const targetChain =
+    'chain' in transaction ? transaction.chain : transaction.targetChain
+  const withSession =
+    transaction.signers?.type === 'session' ? transaction.signers.session : null
+  if (withSession) {
+    if (!sourceChain) {
+      throw new Error(
+        `Specifying source chain is required when using smart sessions`,
+      )
+    }
+    const userOp = bundleData.userOp
+    if (!userOp) {
+      throw new Error(`User operation is required when using smart sessions`)
+    }
+    // Smart sessions require a UserOp flow
+    return await submitUserOp(
+      config,
+      sourceChain,
+      targetChain,
+      userOp,
+      bundleData.orderPath,
+      signature,
+    )
+  } else {
+    return await submitIntent(
+      config,
+      sourceChain,
+      targetChain,
+      bundleData.orderPath,
+      signature,
+    )
+  }
+}
+
+async function prepareTransactionAsUserOp(
+  config: RhinestoneAccountConfig,
+  sourceChain: Chain,
+  targetChain: Chain,
+  calls: Call[],
+  gasLimit: bigint | undefined,
+  tokenRequests: TokenRequest[],
+  accountAddress: Address,
+  withSession: Session,
+) {
+  const targetPublicClient = createPublicClient({
+    chain: targetChain,
+    transport: http(),
+  })
+  const targetSessionAccount = await getSmartSessionSmartAccount(
+    config,
+    targetPublicClient,
+    targetChain,
+    withSession,
+  )
+  const targetBundlerClient = getBundlerClient(config, targetPublicClient)
+
+  if (sourceChain.id === targetChain.id) {
+    throw new Error(
+      'Source and target chains cannot be the same when using user operations',
+    )
+  }
+
+  const accountAccessList = sourceChain
+    ? {
+        chainIds: [sourceChain.id as SupportedChain],
+      }
+    : getDefaultAccountAccessList()
+
+  const metaIntent: MetaIntent = {
+    targetChainId: targetChain.id,
+    tokenTransfers: tokenRequests.map((tokenRequest) => ({
+      tokenAddress: tokenRequest.address,
+      amount: tokenRequest.amount,
+    })),
+    targetAccount: accountAddress,
+    targetGasUnits: gasLimit,
+    userOp: getEmptyUserOp(),
+    accountAccessList,
+  }
+
+  const orchestrator = getOrchestratorByChain(
+    targetChain.id,
+    config.rhinestoneApiKey,
+  )
+  const orderPath = await orchestrator.getOrderPath(metaIntent, accountAddress)
+
+  const userOp = await targetBundlerClient.prepareUserOperation({
+    account: targetSessionAccount,
+    calls: [...orderPath[0].injectedExecutions, ...calls],
+    stateOverride: [
+      ...tokenRequests.map((request) => {
+        const rootBalanceSlot = getTokenRootBalanceSlot(
+          targetChain,
+          request.address,
+        )
+        const balanceSlot = rootBalanceSlot
+          ? keccak256(
+              encodeAbiParameters(
+                [{ type: 'address' }, { type: 'uint256' }],
+                [accountAddress, rootBalanceSlot],
+              ),
+            )
+          : '0x'
+        return {
+          address: request.address,
+          stateDiff: [
+            {
+              slot: balanceSlot,
+              value: pad(toHex(request.amount)),
+            },
+          ],
+        }
+      }),
+    ],
+  })
+
+  const hash = getUserOperationHash({
+    userOperation: userOp,
+    entryPointAddress: entryPoint07Address,
+    entryPointVersion: '0.7',
+    chainId: targetChain.id,
+  })
+
+  return {
+    orderPath,
+    userOp,
+    hash,
+  } as BundleData
+}
+
+async function prepareTransactionAsIntent(
+  config: RhinestoneAccountConfig,
+  sourceChain: Chain | undefined,
+  targetChain: Chain,
+  calls: Call[],
+  gasLimit: bigint | undefined,
+  tokenRequests: TokenRequest[],
+  accountAddress: Address,
+) {
+  const accountAccessList = sourceChain
+    ? {
+        chainIds: [sourceChain.id as SupportedChain],
+      }
+    : getDefaultAccountAccessList()
+
+  const metaIntent: MetaIntent = {
+    targetChainId: targetChain.id,
+    tokenTransfers: tokenRequests.map((tokenRequest) => ({
+      tokenAddress: tokenRequest.address,
+      amount: tokenRequest.amount,
+    })),
+    targetAccount: accountAddress,
+    targetExecutions: calls.map((call) => ({
+      value: call.value ?? 0n,
+      to: call.to,
+      data: call.data ?? '0x',
+    })),
+    targetGasUnits: gasLimit,
+    accountAccessList,
+  }
+
+  const orchestrator = getOrchestratorByChain(
+    targetChain.id,
+    config.rhinestoneApiKey,
+  )
+  const orderPath = await orchestrator.getOrderPath(metaIntent, accountAddress)
+  orderPath[0].orderBundle.segments[0].witness.execs = [
+    ...orderPath[0].injectedExecutions,
+    ...metaIntent.targetExecutions,
+  ]
+
+  const orderBundleHash = getOrderBundleHash(orderPath[0].orderBundle)
+
+  return {
+    orderPath,
+    hash: orderBundleHash,
+  } as BundleData
+}
+
+async function signIntent(
+  config: RhinestoneAccountConfig,
+  sourceChain: Chain | undefined,
+  targetChain: Chain,
+  bundleHash: Hex,
+) {
+  const signature = await sign(
+    config.owners,
+    sourceChain || targetChain,
+    bundleHash,
+  )
+
+  return signature
+}
+
+async function signUserOp(
+  config: RhinestoneAccountConfig,
+  sourceChain: Chain,
+  targetChain: Chain,
+  accountAddress: Address,
+  withSession: Session,
+  userOp: UserOperation,
+  orderPath: OrderPath,
+) {
+  const targetPublicClient = createPublicClient({
+    chain: targetChain,
+    transport: http(),
+  })
+  const targetSessionAccount = await getSmartSessionSmartAccount(
+    config,
+    targetPublicClient,
+    targetChain,
+    withSession,
+  )
+
+  userOp.signature = await targetSessionAccount.signUserOperation(userOp)
+  const userOpHash = getUserOperationHash({
+    userOperation: userOp,
+    chainId: targetChain.id,
+    entryPointAddress: entryPoint07Address,
+    entryPointVersion: '0.7',
+  })
+  orderPath[0].orderBundle.segments[0].witness.userOpHash = userOpHash
+  const { hash, appDomainSeparator, contentsType, structHash } =
+    await hashErc7739(sourceChain, orderPath, accountAddress)
+  const signature = await sign(withSession.owners, targetChain, hash)
+  const sessionSignature = getSessionSignature(
+    signature,
+    appDomainSeparator,
+    structHash,
+    contentsType,
+    withSession,
+  )
+
+  return sessionSignature
+}
+
+async function submitUserOp(
+  config: RhinestoneAccountConfig,
+  sourceChain: Chain,
+  targetChain: Chain,
+  userOp: UserOperation,
+  orderPath: OrderPath,
+  sessionSignature: Hex,
+) {
+  const smartSessionValidator = getSmartSessionValidator(config)
+  if (!smartSessionValidator) {
+    throw new Error('Smart session validator not available')
+  }
+  const packedSig = encodePacked(
+    ['address', 'bytes'],
+    [smartSessionValidator.address, sessionSignature],
+  )
+  const signedOrderBundle: SignedMultiChainCompact = {
+    ...orderPath[0].orderBundle,
+    originSignatures: Array(orderPath[0].orderBundle.segments.length).fill(
+      packedSig,
+    ),
+    targetSignature: packedSig,
+  }
+  const orchestrator = getOrchestratorByChain(
+    targetChain.id,
+    config.rhinestoneApiKey,
+  )
+  const bundleResults = await orchestrator.postSignedOrderBundle([
+    {
+      signedOrderBundle,
+      userOp,
+    },
+  ])
+  return {
+    type: 'bundle',
+    id: bundleResults[0].bundleId,
+    sourceChain: sourceChain.id,
+    targetChain: targetChain.id,
+  } as TransactionResult
+}
+
+async function submitIntent(
+  config: RhinestoneAccountConfig,
+  sourceChain: Chain | undefined,
+  targetChain: Chain,
+  orderPath: OrderPath,
+  bundleSignature: Hex,
+) {
+  const validatorModule = getOwnerValidator(config)
+  const packedSig = encodePacked(
+    ['address', 'bytes'],
+    [validatorModule.address, bundleSignature],
+  )
+  const signedOrderBundle: SignedMultiChainCompact = {
+    ...orderPath[0].orderBundle,
+    originSignatures: Array(orderPath[0].orderBundle.segments.length).fill(
+      packedSig,
+    ),
+    targetSignature: packedSig,
+  }
+  const initCode = getBundleInitCode(config)
+  const orchestrator = getOrchestratorByChain(
+    targetChain.id,
+    config.rhinestoneApiKey,
+  )
+  const bundleResults = await orchestrator.postSignedOrderBundle([
+    {
+      signedOrderBundle,
+      initCode,
+    },
+  ])
+  return {
+    type: 'bundle',
+    id: bundleResults[0].bundleId,
+    sourceChain: sourceChain?.id,
+    targetChain: targetChain.id,
+  } as TransactionResult
+}
+
+function getOrchestratorByChain(chainId: number, apiKey: string) {
+  const orchestratorUrl = isTestnet(chainId)
+    ? DEV_ORCHESTRATOR_URL
+    : PROD_ORCHESTRATOR_URL
+  return getOrchestrator(apiKey, orchestratorUrl)
+}
+
+export { prepareTransaction, signTransaction, submitTransaction }
+export type { BundleData }

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -16,14 +16,6 @@ import {
   getUserOperationHash,
   UserOperation,
 } from 'viem/account-abstraction'
-
-import {
-  Call,
-  RhinestoneAccountConfig,
-  Session,
-  TokenRequest,
-  Transaction,
-} from '../types'
 import {
   deployTarget,
   getAddress,
@@ -31,17 +23,11 @@ import {
   getSmartSessionSmartAccount,
   sign,
 } from '../accounts'
+import { getBundlerClient } from '../accounts/utils'
 import {
-  MetaIntent,
-  OrderPath,
-  SignedMultiChainCompact,
-  SupportedChain,
-} from '../orchestrator/types'
-import {
-  getDefaultAccountAccessList,
-  getTokenRootBalanceSlot,
-  isTestnet,
-} from '../orchestrator/registry'
+  getOwnerValidator,
+  getSmartSessionValidator,
+} from '../modules/validators'
 import {
   getEmptyUserOp,
   getOrchestrator,
@@ -51,11 +37,24 @@ import {
   DEV_ORCHESTRATOR_URL,
   PROD_ORCHESTRATOR_URL,
 } from '../orchestrator/consts'
-import { getBundlerClient } from '../accounts/utils'
 import {
-  getOwnerValidator,
-  getSmartSessionValidator,
-} from '../modules/validators'
+  getDefaultAccountAccessList,
+  getTokenRootBalanceSlot,
+  isTestnet,
+} from '../orchestrator/registry'
+import {
+  MetaIntent,
+  OrderPath,
+  SignedMultiChainCompact,
+  SupportedChain,
+} from '../orchestrator/types'
+import {
+  Call,
+  RhinestoneAccountConfig,
+  Session,
+  TokenRequest,
+  Transaction,
+} from '../types'
 
 import { getSessionSignature, hashErc7739 } from './smart-session'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
-import type { Address, Chain } from 'viem'
-import { getAddress as getAddressInternal } from './accounts'
+import type { Address, Chain, Hex } from 'viem'
+import {
+  deploy as deployInternal,
+  getAddress as getAddressInternal,
+} from './accounts'
 import type { TransactionResult } from './execution'
 import {
   getMaxSpendableAmount as getMaxSpendableAmountInternal,
@@ -7,6 +10,12 @@ import {
   sendTransaction as sendTransactionInternal,
   waitForExecution as waitForExecutionInternal,
 } from './execution'
+import {
+  BundleData,
+  prepareTransaction as prepareTransactionInternal,
+  signTransaction as signTransactionInternal,
+  submitTransaction as submitTransactionInternal,
+} from './execution/modular'
 import type {
   BundleStatus,
   MetaIntent,
@@ -29,6 +38,26 @@ import type {
  * @returns account
  */
 async function createRhinestoneAccount(config: RhinestoneAccountConfig) {
+  function deploy(chain: Chain, session?: Session) {
+    return deployInternal(config, chain, session)
+  }
+
+  function prepareTransaction(transaction: Transaction) {
+    return prepareTransactionInternal(config, transaction)
+  }
+
+  function signTransaction(transaction: Transaction, bundleData: BundleData) {
+    return signTransactionInternal(config, transaction, bundleData)
+  }
+
+  function submitTransaction(
+    transaction: Transaction,
+    bundleData: BundleData,
+    signature: Hex,
+  ) {
+    return submitTransactionInternal(config, transaction, bundleData, signature)
+  }
+
   /**
    * Sign and send a transaction
    * @param transaction Transaction to send
@@ -85,6 +114,10 @@ async function createRhinestoneAccount(config: RhinestoneAccountConfig) {
 
   return {
     config,
+    deploy,
+    prepareTransaction,
+    signTransaction,
+    submitTransaction,
     sendTransaction,
     waitForExecution,
     getAddress,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import {
 } from './execution'
 import {
   BundleData,
+  PreparedTransactionData,
+  SignedTransactionData,
   prepareTransaction as prepareTransactionInternal,
   signTransaction as signTransactionInternal,
   submitTransaction as submitTransactionInternal,
@@ -46,16 +48,12 @@ async function createRhinestoneAccount(config: RhinestoneAccountConfig) {
     return prepareTransactionInternal(config, transaction)
   }
 
-  function signTransaction(transaction: Transaction, bundleData: BundleData) {
-    return signTransactionInternal(config, transaction, bundleData)
+  function signTransaction(preparedTransaction: PreparedTransactionData) {
+    return signTransactionInternal(config, preparedTransaction)
   }
 
-  function submitTransaction(
-    transaction: Transaction,
-    bundleData: BundleData,
-    signature: Hex,
-  ) {
-    return submitTransactionInternal(config, transaction, bundleData, signature)
+  function submitTransaction(signedTransaction: SignedTransactionData) {
+    return submitTransactionInternal(config, signedTransaction)
   }
 
   /**
@@ -136,4 +134,8 @@ export type {
   MultiChainCompact,
   PostOrderBundleResult,
   SignedMultiChainCompact,
+  BundleData,
+  PreparedTransactionData,
+  SignedTransactionData,
+  TransactionResult,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   prepareTransaction as prepareTransactionInternal,
   signTransaction as signTransactionInternal,
   submitTransaction as submitTransactionInternal,
-} from './execution/modular'
+} from './execution/utils'
 import type {
   BundleStatus,
   MetaIntent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Address, Chain, Hex } from 'viem'
+import type { Address, Chain } from 'viem'
 import {
   deploy as deployInternal,
   getAddress as getAddressInternal,
@@ -13,8 +13,8 @@ import {
 import {
   BundleData,
   PreparedTransactionData,
-  SignedTransactionData,
   prepareTransaction as prepareTransactionInternal,
+  SignedTransactionData,
   signTransaction as signTransactionInternal,
   submitTransaction as submitTransactionInternal,
 } from './execution/utils'


### PR DESCRIPTION
## Description

Adds a list of lower level APIs for granular control over the tx flow:
- `deploy`
- `prepareTransaction`
- `signTransaction`
- `submitTransaction`

## Example

```ts
await rhinestoneAccount.deploy(sourceChain)

const transactionData: Transaction = {
  sourceChain,
  targetChain,
  calls: [
    {
      to: usdcTarget,
      value: 0n,
      data: encodeFunctionData({
        abi: erc20Abi,
        functionName: 'transfer',
        args: ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045', usdcAmount],
      }),
    },
  ],
  tokenRequests: [
    {
      address: usdcTarget,
      amount: usdcAmount,
    },
  ],
}
const bundleData = await rhinestoneAccount.prepareTransaction(transactionData)
const signature = await rhinestoneAccount.signTransaction(
  transactionData,
  bundleData,
)
const transactionResult = await rhinestoneAccount.submitTransaction(
  transactionData,
  bundleData,
  signature,
)
```

## Checklist
- [x] Changeset
- [ ] Docs
