### PR TITLE
Multi-factor validator

### DIFF
--- a/.changeset/tidy-radios-act.md
+++ b/.changeset/tidy-radios-act.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Multi-factor validator

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -469,7 +469,7 @@ async function sign(signers: SignerSet, chain: Chain, hash: Hex): Promise<Hex> {
                 const validatorModule = getValidator(validator)
                 return {
                   packedValidatorAndId: concat([
-                    pad(toHex(index), {
+                    pad(toHex(validator.id), {
                       size: 12,
                     }),
                     validatorModule.address,
@@ -554,7 +554,24 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
       return {
         type: 'owner',
         kind: 'multi-factor',
-        validators: owners.validators,
+        validators: owners.validators.map((validator, index) => {
+          switch (validator.type) {
+            case 'ecdsa': {
+              return {
+                type: 'ecdsa',
+                id: index,
+                accounts: validator.accounts,
+              }
+            }
+            case 'passkey': {
+              return {
+                type: 'passkey',
+                id: index,
+                account: validator.account,
+              }
+            }
+          }
+        }),
       }
     }
   }

--- a/src/accounts/safe.ts
+++ b/src/accounts/safe.ts
@@ -341,6 +341,8 @@ function getOwners(config: RhinestoneAccountConfig) {
       return ownerSet.accounts.map((account) => account.address)
     case 'passkey':
       return [NO_SAFE_OWNER_ADDRESS]
+    case 'multi-factor':
+      return [NO_SAFE_OWNER_ADDRESS]
   }
 }
 
@@ -350,6 +352,8 @@ function getThreshold(config: RhinestoneAccountConfig) {
     case 'ecdsa':
       return ownerSet.threshold ? BigInt(ownerSet.threshold) : 1n
     case 'passkey':
+      return 1n
+    case 'multi-factor':
       return 1n
   }
 }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -341,8 +341,7 @@ function setSubValidator(
   id: Hex | number,
   validator: OwnableValidatorConfig | WebauthnValidatorConfig,
 ): Call {
-  const validatorId =
-    typeof id === 'number' ? padHex(toHex(id), { size: 12 }) : id
+  const validatorId = padHex(toHex(id), { size: 12 })
   const validatorModule = getValidator(validator)
   return {
     to: MULTI_FACTOR_VALIDATOR_ADDRESS,
@@ -378,8 +377,7 @@ function removeSubValidator(
   id: Hex | number,
   validator: OwnableValidatorConfig | WebauthnValidatorConfig,
 ): Call {
-  const validatorId =
-    typeof id === 'number' ? padHex(toHex(id), { size: 12 }) : id
+  const validatorId = padHex(toHex(id), { size: 12 })
   const validatorModule = getValidator(validator)
   return {
     to: MULTI_FACTOR_VALIDATOR_ADDRESS,
@@ -388,7 +386,7 @@ function removeSubValidator(
       abi: [
         {
           type: 'function',
-          name: 'setValidator',
+          name: 'removeValidator',
           inputs: [
             {
               type: 'address',

--- a/src/execution/smart-session.ts
+++ b/src/execution/smart-session.ts
@@ -77,7 +77,7 @@ async function getSessionDetails(
     signature ??
     (await getPackedSignature(
       config,
-      config.owners,
+      undefined,
       chain,
       validator,
       sessionDetails.permissionEnableHash,

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -47,7 +47,6 @@ import { isTestnet, resolveTokenAddress } from '../orchestrator/registry'
 import type {
   Call,
   CallInput,
-  OwnerSet,
   RhinestoneAccountConfig,
   SignerSet,
   TokenRequest,
@@ -343,13 +342,9 @@ async function signIntent(
   const ownerValidator = getOwnerValidator(config)
   const isRoot = validator.address === ownerValidator.address
 
-  const owners = getOwners(config, signers)
-  if (!owners) {
-    throw new Error('No owners found')
-  }
   const signature = await getPackedSignature(
     config,
-    owners,
+    signers,
     sourceChain || targetChain,
     {
       address: validator.address,
@@ -561,58 +556,6 @@ function getValidator(
     return getSocialRecoveryValidator(withGuardians.guardians)
   }
   // Fallback
-  return undefined
-}
-
-function getOwners(
-  config: RhinestoneAccountConfig,
-  signers: SignerSet | undefined,
-): OwnerSet | undefined {
-  if (!signers) {
-    return config.owners
-  }
-
-  // Owners
-  const withOwner = signers.type === 'owner' ? signers : null
-  if (withOwner) {
-    // ECDSA
-    if (withOwner.kind === 'ecdsa') {
-      return {
-        type: 'ecdsa',
-        accounts: withOwner.accounts,
-      }
-    }
-    // Passkeys (WebAuthn)
-    if (withOwner.kind === 'passkey') {
-      return {
-        type: 'passkey',
-        account: withOwner.account,
-      }
-    }
-    // Multi-factor
-    if (withOwner.kind === 'multi-factor') {
-      return {
-        type: 'multi-factor',
-        validators: withOwner.validators,
-      }
-    }
-  }
-
-  // Smart sessions
-  const withSession = signers.type === 'session' ? signers.session : null
-  if (withSession) {
-    return withSession.owners
-  }
-
-  // Guardians (social recovery)
-  const withGuardians = signers.type === 'guardians' ? signers : null
-  if (withGuardians) {
-    return {
-      type: 'ecdsa',
-      accounts: withGuardians.guardians,
-    }
-  }
-
   return undefined
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,20 +16,24 @@ import {
 import { createTransport } from './accounts/utils'
 import {
   addOwner,
+  changeMultiFactorThreshold,
   changeThreshold,
   disableEcdsa,
+  disableMultiFactor,
   disablePasskeys,
   enableEcdsa,
+  enableMultiFactor,
   enablePasskeys,
   encodeSmartSessionSignature,
   recover,
   removeOwner,
+  removeSubValidator,
+  setSubValidator,
   setUpRecovery,
   trustAttester,
 } from './actions'
 import type { TransactionResult } from './execution'
 import {
-  deposit as depositInternal,
   ExecutionError,
   getMaxSpendableAmount as getMaxSpendableAmountInternal,
   getPortfolio as getPortfolioInternal,
@@ -126,11 +130,6 @@ interface RhinestoneAccount {
     threshold: number
   } | null>
   getValidators: (chain: Chain) => Promise<Address[]>
-  deposit: (
-    chain: Chain,
-    amount: bigint,
-    tokenAddress?: Address,
-  ) => Promise<TransactionResult>
 }
 
 /**
@@ -236,10 +235,6 @@ async function createRhinestoneAccount(
     return getValidatorsInternal(accountType, account, chain, config.provider)
   }
 
-  async function deposit(chain: Chain, amount: bigint, tokenAddress?: Address) {
-    return depositInternal(config, chain, amount, tokenAddress)
-  }
-
   return {
     config,
     deploy,
@@ -255,23 +250,28 @@ async function createRhinestoneAccount(
     areAttestersTrusted,
     getOwners,
     getValidators,
-    deposit,
   }
 }
 
 export {
   createRhinestoneAccount,
   createTransport,
+  // Actions
   addOwner,
+  changeMultiFactorThreshold,
   changeThreshold,
   disableEcdsa,
+  disableMultiFactor,
   disablePasskeys,
   enableEcdsa,
+  enableMultiFactor,
   enablePasskeys,
+  encodeSmartSessionSignature,
   recover,
   removeOwner,
+  removeSubValidator,
+  setSubValidator,
   setUpRecovery,
-  encodeSmartSessionSignature,
   trustAttester,
   // Account errors
   isAccountError,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,12 @@ interface WebauthnValidatorConfig {
   account: WebAuthnAccount
 }
 
+interface MultiFactorValidatorConfig {
+  type: 'multi-factor'
+  validators: (OwnableValidatorConfig | WebauthnValidatorConfig)[]
+  threshold?: number
+}
+
 interface ProviderConfig {
   type: 'alchemy'
   apiKey: string
@@ -34,7 +40,10 @@ interface PaymasterConfig {
   apiKey: string
 }
 
-type OwnerSet = OwnableValidatorConfig | WebauthnValidatorConfig
+type OwnerSet =
+  | OwnableValidatorConfig
+  | WebauthnValidatorConfig
+  | MultiFactorValidatorConfig
 
 interface SudoPolicy {
   type: 'sudo'
@@ -156,6 +165,20 @@ type OwnerSignerSet =
       kind: 'passkey'
       account: WebAuthnAccount
     }
+  | {
+      type: 'owner'
+      kind: 'multi-factor'
+      validators: (
+        | {
+            type: 'ecdsa'
+            accounts: Account[]
+          }
+        | {
+            type: 'passkey'
+            account: WebAuthnAccount
+          }
+      )[]
+    }
 
 interface SessionSignerSet {
   type: 'session'
@@ -203,6 +226,7 @@ export type {
   OwnerSet,
   OwnableValidatorConfig,
   WebauthnValidatorConfig,
+  MultiFactorValidatorConfig,
   SignerSet,
   Session,
   Recovery,

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,10 +171,12 @@ type OwnerSignerSet =
       validators: (
         | {
             type: 'ecdsa'
+            id: number | Hex
             accounts: Account[]
           }
         | {
             type: 'passkey'
+            id: number | Hex
             account: WebAuthnAccount
           }
       )[]


### PR DESCRIPTION
## Description

Adds support for the multi-factor validator.

```ts
const rhinestoneAccount = await createRhinestoneAccount({
  owners: {
    type: 'multi-factor',
    validators: [
      {
        type: 'ecdsa',
        accounts: [accountA, accountB],
      },
      {
        type: 'passkey',
        account: accountC,
      },
    ],
  },
})
```

## Checklist
- [x] Changeset
