### PR TITLE
feat: add transaction simulation functionality

### DIFF
--- a/.changeset/quiet-spies-report.md
+++ b/.changeset/quiet-spies-report.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Add transaction simulation method

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ import {
   signTransaction as signTransactionInternal,
   signTypedData as signTypedDataInternal,
   submitTransaction as submitTransactionInternal,
+  simulateTransaction as simulateTransactionInternal,
 } from './execution/utils'
 import {
   getOwners as getOwnersInternal,
@@ -141,6 +142,10 @@ interface RhinestoneAccount {
     signedTransaction: SignedTransactionData,
     authorizations?: SignedAuthorizationList,
   ) => Promise<TransactionResult>
+  simulateTransaction: (
+    signedTransaction: SignedTransactionData,
+    authorizations?: SignedAuthorizationList,
+  ) => Promise<IntentResult>
   sendTransaction: (transaction: Transaction) => Promise<TransactionResult>
   waitForExecution: (
     result: TransactionResult,
@@ -278,6 +283,25 @@ async function createRhinestoneAccount(
   }
 
   /**
+   * Simulate a transaction
+   * @param signedTransaction Signed transaction data
+   * @param authorizations EIP-7702 authorizations to simulate (optional)
+   * @returns simulation result
+   * @see {@link signTransaction} to sign the transaction data
+   * @see {@link signAuthorizations} to sign the required EIP-7702 authorizations
+   */
+  function simulateTransaction(
+    signedTransaction: SignedTransactionData,
+    authorizations?: SignedAuthorizationList,
+  ) {
+    return simulateTransactionInternal(
+      config,
+      signedTransaction,
+      authorizations ?? [],
+    )
+  }
+
+  /**
    * Sign and send a transaction
    * @param transaction Transaction to send
    * @returns transaction result object (an intent ID or a UserOp hash)
@@ -370,6 +394,7 @@ async function createRhinestoneAccount(
     signMessage,
     signTypedData,
     submitTransaction,
+    simulateTransaction,
     sendTransaction,
     waitForExecution,
     getAddress,

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -209,6 +209,27 @@ export class Orchestrator {
     }
   }
 
+  async simulateIntent(signedIntentOp: SignedIntentOp): Promise<IntentResult> {
+    try {
+      const response = await axios.post(
+        `${this.serverUrl}/intent-operations/simulate`,
+        {
+          signedIntentOp: convertBigIntFields(signedIntentOp),
+        },
+        {
+          headers: {
+            'x-api-key': this.apiKey,
+          },
+        },
+      )
+
+      return response.data
+    } catch (error) {
+      this.parseError(error)
+      throw new Error('Failed to simulate intent')
+    }
+  }
+
   async getIntentOpStatus(intentId: bigint): Promise<IntentOpStatus> {
     try {
       const response = await axios.get(


### PR DESCRIPTION
## Description
Add method `simulateTransaction` to simulate the intent transactions.

Functionality tested here https://github.com/rhinestonewtf/bundle-generator/pull/18
```ts
const signedTransaction = await rhinestoneAccount.signTransaction(
  preparedTransaction
);
const simulationResult = await rhinestoneAccount.simulateTransaction(
	signedTransaction
);
```

## Checklist
- [x] Changeset
