### PR TITLE
feat: add optional orchestratorUrl parameter for internal testing

### DIFF
--- a/.changeset/plenty-rivers-teach.md
+++ b/.changeset/plenty-rivers-teach.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Add optional orchestratorUrl parameter for internal testing

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -228,7 +228,7 @@ async function waitForExecution(
         const orchestrator = getOrchestratorByChain(
           result.targetChain,
           config.rhinestoneApiKey,
-          config.useDev,
+          config.orchestratorUrl,
         )
         intentStatus = await orchestrator.getIntentOpStatus(result.id)
         await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL))
@@ -264,7 +264,7 @@ async function getMaxSpendableAmount(
   const orchestrator = getOrchestratorByChain(
     chain.id,
     config.rhinestoneApiKey,
-    config.useDev,
+    config.orchestratorUrl,
   )
   return orchestrator.getMaxTokenAmount(
     address,
@@ -284,7 +284,7 @@ async function getPortfolio(
   const orchestrator = getOrchestratorByChain(
     chainId,
     config.rhinestoneApiKey,
-    config.useDev,
+    config.orchestratorUrl,
   )
   return orchestrator.getPortfolio(address)
 }

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -52,7 +52,6 @@ import {
   type SupportedChain,
 } from '../orchestrator'
 import {
-  DEV_ORCHESTRATOR_URL,
   PROD_ORCHESTRATOR_URL,
   STAGING_ORCHESTRATOR_URL,
 } from '../orchestrator/consts'
@@ -483,7 +482,7 @@ async function prepareTransactionAsIntent(
   const orchestrator = getOrchestratorByChain(
     targetChain.id,
     config.rhinestoneApiKey,
-    config.useDev,
+    config.orchestratorUrl,
   )
   const intentRoute = await orchestrator.getIntentRoute(metaIntent)
 
@@ -614,15 +613,16 @@ async function submitIntent(
 function getOrchestratorByChain(
   chainId: number,
   apiKey: string | undefined,
-  useDev: boolean | undefined,
+  orchestratorUrl?: string,
 ) {
-  const orchestratorUrl =
-    (useDev ?? false)
-      ? DEV_ORCHESTRATOR_URL
-      : isTestnet(chainId)
-        ? STAGING_ORCHESTRATOR_URL
-        : PROD_ORCHESTRATOR_URL
-  return getOrchestrator(apiKey, orchestratorUrl)
+  if (orchestratorUrl) {
+    return getOrchestrator(apiKey, orchestratorUrl)
+  }
+
+  const defaultOrchestratorUrl = isTestnet(chainId)
+    ? STAGING_ORCHESTRATOR_URL
+    : PROD_ORCHESTRATOR_URL
+  return getOrchestrator(apiKey, defaultOrchestratorUrl)
 }
 
 async function simulateIntent(
@@ -682,7 +682,7 @@ async function submitIntentInternal(
   const orchestrator = getOrchestratorByChain(
     targetChain.id,
     config.rhinestoneApiKey,
-    config.useDev,
+    config.orchestratorUrl,
   )
   const intentResults = await orchestrator.submitIntent(signedIntentOp)
   return {
@@ -709,7 +709,7 @@ async function simulateIntentInternal(
   const orchestrator = getOrchestratorByChain(
     targetChain.id,
     config.rhinestoneApiKey,
-    config.useDev,
+    config.orchestratorUrl,
   )
   const simulationResults = await orchestrator.simulateIntent(signedIntentOp)
   return simulationResults

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -51,7 +51,7 @@ function getSetup(config: RhinestoneAccountConfig): ModeleSetup {
     validators.push(socialRecoveryValidator)
   }
 
-  const intentExecutorAddress = config.useDev
+  const intentExecutorAddress = config.orchestratorUrl
     ? INTENT_EXECUTOR_ADDRESS_DEV
     : INTENT_EXECUTOR_ADDRESS
   const executors: Module[] = [

--- a/src/orchestrator/consts.ts
+++ b/src/orchestrator/consts.ts
@@ -1,13 +1,11 @@
 const PROD_ORCHESTRATOR_URL = 'https://v1.orchestrator.rhinestone.dev'
 const STAGING_ORCHESTRATOR_URL =
   'https://staging.v1.orchestrator.rhinestone.dev'
-const DEV_ORCHESTRATOR_URL = 'https://dev.v1.orchestrator.rhinestone.dev'
 const RHINESTONE_SPOKE_POOL_ADDRESS =
   '0x000000000060f6e853447881951574cdd0663530'
 
 export {
   PROD_ORCHESTRATOR_URL,
   STAGING_ORCHESTRATOR_URL,
-  DEV_ORCHESTRATOR_URL,
   RHINESTONE_SPOKE_POOL_ADDRESS,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,9 +163,9 @@ interface RhinestoneAccountConfig {
   paymaster?: PaymasterConfig
   /**
    * @internal
-   * For internal testing only - do not use
+   * Optional orchestrator URL override for internal testing - do not use
    */
-  useDev?: boolean
+  orchestratorUrl?: string
 }
 
 type TokenSymbol = 'ETH' | 'WETH' | 'USDC' | 'USDT'


### PR DESCRIPTION
## Description
If user doesn't pass `orchestratorUrl`: Use existing mainnet/testnet flow
- Mainnet chains → production orchestrator URL with production contracts
- Testnet chains → staging orchestrator URL with production contracts

If user passes `orchestratorUrl`: Use custom URL for internal testing
- Use the provided orchestrator URL directly
- Automatically enable dev contracts for testing

## Checklist
- [x] Changeset
