### PR TITLE
feat: add ens validator config and support

### DIFF
--- a/.changeset/proud-donuts-work.md
+++ b/.changeset/proud-donuts-work.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Add ens ownable validator support

--- a/src/accounts/safe.ts
+++ b/src/accounts/safe.ts
@@ -387,7 +387,6 @@ function getOwners(config: RhinestoneAccountConfig) {
   const ownerSet = config.owners
   switch (ownerSet.type) {
     case 'ecdsa':
-      return ownerSet.accounts.map((account) => account.address)
     case 'ens':
       return ownerSet.accounts.map((account) => account.address)
     case 'passkey':

--- a/src/accounts/safe.ts
+++ b/src/accounts/safe.ts
@@ -388,6 +388,8 @@ function getOwners(config: RhinestoneAccountConfig) {
   switch (ownerSet.type) {
     case 'ecdsa':
       return ownerSet.accounts.map((account) => account.address)
+    case 'ens':
+      return ownerSet.accounts.map((account) => account.address)
     case 'passkey':
       return [NO_SAFE_OWNER_ADDRESS]
     case 'multi-factor':
@@ -402,6 +404,9 @@ function getThreshold(config: RhinestoneAccountConfig) {
   const ownerSet = config.owners
   switch (ownerSet.type) {
     case 'ecdsa':
+      return ownerSet.threshold ? BigInt(ownerSet.threshold) : 1n
+    case 'ens':
+      // ENS validator uses the same threshold logic as ECDSA
       return ownerSet.threshold ? BigInt(ownerSet.threshold) : 1n
     case 'passkey':
       return 1n

--- a/src/accounts/safe.ts
+++ b/src/accounts/safe.ts
@@ -404,9 +404,7 @@ function getThreshold(config: RhinestoneAccountConfig) {
   const ownerSet = config.owners
   switch (ownerSet.type) {
     case 'ecdsa':
-      return ownerSet.threshold ? BigInt(ownerSet.threshold) : 1n
     case 'ens':
-      // ENS validator uses the same threshold logic as ECDSA
       return ownerSet.threshold ? BigInt(ownerSet.threshold) : 1n
     case 'passkey':
       return 1n

--- a/src/accounts/signing/common.ts
+++ b/src/accounts/signing/common.ts
@@ -35,6 +35,14 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
         module: owners.module,
       }
     }
+    case 'ens': {
+      return {
+        type: 'owner',
+        kind: 'ecdsa',
+        accounts: owners.accounts,
+        module: owners.module,
+      }
+    }
     case 'passkey': {
       return {
         type: 'owner',
@@ -57,6 +65,14 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
                 module: validator.module,
               }
             }
+            case 'ens': {
+              return {
+                type: 'ecdsa',
+                id: index,
+                accounts: validator.accounts,
+                module: validator.module,
+              }
+            }
             case 'passkey': {
               return {
                 type: 'passkey',
@@ -64,6 +80,11 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
                 accounts: validator.accounts,
                 module: validator.module,
               }
+            }
+            default: {
+              throw new Error(
+                `Unsupported validator type: ${(validator as any).type}`,
+              )
             }
           }
         }),

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -1127,10 +1127,8 @@ function getValidator(
   if (withOwner) {
     // ECDSA
     if (withOwner.kind === 'ecdsa') {
-      return getOwnableValidator(
-        1,
-        withOwner.accounts.map((account) => account.address),
-      )
+      // Use the configured owner validator (e.g., ENS) rather than forcing Ownable
+      return getOwnerValidator(config)
     }
     // Passkeys (WebAuthn)
     if (withOwner.kind === 'passkey') {

--- a/src/orchestrator/error.ts
+++ b/src/orchestrator/error.ts
@@ -1,4 +1,4 @@
-import { Address, Hex } from 'viem'
+import type { Address, Hex } from 'viem'
 
 interface Simulation {
   success: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,14 @@ interface OwnableValidatorConfig {
   module?: Address
 }
 
+interface ENSValidatorConfig {
+  type: 'ens'
+  accounts: Account[]
+  threshold?: number
+  ownerExpirations: number[]
+  module?: Address
+}
+
 interface WebauthnValidatorConfig {
   type: 'passkey'
   accounts: WebAuthnAccount[]
@@ -60,7 +68,11 @@ interface WebauthnValidatorConfig {
 
 interface MultiFactorValidatorConfig {
   type: 'multi-factor'
-  validators: (OwnableValidatorConfig | WebauthnValidatorConfig)[]
+  validators: (
+    | OwnableValidatorConfig
+    | ENSValidatorConfig
+    | WebauthnValidatorConfig
+  )[]
   threshold?: number
   module?: Address
 }
@@ -87,6 +99,7 @@ interface PaymasterConfig {
 
 type OwnerSet =
   | OwnableValidatorConfig
+  | ENSValidatorConfig
   | WebauthnValidatorConfig
   | MultiFactorValidatorConfig
 
@@ -350,6 +363,7 @@ export type {
   SourceAssetInput,
   OwnerSet,
   OwnableValidatorConfig,
+  ENSValidatorConfig,
   WebauthnValidatorConfig,
   MultiFactorValidatorConfig,
   SignerSet,


### PR DESCRIPTION
## Description
Add ENS multi ownable validator config

```ts
const rhinestone = new RhinestoneSDK({
	apiKey: API_KEY,
});

const smartAccount = await rhinestone.createAccount({
  type: 'nexus',
  salt: '',
  owners: {
    type: 'ens',
    accounts: [eoaAccount],
    threshold: 1,
    ownerExpirations: [
      281474976710655, // type(uint48).max for permanent ownership
    ],
    module: ENS_VALIDATOR_ADDRESS,
  },
})
``` 

## Checklist

- [x] Changeset
