### PR TITLE
feat: support custom http / bundler / paymaster client

### DIFF
--- a/.changeset/pink-moons-admire.md
+++ b/.changeset/pink-moons-admire.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Support custom bundler / paymaster / provider transport using `factory` prop

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {

--- a/src/accounts/json-rpc/index.test.ts
+++ b/src/accounts/json-rpc/index.test.ts
@@ -1,6 +1,6 @@
+import { http } from 'viem'
 import { base, mainnet } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
-
 import { createTransport } from './index'
 
 describe('JSON-RPC', () => {
@@ -21,6 +21,16 @@ describe('JSON-RPC', () => {
         },
       })
       expect(transport).toBeDefined()
+    })
+
+    test('Factory', () => {
+      const viemTransport = http('https://my-rpc.example.com')
+      const transport = createTransport(mainnet, {
+        type: 'factory',
+        getTransport: (_chainId: number) => viemTransport,
+      })
+      expect(transport).toBeDefined()
+      expect(transport).toBe(viemTransport)
     })
 
     test('Custom throws error when URL not configured for chain', () => {

--- a/src/accounts/json-rpc/index.ts
+++ b/src/accounts/json-rpc/index.ts
@@ -20,6 +20,9 @@ function createTransport(chain: Chain, provider?: ProviderConfig): Transport {
       const customUrl = getCustomUrl(chain.id, provider.urls)
       return http(customUrl)
     }
+    case 'factory': {
+      return provider.getTransport(chain.id)
+    }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Account, Address, Chain, Hex } from 'viem'
+import type { Account, Address, Chain, Hex, Transport } from 'viem'
 import type { WebAuthnAccount } from 'viem/account-abstraction'
 import type { ModuleType } from './modules/common'
 import type { EnableSessionData } from './modules/validators/smart-sessions'
@@ -88,16 +88,30 @@ type ProviderConfig =
       type: 'custom'
       urls: Record<number, string>
     }
+  | {
+      type: 'factory'
+      getTransport: (chainId: number) => Transport
+    }
 
-interface BundlerConfig {
-  type: 'pimlico' | 'biconomy'
-  apiKey: string
-}
+type BundlerConfig =
+  | {
+      type: 'pimlico' | 'biconomy'
+      apiKey: string
+    }
+  | {
+      type: 'factory'
+      getTransport: (chainId: number) => Transport
+    }
 
-interface PaymasterConfig {
-  type: 'pimlico' | 'biconomy'
-  apiKey: string
-}
+type PaymasterConfig =
+  | {
+      type: 'pimlico' | 'biconomy'
+      apiKey: string
+    }
+  | {
+      type: 'factory'
+      getTransport: (chainId: number) => Transport
+    }
 
 type OwnerSet =
   | OwnableValidatorConfig


### PR DESCRIPTION
## Description

Related to: https://github.com/rhinestonewtf/sdk/issues/269

Support custom transport for the viem public client, and the bundler / paymaster.

Eposing new `factory` properties, on the 3 config types (`ProviderConfig`, `BundlerConfig` and `PaymasterConfig`), taking as param the chainId, and returning a viem Transport.

## Checklist

- [x] Changeset
