### PR TITLE
fix: skip initData check if factory data is not provided

### DIFF
--- a/.changeset/fix-init-data-check.md
+++ b/.changeset/fix-init-data-check.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Skip initData check if factory data is not provided

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -366,12 +366,14 @@ function getAddress(config: RhinestoneConfig) {
 }
 
 function checkAddress(config: RhinestoneConfig) {
-  if (!config.initData) {
+  const initData = config.initData
+  if (!initData) {
     return true
   }
-  return (
-    config.initData.address.toLowerCase() === getAddress(config).toLowerCase()
-  )
+  if (!('factory' in initData)) {
+    return true
+  }
+  return initData.address.toLowerCase() === getAddress(config).toLowerCase()
 }
 
 // Signs and packs a signature to be EIP-1271 compatible


### PR DESCRIPTION
Lets clients use existing accounts created elsewhere by only providing an address.