### PR TITLE
fix: improve EIP-7702 init signature required error message

### DIFF
--- a/.changeset/improve-7702-init-error.md
+++ b/.changeset/improve-7702-init-error.md
@@ -1,0 +1,6 @@
+---
+"@rhinestone/sdk": patch
+---
+
+- Pass `eip7702InitSignature` to `sendTransaction`
+- Improve EIP-7702 init signature required error message

--- a/src/execution/error.ts
+++ b/src/execution/error.ts
@@ -102,6 +102,20 @@ class IntentStatusTimeoutError extends ExecutionError {
   }
 }
 
+class Eip7702InitSignatureRequiredError extends ExecutionError {
+  constructor(params?: {
+    context?: any
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        'EIP-7702 initialization signature is required for 7702 accounts. This signature is needed during transaction preparation, even if your account is already deployed on all chains. Use `getEip7702InitSignature()` to generate it.',
+      ...params,
+    })
+  }
+}
+
 function isExecutionError(error: Error): error is ExecutionError {
   return error instanceof ExecutionError
 }
@@ -109,6 +123,7 @@ function isExecutionError(error: Error): error is ExecutionError {
 export {
   isExecutionError,
   ExecutionError,
+  Eip7702InitSignatureRequiredError,
   OrderPathRequiredForIntentsError,
   SessionChainRequiredError,
   IntentFailedError,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -83,6 +83,7 @@ async function sendTransaction(
     recipient,
     signers,
     sponsored,
+    eip7702InitSignature,
     settlementLayers,
     sourceAssets,
     feeAsset,
@@ -98,6 +99,7 @@ async function sendTransaction(
     recipient,
     signers,
     sponsored,
+    eip7702InitSignature,
     settlementLayers,
     sourceAssets,
     feeAsset,
@@ -134,6 +136,7 @@ async function sendTransactionInternal(
     recipient?: RhinestoneAccountConfig | Address
     signers?: SignerSet
     sponsored?: Sponsorship
+    eip7702InitSignature?: Hex
     settlementLayers?: SettlementLayer[]
     sourceAssets?: SourceAssetInput
     lockFunds?: boolean
@@ -170,6 +173,7 @@ async function sendTransactionInternal(
       options.recipient,
       options.signers,
       options.sponsored,
+      options.eip7702InitSignature,
       options.settlementLayers,
       options.sourceAssets,
       options.feeAsset,
@@ -222,6 +226,7 @@ async function sendTransactionAsIntent(
   recipient: RhinestoneAccountConfig | Address | undefined,
   signers?: SignerSet,
   sponsored?: Sponsorship,
+  eip7702InitSignature?: Hex,
   settlementLayers?: SettlementLayer[],
   sourceAssets?: SourceAssetInput,
   feeAsset?: Address | TokenSymbol,
@@ -236,7 +241,7 @@ async function sendTransactionAsIntent(
     tokenRequests,
     recipient,
     sponsored ?? false,
-    undefined,
+    eip7702InitSignature,
     settlementLayers,
     sourceAssets,
     feeAsset,

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -105,7 +105,10 @@ import type {
   UserOperationTransaction,
 } from '../types'
 import { getCompactTypedData } from './compact'
-import { SignerNotSupportedError } from './error'
+import {
+  Eip7702InitSignatureRequiredError,
+  SignerNotSupportedError,
+} from './error'
 import { getTypedData as getPermit2TypedData } from './permit2'
 import { getTypedData as getSingleChainOpsTypedData } from './singleChainOps'
 
@@ -1338,9 +1341,7 @@ function getSetupOperationsAndDelegations(
   } else if (is7702(config)) {
     // EIP-7702 initialization is only needed for EOA accounts
     if (!eip7702InitSignature || eip7702InitSignature === '0x') {
-      throw new Error(
-        'EIP-7702 initialization signature is required for EOA accounts',
-      )
+      throw new Eip7702InitSignatureRequiredError()
     }
 
     const { initData: eip7702InitData, contract: eip7702Contract } =


### PR DESCRIPTION
## Summary
- Properly pass `eip7702InitSignature` to internal function when using `sendTransaction`
- Improve error message to explain that the signature is needed during transaction preparation, even if the account is already deployed on all chains