### PR TITLE
feat: implement neverthrow wrapper for orchestrator client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,9 +23,10 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "dependencies": {
         "@rhinestone/shared-configs": "1.4.91",
+        "neverthrow": "^8.2.0",
         "ox": "^0.11.3",
         "solady": "^0.1.26",
       },
@@ -494,6 +495,8 @@
     "nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
 
     "nanospinner": ["nanospinner@1.2.2", "", { "dependencies": { "picocolors": "^1.1.1" } }, "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA=="],
+
+    "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1,6 +1,14 @@
 import { Orchestrator } from './client'
 import { PROD_ORCHESTRATOR_URL, RHINESTONE_SPOKE_POOL_ADDRESS } from './consts'
 import {
+  SafeOrchestrator,
+  getSafeOrchestrator,
+  categorizeError,
+  ErrorCategory,
+  type OrchestratorResult,
+  type CategorizedError,
+} from './safeClient'
+import {
   AuthenticationRequiredError,
   BadRequestError,
   BodyParserError,
@@ -91,6 +99,8 @@ export type {
   TokenRequirements,
   WrapRequired,
   ApprovalRequired,
+  OrchestratorResult,
+  CategorizedError,
 }
 export {
   INTENT_STATUS_PENDING,
@@ -128,6 +138,10 @@ export {
   UnsupportedChainIdError,
   UnsupportedTokenError,
   getOrchestrator,
+  SafeOrchestrator,
+  getSafeOrchestrator,
+  categorizeError,
+  ErrorCategory,
   getWethAddress,
   getTokenSymbol,
   getTokenAddress,

--- a/src/orchestrator/safeClient.test.ts
+++ b/src/orchestrator/safeClient.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from 'vitest'
+import { errAsync, okAsync } from 'neverthrow'
+import {
+  categorizeError,
+  ErrorCategory,
+  type CategorizedError,
+  type OrchestratorResult,
+} from './safeClient'
+import {
+  AuthenticationRequiredError,
+  BadRequestError,
+  ForbiddenError,
+  InsufficientBalanceError,
+  InsufficientLiquidityError,
+  InternalServerError,
+  InvalidApiKeyError,
+  NoPathFoundError,
+  OrchestratorError,
+  RateLimitedError,
+  ServiceUnavailableError,
+  UnsupportedChainError,
+  UnsupportedTokenError,
+} from './error'
+import type { Portfolio } from './types'
+
+/**
+ * Helper for exhaustive checks - TypeScript will error if a case is missed.
+ */
+function assertNever(x: never): never {
+  throw new Error(`Unexpected case: ${x}`)
+}
+
+/**
+ * Example error handler using exhaustive pattern matching.
+ * TypeScript ensures all categories are handled.
+ */
+function handlePortfolioError(categorized: CategorizedError): string {
+  switch (categorized.category) {
+    case ErrorCategory.Auth:
+      return `Authentication failed: ${categorized.error.message}. Please check your API key.`
+
+    case ErrorCategory.Balance:
+      if (categorized.error instanceof InsufficientLiquidityError) {
+        const available = categorized.error.availableIntents
+          .map(intent => Object.entries(intent).map(([k, v]) => `${k}: ${v.toString()}`).join(', '))
+          .join('; ')
+        return `Insufficient liquidity. Available: [${available}]`
+      }
+      return `Insufficient balance: ${categorized.error.message}`
+
+    case ErrorCategory.Validation:
+      return `Invalid request: ${categorized.error.message}`
+
+    case ErrorCategory.Server:
+      return `Server error: ${categorized.error.message}. Please try again later.`
+
+    case ErrorCategory.RateLimit:
+      const retryMsg = categorized.retryAfter
+        ? ` Retry after ${categorized.retryAfter}s.`
+        : ''
+      return `Rate limited.${retryMsg}`
+
+    case ErrorCategory.Unknown:
+      return `Unexpected error: ${categorized.error.message}`
+
+    default:
+      // TypeScript will error here if we miss a case
+      return assertNever(categorized)
+  }
+}
+
+describe('SafeOrchestrator', () => {
+  describe('Result pattern with exhaustive error handling', () => {
+    test('handles successful portfolio fetch', async () => {
+      const mockPortfolio: Portfolio = [
+        {
+          symbol: 'ETH',
+          decimals: 18,
+          balances: { locked: 0n, unlocked: 1000000000000000000n },
+          chains: [
+            {
+              chain: 1,
+              address: '0x0000000000000000000000000000000000000000',
+              locked: 0n,
+              unlocked: 1000000000000000000n,
+            },
+          ],
+        },
+      ]
+
+      // Simulate a successful result
+      const result: OrchestratorResult<Portfolio> = okAsync(mockPortfolio)
+
+      // Pattern: match on result
+      const output = await result.match(
+        (portfolio) => `Found ${portfolio.length} tokens`,
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toBe('Found 1 tokens')
+    })
+
+    test('handles InsufficientBalanceError with exhaustive check', async () => {
+      const error = new InsufficientBalanceError({
+        traceId: 'trace-123',
+        statusCode: 400,
+      })
+
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      const output = await result.match(
+        (portfolio) => `Found ${portfolio.length} tokens`,
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toBe('Insufficient balance: Insufficient balance')
+    })
+
+    test('handles AuthenticationRequiredError', async () => {
+      const error = new AuthenticationRequiredError({
+        traceId: 'trace-456',
+        statusCode: 401,
+      })
+
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      const output = await result.match(
+        () => 'success',
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toContain('Authentication failed')
+      expect(output).toContain('Please check your API key')
+    })
+
+    test('handles RateLimitedError with retry-after', async () => {
+      const error = new RateLimitedError({
+        context: { retryAfter: '30' },
+        traceId: 'trace-789',
+        statusCode: 429,
+      })
+
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      const output = await result.match(
+        () => 'success',
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toBe('Rate limited. Retry after 30s.')
+    })
+
+    test('handles InsufficientLiquidityError with partial data', async () => {
+      const error = new InsufficientLiquidityError({
+        availableIntents: [{ '0xtoken': 500n }],
+        unfillable: { '0xtoken': 500n },
+        traceId: 'trace-liquidity',
+        statusCode: 422,
+      })
+
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      const output = await result.match(
+        () => 'success',
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toContain('Insufficient liquidity')
+      expect(output).toContain('Available:')
+    })
+
+    test('handles UnsupportedChainError as validation', async () => {
+      const error = new UnsupportedChainError(999, {
+        traceId: 'trace-chain',
+        statusCode: 400,
+      })
+
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      const output = await result.match(
+        () => 'success',
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toBe('Invalid request: Unsupported chain 999')
+    })
+
+    test('handles server errors', async () => {
+      const error = new ServiceUnavailableError({
+        traceId: 'trace-503',
+        statusCode: 503,
+      })
+
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      const output = await result.match(
+        () => 'success',
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toContain('Server error')
+      expect(output).toContain('try again later')
+    })
+
+    test('handles unknown OrchestratorError', async () => {
+      const error = new OrchestratorError({
+        message: 'Something unexpected happened',
+        traceId: 'trace-unknown',
+      })
+
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      const output = await result.match(
+        () => 'success',
+        (error) => handlePortfolioError(categorizeError(error)),
+      )
+
+      expect(output).toBe('Unexpected error: Something unexpected happened')
+    })
+  })
+
+  describe('Chaining with mapErr', () => {
+    test('can transform errors in a pipeline', async () => {
+      const error = new InsufficientBalanceError({ statusCode: 400 })
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      // Chain error transformations
+      const processed = result
+        .map((p) => p.filter((t) => t.symbol === 'ETH'))
+        .mapErr((e) => {
+          // Log or transform the error
+          return {
+            originalError: e,
+            userMessage: handlePortfolioError(categorizeError(e)),
+            timestamp: Date.now(),
+          }
+        })
+
+      const output = await processed.match(
+        () => null,
+        (transformed) => transformed,
+      )
+
+      expect(output).not.toBeNull()
+      expect(output?.userMessage).toContain('Insufficient balance')
+      expect(output?.originalError).toBeInstanceOf(InsufficientBalanceError)
+    })
+  })
+
+  describe('isErr/isOk pattern', () => {
+    test('can use isErr for early returns', async () => {
+      const error = new NoPathFoundError({ statusCode: 422 })
+      const result: OrchestratorResult<Portfolio> = errAsync(error)
+
+      // Unwrap the ResultAsync to get a Result
+      const syncResult = await result
+
+      if (syncResult.isErr()) {
+        const categorized = categorizeError(syncResult.error)
+        expect(categorized.category).toBe(ErrorCategory.Validation)
+        return
+      }
+
+      // TypeScript knows syncResult.value is Portfolio here
+      expect(syncResult.value).toBeDefined()
+    })
+  })
+})
+
+describe('Error categorization', () => {
+  test('categorizes all error types correctly', () => {
+    const testCases: [OrchestratorError, CategorizedError['category']][] = [
+      [new AuthenticationRequiredError({}), ErrorCategory.Auth],
+      [new InvalidApiKeyError({}), ErrorCategory.Auth],
+      [new ForbiddenError({}), ErrorCategory.Auth],
+      [new InsufficientBalanceError({}), ErrorCategory.Balance],
+      [new InsufficientLiquidityError({ availableIntents: [], unfillable: {} }), ErrorCategory.Balance],
+      [new BadRequestError({}), ErrorCategory.Validation],
+      [new UnsupportedChainError(1, {}), ErrorCategory.Validation],
+      [new UnsupportedTokenError('ETH', 1, {}), ErrorCategory.Validation],
+      [new NoPathFoundError({}), ErrorCategory.Validation],
+      [new InternalServerError({}), ErrorCategory.Server],
+      [new ServiceUnavailableError({}), ErrorCategory.Server],
+      [new RateLimitedError({}), ErrorCategory.RateLimit],
+      [new OrchestratorError({}), ErrorCategory.Unknown],
+    ]
+
+    for (const [error, expectedCategory] of testCases) {
+      const categorized = categorizeError(error)
+      expect(categorized.category).toBe(expectedCategory)
+    }
+  })
+})

--- a/src/orchestrator/safeClient.ts
+++ b/src/orchestrator/safeClient.ts
@@ -1,0 +1,230 @@
+import type { Address } from 'viem'
+import { ResultAsync } from 'neverthrow'
+import { Orchestrator } from './client'
+import { PROD_ORCHESTRATOR_URL } from './consts'
+import {
+  type OrchestratorError,
+  AuthenticationRequiredError,
+  BadRequestError,
+  ForbiddenError,
+  InsufficientBalanceError,
+  InsufficientLiquidityError,
+  InternalServerError,
+  InvalidApiKeyError,
+  NoPathFoundError,
+  RateLimitedError,
+  ServiceUnavailableError,
+  UnsupportedChainError,
+  UnsupportedChainIdError,
+  UnsupportedTokenError,
+  TokenNotSupportedError,
+} from './error'
+import type {
+  IntentInput,
+  IntentOpStatus,
+  IntentResult,
+  IntentRoute,
+  Portfolio,
+  SignedIntentOp,
+  SplitIntentsInput,
+  SplitIntentsResult,
+} from './types'
+
+/**
+ * A Result type that wraps orchestrator responses.
+ * Success contains the value T, Error contains an OrchestratorError.
+ */
+export type OrchestratorResult<T> = ResultAsync<T, OrchestratorError>
+
+/**
+ * Error categories for discriminated union pattern matching.
+ */
+export const ErrorCategory = {
+  Auth: 'auth',
+  Balance: 'balance',
+  Validation: 'validation',
+  Server: 'server',
+  RateLimit: 'rate_limit',
+  Unknown: 'unknown',
+} as const
+
+export type ErrorCategory = (typeof ErrorCategory)[keyof typeof ErrorCategory]
+
+/**
+ * Discriminated union for categorized error handling.
+ * Enables exhaustive switch statements with TypeScript.
+ */
+export type CategorizedError =
+  | { category: typeof ErrorCategory.Auth; error: AuthenticationRequiredError | InvalidApiKeyError | ForbiddenError }
+  | { category: typeof ErrorCategory.Balance; error: InsufficientBalanceError | InsufficientLiquidityError }
+  | { category: typeof ErrorCategory.Validation; error: BadRequestError | UnsupportedChainError | UnsupportedChainIdError | UnsupportedTokenError | TokenNotSupportedError | NoPathFoundError }
+  | { category: typeof ErrorCategory.Server; error: InternalServerError | ServiceUnavailableError }
+  | { category: typeof ErrorCategory.RateLimit; error: RateLimitedError; retryAfter?: string }
+  | { category: typeof ErrorCategory.Unknown; error: OrchestratorError }
+
+/**
+ * Categorize an OrchestratorError into a discriminated union.
+ * Enables exhaustive pattern matching in switch statements.
+ *
+ * @example
+ * ```ts
+ * const result = await client.getPortfolio(address)
+ *
+ * if (result.isErr()) {
+ *   const categorized = categorizeError(result.error)
+ *   switch (categorized.category) {
+ *     case 'auth':
+ *       // Handle auth errors
+ *       break
+ *     case 'balance':
+ *       // Handle balance errors
+ *       break
+ *     // ... TypeScript ensures all cases are handled
+ *   }
+ * }
+ * ```
+ */
+export function categorizeError(error: OrchestratorError): CategorizedError {
+  if (
+    error instanceof AuthenticationRequiredError ||
+    error instanceof InvalidApiKeyError ||
+    error instanceof ForbiddenError
+  ) {
+    return { category: ErrorCategory.Auth, error }
+  }
+
+  if (
+    error instanceof InsufficientBalanceError ||
+    error instanceof InsufficientLiquidityError
+  ) {
+    return { category: ErrorCategory.Balance, error }
+  }
+
+  if (
+    error instanceof BadRequestError ||
+    error instanceof UnsupportedChainError ||
+    error instanceof UnsupportedChainIdError ||
+    error instanceof UnsupportedTokenError ||
+    error instanceof TokenNotSupportedError ||
+    error instanceof NoPathFoundError
+  ) {
+    return { category: ErrorCategory.Validation, error }
+  }
+
+  if (
+    error instanceof InternalServerError ||
+    error instanceof ServiceUnavailableError
+  ) {
+    return { category: ErrorCategory.Server, error }
+  }
+
+  if (error instanceof RateLimitedError) {
+    return {
+      category: ErrorCategory.RateLimit,
+      error,
+      retryAfter: error.context?.retryAfter,
+    }
+  }
+
+  return { category: ErrorCategory.Unknown, error }
+}
+
+/**
+ * A wrapper around the Orchestrator client that returns Result types
+ * instead of throwing exceptions. This forces explicit error handling
+ * and provides a more functional API.
+ *
+ * @example
+ * ```ts
+ * const client = new SafeOrchestrator(url, apiKey)
+ *
+ * const result = await client.getPortfolio(address)
+ *
+ * if (result.isErr()) {
+ *   // Handle error - TypeScript knows result.error is OrchestratorError
+ *   console.error(result.error.message)
+ *   return
+ * }
+ *
+ * // TypeScript knows result.value is Portfolio
+ * console.log(result.value)
+ * ```
+ */
+export class SafeOrchestrator {
+  private client: Orchestrator
+
+  constructor(serverUrl: string, apiKey?: string) {
+    this.client = new Orchestrator(serverUrl, apiKey)
+  }
+
+  /**
+   * Get the portfolio (token balances) for an account.
+   */
+  getPortfolio(
+    userAddress: Address,
+    filter?: {
+      chainIds?: number[]
+      tokens?: {
+        [chainId: number]: Address[]
+      }
+    },
+  ): OrchestratorResult<Portfolio> {
+    return ResultAsync.fromPromise(
+      this.client.getPortfolio(userAddress, filter),
+      (error) => error as OrchestratorError,
+    )
+  }
+
+  /**
+   * Get the intent route for a given intent input.
+   */
+  getIntentRoute(input: IntentInput): OrchestratorResult<IntentRoute> {
+    return ResultAsync.fromPromise(
+      this.client.getIntentRoute(input),
+      (error) => error as OrchestratorError,
+    )
+  }
+
+  /**
+   * Split intents into smaller chunks based on liquidity availability.
+   */
+  splitIntents(input: SplitIntentsInput): OrchestratorResult<SplitIntentsResult> {
+    return ResultAsync.fromPromise(
+      this.client.splitIntents(input),
+      (error) => error as OrchestratorError,
+    )
+  }
+
+  /**
+   * Submit a signed intent operation to the orchestrator.
+   */
+  submitIntent(
+    signedIntentOp: SignedIntentOp,
+    dryRun: boolean,
+  ): OrchestratorResult<IntentResult> {
+    return ResultAsync.fromPromise(
+      this.client.submitIntent(signedIntentOp, dryRun),
+      (error) => error as OrchestratorError,
+    )
+  }
+
+  /**
+   * Get the status of a submitted intent operation.
+   */
+  getIntentOpStatus(intentId: bigint): OrchestratorResult<IntentOpStatus> {
+    return ResultAsync.fromPromise(
+      this.client.getIntentOpStatus(intentId),
+      (error) => error as OrchestratorError,
+    )
+  }
+}
+
+/**
+ * Factory function to create a SafeOrchestrator with default production URL.
+ */
+export function getSafeOrchestrator(
+  apiKey?: string,
+  orchestratorUrl?: string,
+): SafeOrchestrator {
+  return new SafeOrchestrator(orchestratorUrl ?? PROD_ORCHESTRATOR_URL, apiKey)
+}

--- a/src/package.json
+++ b/src/package.json
@@ -152,6 +152,7 @@
   },
   "dependencies": {
     "@rhinestone/shared-configs": "1.4.91",
+    "neverthrow": "^8.2.0",
     "ox": "^0.11.3",
     "solady": "^0.1.26"
   },


### PR DESCRIPTION
# Result-based Error Handling for Orchestrator Client

## Motivation

The current `Orchestrator` client uses traditional throw-based error handling. While familiar, this pattern has drawbacks:

1. **Errors are invisible in function signatures** - Callers don't know what errors a function can throw without reading implementation details
2. **Easy to forget error handling** - Nothing forces developers to handle errors at compile time
3. **Try/catch blocks are verbose** - Error handling code gets scattered and nested
4. **No composability** - Can't easily chain operations that might fail

This PR introduces a Rust-inspired `Result` pattern using [neverthrow](https://github.com/supermacro/neverthrow), which makes error handling:
- **Explicit** - Errors are part of the return type
- **Exhaustive** - TypeScript ensures all error cases are handled
- **Composable** - Chain operations with `.map()`, `.mapErr()`, `.andThen()`

## Changes

### New Dependencies
- `neverthrow` - Lightweight Result type library

### New Exports

| Export | Type | Description |
|--------|------|-------------|
| `SafeOrchestrator` | Class | Result-returning wrapper around `Orchestrator` |
| `getSafeOrchestrator()` | Function | Factory function (mirrors `getOrchestrator()`) |
| `OrchestratorResult<T>` | Type | `ResultAsync<T, OrchestratorError>` |
| `ErrorCategory` | Const | Category enum: `Auth`, `Balance`, `Validation`, `Server`, `RateLimit`, `Unknown` |
| `CategorizedError` | Type | Discriminated union for exhaustive matching |
| `categorizeError()` | Function | Converts error to `CategorizedError` |

### Backwards Compatibility

The existing `Orchestrator` class is unchanged. All current code continues to work.

## Usage

### Basic Usage

```typescript
import {
  getSafeOrchestrator,
  type OrchestratorResult
} from '@rhinestone/sdk/dist/src/orchestrator'

const client = getSafeOrchestrator(apiKey)

const result = await client.getPortfolio(address)

if (result.isErr()) {
  console.error(result.error.message)
  return
}

// TypeScript knows result.value is Portfolio
console.log(result.value)
```

### Pattern Matching with `.match()`

```typescript
const message = await client.getPortfolio(address).match(
  (portfolio) => `Found ${portfolio.length} tokens`,
  (error) => `Error: ${error.message}`
)
```

### Chaining Operations

```typescript
const ethBalance = await client
  .getPortfolio(address)
  .map((portfolio) => portfolio.find((t) => t.symbol === 'ETH'))
  .map((eth) => eth?.balances.unlocked ?? 0n)
  .mapErr((error) => {
    logger.error('Portfolio fetch failed', { error, traceId: error.traceId })
    return error
  })
```

### Exhaustive Error Handling

```typescript
import {
  getSafeOrchestrator,
  categorizeError,
  ErrorCategory
} from '@rhinestone/sdk/dist/src/orchestrator'

const client = getSafeOrchestrator(apiKey)
const result = await client.getPortfolio(address)

if (result.isErr()) {
  const categorized = categorizeError(result.error)

  switch (categorized.category) {
    case ErrorCategory.Auth:
      // Handle auth errors (invalid API key, unauthorized, forbidden)
      showLoginPrompt()
      break

    case ErrorCategory.Balance:
      // Handle balance errors (insufficient balance, insufficient liquidity)
      if (categorized.error instanceof InsufficientLiquidityError) {
        showPartialFillOptions(categorized.error.availableIntents)
      } else {
        showInsufficientFundsMessage()
      }
      break

    case ErrorCategory.Validation:
      // Handle validation errors (bad request, unsupported chain/token, no path)
      showValidationError(categorized.error.message)
      break

    case ErrorCategory.Server:
      // Handle server errors (500, 503)
      showRetryMessage()
      break

    case ErrorCategory.RateLimit:
      // Handle rate limiting with retry-after
      const retryAfter = categorized.retryAfter ?? '60'
      scheduleRetry(parseInt(retryAfter) * 1000)
      break

    case ErrorCategory.Unknown:
      // Handle unexpected errors
      reportToSentry(categorized.error)
      break

    default:
      // TypeScript error if a case is missed
      assertNever(categorized)
  }
}

function assertNever(x: never): never {
  throw new Error(`Unhandled case: ${x}`)
}
```

### Available Methods

All `Orchestrator` methods have `SafeOrchestrator` equivalents:

```typescript
// Throws
const orchestrator = getOrchestrator(apiKey)
const portfolio = await orchestrator.getPortfolio(address)        // throws on error

// Returns Result
const safeOrchestrator = getSafeOrchestrator(apiKey)
const result = await safeOrchestrator.getPortfolio(address)       // returns Result

// Methods available:
safeOrchestrator.getPortfolio(address, filter?)      // OrchestratorResult<Portfolio>
safeOrchestrator.getIntentRoute(input)               // OrchestratorResult<IntentRoute>
safeOrchestrator.splitIntents(input)                 // OrchestratorResult<SplitIntentsResult>
safeOrchestrator.submitIntent(signedOp, dryRun)      // OrchestratorResult<IntentResult>
safeOrchestrator.getIntentOpStatus(intentId)         // OrchestratorResult<IntentOpStatus>
```

## Error Categories

| Category | Errors | When |
|----------|--------|------|
| `Auth` | `AuthenticationRequiredError`, `InvalidApiKeyError`, `ForbiddenError` | Missing/invalid API key, insufficient permissions |
| `Balance` | `InsufficientBalanceError`, `InsufficientLiquidityError` | User has no funds or not enough liquidity |
| `Validation` | `BadRequestError`, `UnsupportedChainError`, `UnsupportedTokenError`, `NoPathFoundError`, etc. | Invalid input, unsupported chains/tokens |
| `Server` | `InternalServerError`, `ServiceUnavailableError` | 500/503 errors, retry recommended |
| `RateLimit` | `RateLimitedError` | 429 error, includes `retryAfter` hint |
| `Unknown` | `OrchestratorError` | Catch-all for unrecognized errors |

## Testing

```bash
bun run test -- src/orchestrator/safeClient.test.ts
```

Closes [RHI-5053](https://linear.app/rhinestone/issue/RHI-5053)
