### PR TITLE
feat: add auxiliary funds support to transaction options

### DIFF
--- a/.changeset/stupid-drinks-learn.md
+++ b/.changeset/stupid-drinks-learn.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+add auxiliary funds to route

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -247,6 +247,7 @@ async function sendTransactionAsIntent(
     feeAsset,
     lockFunds,
     undefined,
+    undefined,
     signers,
   )
   if (!intentRoute) {

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -1,0 +1,92 @@
+import { zeroAddress } from 'viem'
+import { arbitrum, base } from 'viem/chains'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { accountA } from '../../test/consts'
+import type { IntentInput } from '../orchestrator/types'
+import { prepareTransactionAsIntent } from './utils'
+
+const mockGetIntentRoute = vi.fn()
+
+vi.mock('../orchestrator', () => ({
+  getOrchestrator: () => ({
+    getIntentRoute: mockGetIntentRoute,
+  }),
+}))
+
+describe('prepareTransactionAsIntent', () => {
+  beforeEach(() => {
+    mockGetIntentRoute.mockReset()
+  })
+
+  test('includes auxiliaryFunds in options when provided', async () => {
+    const auxiliaryFunds = {
+      [arbitrum.id]: {
+        '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 500000000n,
+      } as Record<`0x${string}`, bigint>,
+    }
+
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      auxiliaryFunds,
+      undefined,
+      undefined,
+    )
+
+    expect(mockGetIntentRoute).toHaveBeenCalledOnce()
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.auxiliaryFunds).toEqual(auxiliaryFunds)
+  })
+
+  test('does not include auxiliaryFunds in options when not provided', async () => {
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    expect(mockGetIntentRoute).toHaveBeenCalledOnce()
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.auxiliaryFunds).toBeUndefined()
+  })
+})

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -80,6 +80,7 @@ import {
 } from '../orchestrator/registry'
 import {
   type AccountAccessList,
+  type AuxiliaryFunds,
   type Account as OrchestratorAccount,
   type OriginSignature,
   type SettlementLayer,
@@ -161,6 +162,7 @@ async function prepareTransaction(
     sourceAssets,
     feeAsset,
     lockFunds,
+    auxiliaryFunds,
     account,
     recipient,
   } = getTransactionParams(transaction)
@@ -189,6 +191,7 @@ async function prepareTransaction(
     sourceAssets,
     feeAsset,
     lockFunds,
+    auxiliaryFunds,
     account,
     signers,
   )
@@ -568,6 +571,7 @@ function getTransactionParams(transaction: Transaction) {
   const sourceAssets = transaction.sourceAssets
   const feeAsset = transaction.feeAsset
   const lockFunds = transaction.lockFunds
+  const auxiliaryFunds = transaction.auxiliaryFunds
   const account = transaction.experimental_accountOverride
   const recipient = transaction.recipient
 
@@ -590,6 +594,7 @@ function getTransactionParams(transaction: Transaction) {
     sourceAssets,
     feeAsset,
     lockFunds,
+    auxiliaryFunds,
     account,
     recipient,
   }
@@ -716,6 +721,7 @@ async function prepareTransactionAsIntent(
   sourceAssets: SourceAssetInput | undefined,
   feeAsset: Address | TokenSymbol | undefined,
   lockFunds: boolean | undefined,
+  auxiliaryFunds: AuxiliaryFunds | undefined,
   account:
     | {
         setupOps?: {
@@ -783,6 +789,7 @@ async function prepareTransactionAsIntent(
         : undefined,
       settlementLayers,
       signatureMode,
+      auxiliaryFunds,
     },
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import {
 } from './modules/validators/smart-sessions'
 import {
   type ApprovalRequired,
+  type AuxiliaryFunds,
   getAllSupportedChainsAndTokens,
   getSupportedTokens,
   getTokenAddress,
@@ -624,6 +625,7 @@ export type {
   PreparedUserOperationData,
   SignedUserOperationData,
   UserOperationResult,
+  AuxiliaryFunds,
   IntentInput,
   IntentOp,
   IntentOpStatus,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -43,6 +43,7 @@ import {
 } from './registry'
 import type {
   ApprovalRequired,
+  AuxiliaryFunds,
   IntentInput,
   IntentOp,
   IntentOpStatus,
@@ -76,6 +77,7 @@ function getOrchestrator(
 }
 
 export type {
+  AuxiliaryFunds,
   IntentInput,
   IntentOp,
   IntentOpStatus,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -92,12 +92,17 @@ type SignatureMode =
   | typeof SIG_MODE_EMISSARY_EXECUTION_ERC1271
   | typeof SIG_MODE_ERC1271_EMISSARY_EXECUTION
 
+type AuxiliaryFunds = {
+  [chainId: number]: Record<Address, bigint>
+}
+
 interface IntentOptions {
   topupCompact: boolean
   feeToken?: Address | SupportedTokenSymbol
   sponsorSettings?: SponsorSettings
   settlementLayers?: SettlementLayer[]
   signatureMode?: SignatureMode
+  auxiliaryFunds?: AuxiliaryFunds
 }
 
 interface SponsorSettings {
@@ -435,6 +440,7 @@ type PortfolioResponse = PortfolioTokenResponse[]
 export type {
   Account,
   AccountType,
+  AuxiliaryFunds,
   TokenConfig,
   SupportedChain,
   SettlementLayer,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { Account, Address, Chain, Hex } from 'viem'
 import type { WebAuthnAccount } from 'viem/account-abstraction'
 import type { ModuleType } from './modules/common'
-import type { SettlementLayer } from './orchestrator/types'
+import type { AuxiliaryFunds, SettlementLayer } from './orchestrator/types'
 
 type AccountType = 'safe' | 'nexus' | 'kernel' | 'startale' | 'passport' | 'eoa'
 
@@ -370,6 +370,7 @@ interface BaseTransaction {
   feeAsset?: Address | TokenSymbol
   settlementLayers?: SettlementLayer[]
   lockFunds?: boolean
+  auxiliaryFunds?: AuxiliaryFunds
   experimental_accountOverride?: {
     setupOps?: {
       to: Address


### PR DESCRIPTION
## Description

Adds support for specifying auxiliary funds (additional off-chain balances) when sending intents. Users can now pass `auxiliaryFunds` in transaction options to indicate funds available from external sources (e.g., exchange accounts) during route finding. 

This enables use cases like plasma/price discovery without requiring on-chain balances, and lays groundwork for origin executions to procure funds from elsewhere.

## Changes

- Added `AuxiliaryFunds` type definition to orchestrator types
- Added `auxiliaryFunds` optional field to `IntentOptions` 
- Added `auxiliaryFunds` optional parameter to `BaseTransaction`
- Threaded `auxiliaryFunds` through transaction preparation and intent building
- Added comprehensive unit tests verifying the feature works correctly

## Testing

Two new unit tests verify that:
- `auxiliaryFunds` are included in intent options when provided
- Intent options don't include `auxiliaryFunds` when not provided

All existing tests pass.