### PR TITLE
fix: remove default 1 wei token request for cross-chain

### DIFF
--- a/.changeset/remove-default-token-request.md
+++ b/.changeset/remove-default-token-request.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Remove default 1 wei token request for cross-chain transactions

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -155,10 +155,8 @@ async function sendTransactionInternal(
     accountAddress,
   )
   const tokenRequests = getTokenRequests(
-    sourceChains,
     targetChain,
     options.initialTokenRequests,
-    options.settlementLayers,
   )
 
   const sendAsUserOp =

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -569,10 +569,7 @@ function getTransactionParams(transaction: Transaction) {
   const account = transaction.experimental_accountOverride
   const recipient = transaction.recipient
 
-  const tokenRequests = getTokenRequests(
-    targetChain,
-    initialTokenRequests,
-  )
+  const tokenRequests = getTokenRequests(targetChain, initialTokenRequests)
 
   return {
     sourceChains,

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -19,7 +19,6 @@ import {
   type TypedDataDefinition,
   type TypedDataDomain,
   toHex,
-  zeroAddress,
 } from 'viem'
 import {
   entryPoint07Address,
@@ -571,10 +570,8 @@ function getTransactionParams(transaction: Transaction) {
   const recipient = transaction.recipient
 
   const tokenRequests = getTokenRequests(
-    sourceChains || [],
     targetChain,
     initialTokenRequests,
-    settlementLayers,
   )
 
   return {
@@ -596,10 +593,8 @@ function getTransactionParams(transaction: Transaction) {
 }
 
 function getTokenRequests(
-  sourceChains: Chain[] | undefined,
   targetChain: Chain,
   initialTokenRequests: TokenRequest[] | undefined,
-  settlementLayers: SettlementLayer[] | undefined,
 ) {
   if (initialTokenRequests) {
     validateTokenSymbols(
@@ -607,23 +602,7 @@ function getTokenRequests(
       initialTokenRequests.map((tokenRequest) => tokenRequest.address),
     )
   }
-  // Across requires passing some value to repay the solvers
-  const defaultTokenRequest = {
-    address: zeroAddress,
-    amount: 1n,
-  }
-  const isSameChain =
-    (settlementLayers?.length === 1 && settlementLayers[0] === 'SAME_CHAIN') ||
-    (sourceChains &&
-      sourceChains.length === 1 &&
-      sourceChains[0].id === targetChain.id)
-  const tokenRequests =
-    !initialTokenRequests || initialTokenRequests.length === 0
-      ? isSameChain
-        ? []
-        : [defaultTokenRequest]
-      : initialTokenRequests
-  return tokenRequests
+  return initialTokenRequests ?? []
 }
 
 async function prepareTransactionAsUserOp(


### PR DESCRIPTION
## Description

Remove the automatic 1 wei default token request when source chain is not specified. This simplifies the transaction logic and allows callers to explicitly provide token requests if needed.

## Checklist

- [ ] Changeset