### PR TITLE
don't use target executions for cross-chain txs

### DIFF
--- a/.changeset/remove-target-execution.md
+++ b/.changeset/remove-target-execution.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Remove targetExecution parameter from cross-chain transaction signing

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -249,11 +249,7 @@ function getTransactionMessages(
   origin: TypedDataDefinition[]
   destination: TypedDataDefinition
 } {
-  return getIntentMessages(
-    config,
-    preparedTransaction.intentRoute.intentOp,
-    false,
-  )
+  return getIntentMessages(config, preparedTransaction.intentRoute.intentOp)
 }
 
 async function signTransaction(
@@ -776,11 +772,7 @@ async function signIntent(
   signers?: SignerSet,
   targetExecution?: boolean,
 ) {
-  const { origin, destination } = getIntentMessages(
-    config,
-    intentOp,
-    targetExecution ?? false,
-  )
+  const { origin, destination } = getIntentMessages(config, intentOp)
   if (config.account?.type === 'eoa') {
     const eoa = config.eoa
     if (!eoa) {
@@ -888,11 +880,7 @@ async function getDestinationSignature(
     : (lastOriginSignature ?? '0x')
 }
 
-function getIntentMessages(
-  config: RhinestoneConfig,
-  intentOp: IntentOp,
-  targetExecution: boolean,
-) {
+function getIntentMessages(config: RhinestoneConfig, intentOp: IntentOp) {
   const address = getAddress(config)
   const intentExecutor = getIntentExecutor(config)
 
@@ -900,13 +888,11 @@ function getIntentMessages(
     (element) =>
       element.mandate.qualifier.settlementContext.fundingMethod === 'PERMIT2',
   )
-  const withIntentExecutorOps =
-    targetExecution ||
-    intentOp.elements.some(
-      (element) =>
-        element.mandate.qualifier.settlementContext.settlementLayer ===
-        'INTENT_EXECUTOR',
-    )
+  const withIntentExecutorOps = intentOp.elements.some(
+    (element) =>
+      element.mandate.qualifier.settlementContext.settlementLayer ===
+      'INTENT_EXECUTOR',
+  )
   const origin: TypedDataDefinition[] = []
   for (const element of intentOp.elements) {
     if (withIntentExecutorOps) {


### PR DESCRIPTION
## Summary
- Remove the `targetExecution` parameter from `getIntentMessages`
- Derive `withIntentExecutorOps` solely from intent op element settlement layers instead of accepting an override flag