### PR TITLE
fix: pass logger in RhinestoneSDK.createAccount config

### DIFF
--- a/.changeset/fix-logger-create-account.md
+++ b/.changeset/fix-logger-create-account.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Pass logger through `RhinestoneSDK.createAccount` config

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,6 +587,7 @@ class RhinestoneSDK {
       bundler: this.bundler,
       paymaster: this.paymaster,
       useDevContracts: this.useDevContracts,
+      logger: this.logger,
     }
     return createRhinestoneAccount(rhinestoneConfig)
   }


### PR DESCRIPTION
## Summary

- `RhinestoneSDK.createAccount` builds a `RhinestoneConfig` object manually but was missing `logger`, so the logger never reached orchestrator calls made through accounts created via the class API