### PR TITLE
Add optional Authorization header to orchestrator requests

### DIFF
--- a/.changeset/little-islands-post.md
+++ b/.changeset/little-islands-post.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Add optional Authorization header to orch

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -317,6 +317,7 @@ async function waitForExecution(
           config.apiKey,
           config.endpointUrl,
           config.logger,
+          config.authorizationHeader,
         )
         try {
           intentStatus = await orchestrator.getIntentOpStatus(result.id)
@@ -400,6 +401,7 @@ async function getPortfolio(config: RhinestoneConfig, onTestnets: boolean) {
     config.apiKey,
     config.endpointUrl,
     config.logger,
+    config.authorizationHeader,
   )
   const supportedChainIds = getSupportedChainIds()
   const filteredChainIds = supportedChainIds.filter((id) => {
@@ -417,12 +419,18 @@ async function getIntentStatus(
   endpointUrl: string | undefined,
   logger: Logger | undefined,
   intentId: bigint,
+  authorizationHeader?: string,
 ): Promise<
   TransactionStatus & {
     status: IntentOpStatus['status']
   }
 > {
-  const orchestrator = getOrchestrator(apiKey, endpointUrl, logger)
+  const orchestrator = getOrchestrator(
+    apiKey,
+    endpointUrl,
+    logger,
+    authorizationHeader,
+  )
   const internalStatus = await orchestrator.getIntentOpStatus(intentId)
   return {
     status: internalStatus.status,
@@ -442,8 +450,14 @@ async function splitIntents(
   endpointUrl: string | undefined,
   logger: Logger | undefined,
   input: SplitIntentsInput,
+  authorizationHeader?: string,
 ) {
-  const orchestrator = getOrchestrator(apiKey, endpointUrl, logger)
+  const orchestrator = getOrchestrator(
+    apiKey,
+    endpointUrl,
+    logger,
+    authorizationHeader,
+  )
   return orchestrator.splitIntents(input)
 }
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -425,12 +425,7 @@ async function getIntentStatus(
     status: IntentOpStatus['status']
   }
 > {
-  const orchestrator = getOrchestrator(
-    apiKey,
-    endpointUrl,
-    logger,
-    headers,
-  )
+  const orchestrator = getOrchestrator(apiKey, endpointUrl, logger, headers)
   const internalStatus = await orchestrator.getIntentOpStatus(intentId)
   return {
     status: internalStatus.status,
@@ -452,12 +447,7 @@ async function splitIntents(
   input: SplitIntentsInput,
   headers?: Record<string, string>,
 ) {
-  const orchestrator = getOrchestrator(
-    apiKey,
-    endpointUrl,
-    logger,
-    headers,
-  )
+  const orchestrator = getOrchestrator(apiKey, endpointUrl, logger, headers)
   return orchestrator.splitIntents(input)
 }
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -317,7 +317,7 @@ async function waitForExecution(
           config.apiKey,
           config.endpointUrl,
           config.logger,
-          config.authorizationHeader,
+          config.headers,
         )
         try {
           intentStatus = await orchestrator.getIntentOpStatus(result.id)
@@ -401,7 +401,7 @@ async function getPortfolio(config: RhinestoneConfig, onTestnets: boolean) {
     config.apiKey,
     config.endpointUrl,
     config.logger,
-    config.authorizationHeader,
+    config.headers,
   )
   const supportedChainIds = getSupportedChainIds()
   const filteredChainIds = supportedChainIds.filter((id) => {
@@ -419,7 +419,7 @@ async function getIntentStatus(
   endpointUrl: string | undefined,
   logger: Logger | undefined,
   intentId: bigint,
-  authorizationHeader?: string,
+  headers?: Record<string, string>,
 ): Promise<
   TransactionStatus & {
     status: IntentOpStatus['status']
@@ -429,7 +429,7 @@ async function getIntentStatus(
     apiKey,
     endpointUrl,
     logger,
-    authorizationHeader,
+    headers,
   )
   const internalStatus = await orchestrator.getIntentOpStatus(intentId)
   return {
@@ -450,13 +450,13 @@ async function splitIntents(
   endpointUrl: string | undefined,
   logger: Logger | undefined,
   input: SplitIntentsInput,
-  authorizationHeader?: string,
+  headers?: Record<string, string>,
 ) {
   const orchestrator = getOrchestrator(
     apiKey,
     endpointUrl,
     logger,
-    authorizationHeader,
+    headers,
   )
   return orchestrator.splitIntents(input)
 }

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -771,7 +771,7 @@ async function prepareTransactionAsIntent(
     config.apiKey,
     config.endpointUrl,
     config.logger,
-    config.authorizationHeader,
+    config.headers,
   )
   const intentRoute = await orchestrator.getIntentRoute(metaIntent)
   return intentRoute
@@ -1182,7 +1182,7 @@ async function submitIntentInternal(
     config.apiKey,
     config.endpointUrl,
     config.logger,
-    config.authorizationHeader,
+    config.headers,
   )
   const intentResults = await orchestrator.submitIntent(signedIntentOp, dryRun)
   return {

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -771,6 +771,7 @@ async function prepareTransactionAsIntent(
     config.apiKey,
     config.endpointUrl,
     config.logger,
+    config.authorizationHeader,
   )
   const intentRoute = await orchestrator.getIntentRoute(metaIntent)
   return intentRoute
@@ -1181,6 +1182,7 @@ async function submitIntentInternal(
     config.apiKey,
     config.endpointUrl,
     config.logger,
+    config.authorizationHeader,
   )
   const intentResults = await orchestrator.submitIntent(signedIntentOp, dryRun)
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -567,6 +567,7 @@ class RhinestoneSDK {
   private paymaster?: PaymasterConfig
   private useDevContracts?: boolean
   private logger?: Logger
+  private authorizationHeader?: string
 
   constructor(options: RhinestoneSDKConfig) {
     this.apiKey = options.apiKey
@@ -576,6 +577,7 @@ class RhinestoneSDK {
     this.paymaster = options.paymaster
     this.useDevContracts = options.useDevContracts
     this.logger = options.logger
+    this.authorizationHeader = options.authorizationHeader
   }
 
   createAccount(config: RhinestoneAccountConfig) {
@@ -598,6 +600,7 @@ class RhinestoneSDK {
       this.endpointUrl,
       this.logger,
       intentId,
+      this.authorizationHeader,
     )
   }
 
@@ -607,6 +610,7 @@ class RhinestoneSDK {
       this.endpointUrl,
       this.logger,
       input,
+      this.authorizationHeader,
     )
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -567,7 +567,7 @@ class RhinestoneSDK {
   private paymaster?: PaymasterConfig
   private useDevContracts?: boolean
   private logger?: Logger
-  private authorizationHeader?: string
+  private headers?: Record<string, string>
 
   constructor(options: RhinestoneSDKConfig) {
     this.apiKey = options.apiKey
@@ -577,7 +577,7 @@ class RhinestoneSDK {
     this.paymaster = options.paymaster
     this.useDevContracts = options.useDevContracts
     this.logger = options.logger
-    this.authorizationHeader = options.authorizationHeader
+    this.headers = options.headers
   }
 
   createAccount(config: RhinestoneAccountConfig) {
@@ -600,7 +600,7 @@ class RhinestoneSDK {
       this.endpointUrl,
       this.logger,
       intentId,
-      this.authorizationHeader,
+      this.headers,
     )
   }
 
@@ -610,7 +610,7 @@ class RhinestoneSDK {
       this.endpointUrl,
       this.logger,
       input,
-      this.authorizationHeader,
+      this.headers,
     )
   }
 }

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -54,18 +54,18 @@ export class Orchestrator {
   private serverUrl: string
   private apiKey?: string
   private logger?: Logger
-  private authorizationHeader?: string
+  private headers?: Record<string, string>
 
   constructor(
     serverUrl: string,
     apiKey?: string,
     logger?: Logger,
-    authorizationHeader?: string,
+    headers?: Record<string, string>,
   ) {
     this.serverUrl = serverUrl
     this.apiKey = apiKey
     this.logger = logger
-    this.authorizationHeader = authorizationHeader
+    this.headers = headers
   }
 
   async getPortfolio(
@@ -225,10 +225,7 @@ export class Orchestrator {
     if (this.apiKey) {
       headers['x-api-key'] = this.apiKey
     }
-    if (this.authorizationHeader) {
-      headers.Authorization = this.authorizationHeader
-    }
-    return headers
+    return { ...headers, ...this.headers }
   }
 
   private async fetch(url: string, options?: RequestInit): Promise<any> {

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -54,11 +54,18 @@ export class Orchestrator {
   private serverUrl: string
   private apiKey?: string
   private logger?: Logger
+  private authorizationHeader?: string
 
-  constructor(serverUrl: string, apiKey?: string, logger?: Logger) {
+  constructor(
+    serverUrl: string,
+    apiKey?: string,
+    logger?: Logger,
+    authorizationHeader?: string,
+  ) {
     this.serverUrl = serverUrl
     this.apiKey = apiKey
     this.logger = logger
+    this.authorizationHeader = authorizationHeader
   }
 
   async getPortfolio(
@@ -217,6 +224,9 @@ export class Orchestrator {
     }
     if (this.apiKey) {
       headers['x-api-key'] = this.apiKey
+    }
+    if (this.authorizationHeader) {
+      headers.Authorization = this.authorizationHeader
     }
     return headers
   }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -74,11 +74,13 @@ function getOrchestrator(
   apiKey?: string,
   orchestratorUrl?: string,
   logger?: Logger,
+  authorizationHeader?: string,
 ): Orchestrator {
   return new Orchestrator(
     orchestratorUrl ?? PROD_ORCHESTRATOR_URL,
     apiKey,
     logger,
+    authorizationHeader,
   )
 }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -74,13 +74,13 @@ function getOrchestrator(
   apiKey?: string,
   orchestratorUrl?: string,
   logger?: Logger,
-  authorizationHeader?: string,
+  headers?: Record<string, string>,
 ): Orchestrator {
   return new Orchestrator(
     orchestratorUrl ?? PROD_ORCHESTRATOR_URL,
     apiKey,
     logger,
-    authorizationHeader,
+    headers,
   )
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,9 +244,9 @@ interface RhinestoneSDKConfig {
   useDevContracts?: boolean
   logger?: Logger
   /**
-   * Optional Authorization header value sent with every orchestrator request.
+   * Optional custom headers sent with every orchestrator request.
    */
-  authorizationHeader?: string
+  headers?: Record<string, string>
 }
 
 type RhinestoneConfig = RhinestoneAccountConfig & Partial<RhinestoneSDKConfig>

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,6 +243,10 @@ interface RhinestoneSDKConfig {
    */
   useDevContracts?: boolean
   logger?: Logger
+  /**
+   * Optional Authorization header value sent with every orchestrator request.
+   */
+  authorizationHeader?: string
 }
 
 type RhinestoneConfig = RhinestoneAccountConfig & Partial<RhinestoneSDKConfig>


### PR DESCRIPTION
## Description

Adds support for passing a custom `Authorization` HTTP header to all SDK requests sent to the orchestrator endpoint. Users can now specify `authorizationHeader` in `RhinestoneSDKConfig` to enable authorization flows beyond the existing `x-api-key` header.

Changes thread the optional header through:
- `RhinestoneSDKConfig` interface
- `RhinestoneSDK` class
- `getOrchestrator` factory and all call sites
- `Orchestrator` client's `getHeaders()` method

## Checklist

- [ ] Changeset