### PR TITLE
fix: starttale account getDeployArgs and getAddress

### DIFF
--- a/.changeset/twenty-bananas-yell.md
+++ b/.changeset/twenty-bananas-yell.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Fix startale getDeployArgs and getAddress

--- a/src/accounts/startale.test.ts
+++ b/src/accounts/startale.test.ts
@@ -15,13 +15,7 @@ const MOCK_MODULE_ADDRESS = '0x28de6501fa86f2e6cd0b33c3aabdaeb4a1b93f3f'
 describe('Accounts: Startale', () => {
   describe('Deploy Args', () => {
     test('ECDSA owners', () => {
-      const {
-        factory,
-        factoryData,
-        salt,
-        implementation,
-        initializationCallData,
-      } = getDeployArgs({
+      const result = getDeployArgs({
         account: {
           type: 'startale',
         },
@@ -30,6 +24,8 @@ describe('Accounts: Startale', () => {
           accounts: [accountA, accountB],
         },
       })
+      expect(result).not.toBeNull()
+      const { factory, factoryData, salt, implementation, initializationCallData } = result!
 
       expect(factory).toEqual('0x0000003b3e7b530b4f981ae80d9350392defef90')
       expect(factoryData).toEqual(
@@ -47,13 +43,7 @@ describe('Accounts: Startale', () => {
     })
 
     test('Passkey owner', () => {
-      const {
-        factory,
-        factoryData,
-        salt,
-        implementation,
-        initializationCallData,
-      } = getDeployArgs({
+      const result = getDeployArgs({
         account: {
           type: 'startale',
         },
@@ -62,6 +52,8 @@ describe('Accounts: Startale', () => {
           accounts: [passkeyAccount],
         },
       })
+      expect(result).not.toBeNull()
+      const { factory, factoryData, salt, implementation, initializationCallData } = result!
 
       expect(factory).toEqual('0x0000003b3e7b530b4f981ae80d9350392defef90')
       expect(factoryData).toEqual(
@@ -105,6 +97,48 @@ describe('Accounts: Startale', () => {
       })
 
       expect(address).toEqual('0x4d78f6b273d07f2fd24433ebc7a90d89f0d061ae')
+    })
+
+    test('initData with address fallback', () => {
+      const expectedAddress = '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7'
+      const address = getAddress({
+        account: {
+          type: 'startale',
+        },
+        owners: {
+          type: 'ecdsa',
+          accounts: [accountA],
+        },
+        initData: {
+          address: expectedAddress,
+        },
+      })
+      expect(address).toEqual(expectedAddress)
+    })
+
+    test('initData with factory decodes correctly', () => {
+      // First get the real deploy args to get valid factory/factoryData
+      const deployArgs = getDeployArgs({
+        account: { type: 'startale' },
+        owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+      })
+      expect(deployArgs).not.toBeNull()
+      const { factory, factoryData } = deployArgs!
+
+      // Now use initData path with a different owners set (simulating mock signer)
+      const address = getAddress({
+        account: { type: 'startale' },
+        owners: { type: 'ecdsa', accounts: [accountA] },
+        initData: {
+          address: '0x614ea8885429c480a83deddd2e050d411da36d4b',
+          factory,
+          factoryData,
+          intentExecutorInstalled: true,
+        },
+      })
+
+      // Should derive the same address from factoryData, not from the mock owners
+      expect(address).toEqual('0x614ea8885429c480a83deddd2e050d411da36d4b')
     })
   })
 

--- a/src/accounts/startale.test.ts
+++ b/src/accounts/startale.test.ts
@@ -25,7 +25,13 @@ describe('Accounts: Startale', () => {
         },
       })
       expect(result).not.toBeNull()
-      const { factory, factoryData, salt, implementation, initializationCallData } = result!
+      const {
+        factory,
+        factoryData,
+        salt,
+        implementation,
+        initializationCallData,
+      } = result!
 
       expect(factory).toEqual('0x0000003b3e7b530b4f981ae80d9350392defef90')
       expect(factoryData).toEqual(
@@ -53,7 +59,13 @@ describe('Accounts: Startale', () => {
         },
       })
       expect(result).not.toBeNull()
-      const { factory, factoryData, salt, implementation, initializationCallData } = result!
+      const {
+        factory,
+        factoryData,
+        salt,
+        implementation,
+        initializationCallData,
+      } = result!
 
       expect(factory).toEqual('0x0000003b3e7b530b4f981ae80d9350392defef90')
       expect(factoryData).toEqual(

--- a/src/accounts/startale.ts
+++ b/src/accounts/startale.ts
@@ -1,6 +1,7 @@
 import type { Address, Chain, Hex, PublicClient } from 'viem'
 import {
   concat,
+  decodeFunctionData,
   encodeAbiParameters,
   encodeFunctionData,
   encodePacked,
@@ -39,6 +40,34 @@ const CREATION_CODE =
   '0x608060405261029d803803806100148161018c565b92833981016040828203126101885781516001600160a01b03811692909190838303610188576020810151906001600160401b03821161018857019281601f8501121561018857835161006e610069826101c5565b61018c565b9481865260208601936020838301011161018857815f926020809301865e8601015260017f754fd8b321c4649cb777ae6fdce7e89e9cceaa31a4f639795c7807eb7f1a27005d823b15610176577f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc80546001600160a01b031916821790557fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f80a282511561015e575f8091610146945190845af43d15610156573d91610137610069846101c5565b9283523d5f602085013e6101e0565b505b604051605e908161023f8239f35b6060916101e0565b50505034156101485763b398979f60e01b5f5260045ffd5b634c9c8ce360e01b5f5260045260245ffd5b5f80fd5b6040519190601f01601f191682016001600160401b038111838210176101b157604052565b634e487b7160e01b5f52604160045260245ffd5b6001600160401b0381116101b157601f01601f191660200190565b9061020457508051156101f557805190602001fd5b63d6bda27560e01b5f5260045ffd5b81511580610235575b610215575090565b639996b31560e01b5f9081526001600160a01b0391909116600452602490fd5b50803b1561020d56fe60806040523615605c575f8073ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416368280378136915af43d5f803e156058573d5ff35b3d5ffd5b00'
 
 function getDeployArgs(config: RhinestoneAccountConfig) {
+  if (config.initData) {
+    if (!('factory' in config.initData)) {
+      return null
+    }
+    const { factory, factoryData } = config.initData
+    try {
+      const decoded = decodeFunctionData({
+        abi: parseAbi(['function createAccount(bytes,bytes32)']),
+        data: factoryData,
+      })
+      const initData = decoded.args[0]
+      const salt = decoded.args[1]
+      const initializationCallData = encodeFunctionData({
+        abi: parseAbi(['function initializeAccount(bytes)']),
+        functionName: 'initializeAccount',
+        args: [initData],
+      })
+      return {
+        factory,
+        factoryData,
+        salt,
+        implementation: IMPLEMENTATION_ADDRESS,
+        initializationCallData,
+      }
+    } catch {
+      return null
+    }
+  }
   const account = config.account
   const salt = (account as StartaleAccount)?.salt ?? zeroHash
   const moduleSetup = getModuleSetup(config)
@@ -97,7 +126,14 @@ function getDeployArgs(config: RhinestoneAccountConfig) {
 }
 
 function getAddress(config: RhinestoneAccountConfig) {
-  const { factory, salt, initializationCallData } = getDeployArgs(config)
+  const deployArgs = getDeployArgs(config)
+  if (!deployArgs) {
+    if (config.initData?.address) {
+      return config.initData.address
+    }
+    throw new Error('Cannot derive address: deploy args not available')
+  }
+  const { factory, salt, initializationCallData } = deployArgs
 
   const accountInitData = encodeAbiParameters(
     [


### PR DESCRIPTION
## Description
Fix Startale `getDeployArgs` and `getAddress` to handle `initData` config (matching Nexus behavior). This enables deposit processor to reconstruct Startale accounts from stored factory data instead of requiring the original owner signer

## Checklist

- [x] Changeset
