### PR TITLE
feat: add ENS-HCA smart account support

### DIFF
--- a/.changeset/add-hca-account.md
+++ b/.changeset/add-hca-account.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Add ENS-HCA (Hierarchical Contract Account) support

--- a/src/accounts/error.ts
+++ b/src/accounts/error.ts
@@ -230,6 +230,8 @@ function getAccountName(account: AccountType) {
       return 'Nexus'
     case 'startale':
       return 'Startale'
+    case 'hca':
+      return 'HCA'
     case 'eoa':
       return 'EOA'
   }

--- a/src/accounts/hca.test.ts
+++ b/src/accounts/hca.test.ts
@@ -1,0 +1,232 @@
+import type { Address } from 'viem'
+import { decodeFunctionData, maxUint48, parseAbi } from 'viem'
+import { describe, expect, test } from 'vitest'
+
+import { accountA, accountB, passkeyAccount } from '../../test/consts'
+import { MODULE_TYPE_ID_VALIDATOR } from '../modules/common'
+import { AccountConfigurationNotSupportedError } from './error'
+import {
+  ENS_HCA_MODULE,
+  getAddress,
+  getDeployArgs,
+  getInstallData,
+  packSignature,
+} from './hca'
+
+const MOCK_MODULE_ADDRESS = '0x28de6501fa86f2e6cd0b33c3aabdaeb4a1b93f3f'
+
+describe('Accounts: HCA', () => {
+  describe('Deploy Args', () => {
+    test('ENS owner with expirations', () => {
+      const result = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(result).not.toBeNull()
+      const { factory, factoryData, implementation } = result!
+      expect(factory).toBeDefined()
+      expect(factoryData).toBeDefined()
+      expect(implementation).toBeDefined()
+
+      // Verify factoryData encodes createAccount(bytes)
+      const decoded = decodeFunctionData({
+        abi: parseAbi(['function createAccount(bytes)']),
+        data: factoryData,
+      })
+      expect(decoded.functionName).toEqual('createAccount')
+      expect(decoded.args[0]).toBeDefined()
+    })
+
+    test('ENS owner with multiple owners and threshold', () => {
+      const result = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA, accountB],
+          threshold: 2,
+          ownerExpirations: [Number(maxUint48), 1000000],
+        },
+      })
+      expect(result).not.toBeNull()
+      const { factoryData } = result!
+      expect(factoryData).toBeDefined()
+    })
+
+    test('ECDSA owner throws', () => {
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          owners: {
+            type: 'ecdsa',
+            accounts: [accountA],
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('Passkey owner throws', () => {
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          owners: {
+            type: 'passkey',
+            accounts: [passkeyAccount],
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('initData with factory round-trips correctly', () => {
+      const deployArgs = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(deployArgs).not.toBeNull()
+      const { factory, factoryData } = deployArgs!
+
+      const roundTripped = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+        initData: {
+          address: '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7',
+          factory,
+          factoryData,
+          intentExecutorInstalled: true,
+        },
+      })
+      expect(roundTripped).not.toBeNull()
+      expect(roundTripped!.factory).toEqual(factory)
+      expect(roundTripped!.initializationCallData).toBeDefined()
+    })
+
+    test('initData without factory returns null', () => {
+      const result = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+        initData: {
+          address: '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7',
+        },
+      })
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('Get Address', () => {
+    test('CREATE3 derivation is deterministic', () => {
+      const address = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(address).toBeDefined()
+      expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/)
+
+      // Same config produces same address
+      const address2 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(address).toEqual(address2)
+    })
+
+    test('Different primary owners produce different addresses', () => {
+      const address1 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      const address2 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountB],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(address1).not.toEqual(address2)
+    })
+
+    test('initData with address fallback', () => {
+      const expectedAddress = '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7'
+      const address = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+        initData: {
+          address: expectedAddress,
+        },
+      })
+      expect(address).toEqual(expectedAddress)
+    })
+  })
+
+  describe('Get Install Data', () => {
+    test('Module', () => {
+      const installData = getInstallData({
+        address: MOCK_MODULE_ADDRESS,
+        initData: '0xabcd',
+        type: MODULE_TYPE_ID_VALIDATOR,
+        deInitData: '0x0000',
+        additionalContext: '0x0000',
+      })
+      expect(installData).toEqual(
+        '0x9517e29f000000000000000000000000000000000000000000000000000000000000000100000000000000000000000028de6501fa86f2e6cd0b33c3aabdaeb4a1b93f3f00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000002abcd000000000000000000000000000000000000000000000000000000000000',
+      )
+    })
+  })
+
+  describe('Get Packed Signature', () => {
+    test('Non-default validator includes address', async () => {
+      const mockSignature = '0x1234'
+      const validator = {
+        address: '0xe35b75e5ec3c04e9cefa8e581fbee859f56edeb4' as Address,
+        isRoot: true,
+      }
+      const signature = await packSignature(mockSignature, validator)
+      expect(signature).toEqual(
+        '0xe35b75e5ec3c04e9cefa8e581fbee859f56edeb41234',
+      )
+    })
+
+    test('Default ENS validator packs as zero address', async () => {
+      const mockSignature = '0x1234'
+      const validator = {
+        address: ENS_HCA_MODULE,
+        isRoot: true,
+      }
+      const signature = await packSignature(mockSignature, validator)
+      expect(signature).toEqual(
+        '0x00000000000000000000000000000000000000001234',
+      )
+    })
+  })
+})

--- a/src/accounts/hca.ts
+++ b/src/accounts/hca.ts
@@ -1,0 +1,225 @@
+import type { Address, Chain, Hex, PublicClient } from 'viem'
+import {
+  concat,
+  decodeFunctionData,
+  encodeFunctionData,
+  encodePacked,
+  keccak256,
+  pad,
+  parseAbi,
+  slice,
+  zeroHash,
+} from 'viem'
+import type { Module } from '../modules/common'
+import { ENS_HCA_MODULE, getOwnerValidator } from '../modules/validators/core'
+import type { OwnerSet, RhinestoneAccountConfig } from '../types'
+import {
+  AccountConfigurationNotSupportedError,
+  Eip712DomainNotAvailableError,
+} from './error'
+import {
+  getGuardianSmartAccount as getNexusGuardianSmartAccount,
+  getInstallData as getNexusInstallData,
+  getSmartAccount as getNexusSmartAccount,
+  packSignature as packNexusSignature,
+} from './nexus'
+import type { ValidatorConfig } from './utils'
+
+const HCA_IMPLEMENTATION_ADDRESS: Address =
+  '0x04eEd1aA7555C36d26a88E3566A802B6E311B3ac'
+const HCA_FACTORY_ADDRESS: Address =
+  '0x9B5FC82012ea7a306c33246164672e12CC2E52f9'
+
+const HCA_VERSION = '1.0.0'
+
+// Solady CREATE3 proxy bytecode hash
+const CREATE3_PROXY_HASH: Hex =
+  '0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f'
+
+function getDeployArgs(config: RhinestoneAccountConfig) {
+  if (config.initData) {
+    if (!('factory' in config.initData)) {
+      return null
+    }
+    const { factory, factoryData } = config.initData
+    try {
+      const decoded = decodeFunctionData({
+        abi: parseAbi(['function createAccount(bytes)']),
+        data: factoryData,
+      })
+      const moduleInitData = decoded.args[0]
+      const initializationCallData = encodeFunctionData({
+        abi: parseAbi(['function initializeAccount(bytes)']),
+        functionName: 'initializeAccount',
+        args: [moduleInitData],
+      })
+      return {
+        factory,
+        factoryData,
+        salt: zeroHash,
+        implementation: HCA_IMPLEMENTATION_ADDRESS,
+        initializationCallData,
+      }
+    } catch {
+      return null
+    }
+  }
+
+  if (!config.owners || config.owners.type !== 'ens') {
+    throw new AccountConfigurationNotSupportedError(
+      'HCA accounts require ENS owners with ownerExpirations',
+      'hca',
+    )
+  }
+
+  const ownerValidator = getOwnerValidator(config)
+  const moduleInitData = ownerValidator.initData
+
+  // Factory takes module initData directly: abi.encode(threshold, owners[])
+  // It internally calls module.getOwnerFromInitData(initData) to derive the CREATE3 salt,
+  // then deploys the proxy with the stored implementation
+  const factoryData = encodeFunctionData({
+    abi: parseAbi(['function createAccount(bytes)']),
+    functionName: 'createAccount',
+    args: [moduleInitData],
+  })
+
+  const initializationCallData = encodeFunctionData({
+    abi: parseAbi(['function initializeAccount(bytes)']),
+    functionName: 'initializeAccount',
+    args: [moduleInitData],
+  })
+
+  return {
+    factory: HCA_FACTORY_ADDRESS,
+    factoryData,
+    salt: zeroHash,
+    implementation: HCA_IMPLEMENTATION_ADDRESS,
+    initializationCallData,
+  }
+}
+
+function getAddress(config: RhinestoneAccountConfig) {
+  const deployArgs = getDeployArgs(config)
+  if (!deployArgs) {
+    if (config.initData?.address) {
+      return config.initData.address
+    }
+    throw new Error('Cannot derive address: deploy args not available')
+  }
+
+  if (config.initData?.address) {
+    return config.initData.address
+  }
+
+  if (!config.owners || config.owners.type !== 'ens') {
+    throw new Error('Cannot derive HCA address without ENS owners')
+  }
+
+  // Primary owner is the first account
+  const primaryOwner = config.owners.accounts[0].address
+
+  return predictCreate3Address(HCA_FACTORY_ADDRESS, primaryOwner)
+}
+
+// Solady CREATE3 address derivation:
+// 1. salt = bytes32(bytes20(primaryOwner)) — right-padded
+// 2. proxy = CREATE2(factory, salt, CREATE3_PROXY_HASH)
+// 3. account = CREATE(proxy, nonce=1) = keccak256(0xd694 ++ proxy ++ 0x01)
+function predictCreate3Address(
+  factory: Address,
+  primaryOwner: Address,
+): Address {
+  // salt = bytes32(bytes20(owner)) — address right-padded to 32 bytes
+  const salt = pad(primaryOwner as Hex, { size: 32, dir: 'right' })
+
+  // CREATE2: proxy address
+  const proxyHash = keccak256(
+    encodePacked(
+      ['bytes1', 'address', 'bytes32', 'bytes32'],
+      ['0xff', factory, salt, CREATE3_PROXY_HASH],
+    ),
+  )
+  const proxyAddress = slice(proxyHash, 12, 32)
+
+  // CREATE with nonce 1: RLP([proxy, 1]) = 0xd694 ++ proxy ++ 0x01
+  const accountHash = keccak256(concat(['0xd694', proxyAddress, '0x01']))
+  return slice(accountHash, 12, 32)
+}
+
+function getEip712Domain(config: RhinestoneAccountConfig, chain: Chain) {
+  if (config.initData) {
+    throw new Eip712DomainNotAvailableError(
+      'Existing HCA accounts are not yet supported',
+    )
+  }
+  return {
+    name: 'Nexus',
+    version: HCA_VERSION,
+    chainId: chain.id,
+    verifyingContract: getAddress(config),
+    salt: zeroHash,
+  }
+}
+
+function getInstallData(module: Module) {
+  return getNexusInstallData(module)
+}
+
+async function packSignature(
+  signature: Hex,
+  validator: ValidatorConfig,
+  transformSignature: (signature: Hex) => Hex = (signature) => signature,
+) {
+  return packNexusSignature(
+    signature,
+    validator,
+    transformSignature,
+    ENS_HCA_MODULE,
+  )
+}
+
+async function getSmartAccount(
+  client: PublicClient,
+  address: Address,
+  owners: OwnerSet,
+  validatorAddress: Address,
+  sign: (hash: Hex) => Promise<Hex>,
+) {
+  return getNexusSmartAccount(
+    client,
+    address,
+    owners,
+    validatorAddress,
+    sign,
+    ENS_HCA_MODULE,
+  )
+}
+
+async function getGuardianSmartAccount(
+  client: PublicClient,
+  address: Address,
+  guardians: OwnerSet,
+  validatorAddress: Address,
+  sign: (hash: Hex) => Promise<Hex>,
+) {
+  return getNexusGuardianSmartAccount(
+    client,
+    address,
+    guardians,
+    validatorAddress,
+    sign,
+    ENS_HCA_MODULE,
+  )
+}
+
+export {
+  ENS_HCA_MODULE,
+  getEip712Domain,
+  getInstallData,
+  getAddress,
+  packSignature,
+  getDeployArgs,
+  getSmartAccount,
+  getGuardianSmartAccount,
+}

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -51,6 +51,14 @@ import {
   WalletClientNoConnectedAccountError,
 } from './error'
 import {
+  getAddress as getHcaAddress,
+  getDeployArgs as getHcaDeployArgs,
+  getEip712Domain as getHcaEip712Domain,
+  getGuardianSmartAccount as getHcaGuardianSmartAccount,
+  getSmartAccount as getHcaSmartAccount,
+  packSignature as packHcaSignature,
+} from './hca'
+import {
   getAddress as getKernelAddress,
   getDeployArgs as getKernelDeployArgs,
   getEip712Domain as getKernelEip712Domain,
@@ -119,6 +127,9 @@ function getDeployArgs(config: RhinestoneConfig) {
     }
     case 'startale': {
       return getStartaleDeployArgs(config)
+    }
+    case 'hca': {
+      return getHcaDeployArgs(config)
     }
     case 'passport': {
       // Mocked data; will be overridden by the actual deploy args
@@ -204,7 +215,8 @@ async function signEip7702InitData(config: RhinestoneConfig) {
     }
     case 'safe':
     case 'kernel':
-    case 'startale': {
+    case 'startale':
+    case 'hca': {
       throw new Eip7702NotSupportedForAccountError(account.type)
     }
     default: {
@@ -221,7 +233,8 @@ function getEip7702InitCall(config: RhinestoneConfig, signature: Hex) {
     }
     case 'safe':
     case 'kernel':
-    case 'startale': {
+    case 'startale':
+    case 'hca': {
       throw new Eip7702NotSupportedForAccountError(account.type)
     }
     default: {
@@ -244,6 +257,9 @@ function getEip712Domain(config: RhinestoneConfig, chain: Chain) {
     }
     case 'startale': {
       return getStartaleEip712Domain(config, chain)
+    }
+    case 'hca': {
+      return getHcaEip712Domain(config, chain)
     }
     case 'eoa': {
       throw new Eip712DomainNotAvailableError(
@@ -281,6 +297,9 @@ function getModuleInstallationCalls(
       }
       case 'passport': {
         return [getPassportInstallData(module)]
+      }
+      case 'hca': {
+        throw new ModuleInstallationNotSupportedError(account.type)
       }
       case 'eoa': {
         throw new ModuleInstallationNotSupportedError(account.type)
@@ -350,6 +369,9 @@ function getAddress(config: RhinestoneConfig) {
     }
     case 'startale': {
       return getStartaleAddress(config)
+    }
+    case 'hca': {
+      return getHcaAddress(config)
     }
     case 'passport': {
       return getPassportAddress(config)
@@ -422,6 +444,10 @@ async function getEip1271Signature(
     case 'startale': {
       const signature = await signFn(hash)
       return packStartaleSignature(signature, validator, transformSignature)
+    }
+    case 'hca': {
+      const signature = await signFn(hash)
+      return packHcaSignature(signature, validator, transformSignature)
     }
     default: {
       throw new Error(`Unsupported account type: ${(account as any).type}`)
@@ -505,6 +531,10 @@ async function getTypedDataPackedSignature<
       const signature = await signFn(parameters)
       return packStartaleSignature(signature, validator, transformSignature)
     }
+    case 'hca': {
+      const signature = await signFn(parameters)
+      return packHcaSignature(signature, validator, transformSignature)
+    }
     default: {
       throw new Error(`Unsupported account type: ${(account as any).type}`)
     }
@@ -577,7 +607,7 @@ async function deploy(
 async function setup(config: RhinestoneConfig, chain: Chain): Promise<boolean> {
   const account = getAccountProvider(config)
 
-  if (account.type === 'eoa') {
+  if (account.type === 'eoa' || account.type === 'hca') {
     return false
   }
 
@@ -788,6 +818,15 @@ async function getSmartAccount(
         signFn,
       )
     }
+    case 'hca': {
+      return getHcaSmartAccount(
+        client,
+        address,
+        config.owners,
+        ownerValidator.address,
+        signFn,
+      )
+    }
   }
 }
 
@@ -844,6 +883,15 @@ async function getGuardianSmartAccount(
     }
     case 'startale': {
       return getStartaleGuardianSmartAccount(
+        client,
+        address,
+        guardians,
+        socialRecoveryValidator.address,
+        signFn,
+      )
+    }
+    case 'hca': {
+      return getHcaGuardianSmartAccount(
         client,
         address,
         guardians,

--- a/src/accounts/signing/common.ts
+++ b/src/accounts/signing/common.ts
@@ -17,7 +17,7 @@ import {
 import type { WebAuthnAccount } from 'viem/account-abstraction'
 import { isRip7212SupportedNetwork } from '../../modules'
 import {
-  ENS_VALIDATOR_ADDRESS,
+  ENS_HCA_MODULE,
   getValidator,
   OWNABLE_VALIDATOR_ADDRESS,
   WEBAUTHN_V0_VALIDATOR_ADDRESS,
@@ -47,7 +47,7 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
         type: 'owner',
         kind: 'ecdsa',
         accounts: owners.accounts,
-        module: owners.module ?? ENS_VALIDATOR_ADDRESS,
+        module: owners.module ?? ENS_HCA_MODULE,
       }
     }
     case 'passkey': {
@@ -77,7 +77,7 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
                 type: 'ecdsa',
                 id: index,
                 accounts: validator.accounts,
-                module: validator.module ?? ENS_VALIDATOR_ADDRESS,
+                module: validator.module ?? ENS_HCA_MODULE,
               }
             }
             case 'passkey': {
@@ -258,7 +258,7 @@ async function signWithOwners<T>(
       const isOwnableOrENS =
         !signers.module ||
         signers.module?.toLowerCase() === OWNABLE_VALIDATOR_ADDRESS ||
-        signers.module?.toLowerCase() === ENS_VALIDATOR_ADDRESS
+        signers.module?.toLowerCase() === ENS_HCA_MODULE
 
       const updateV = isOwnableOrENS && !isUserOpHash
 

--- a/src/modules/read.ts
+++ b/src/modules/read.ts
@@ -17,6 +17,7 @@ async function getValidators(
     case 'safe':
     case 'startale':
     case 'nexus':
+    case 'hca':
     case 'passport': {
       const validators = await publicClient.readContract({
         abi: [
@@ -149,6 +150,7 @@ async function getExecutors(
     case 'safe':
     case 'startale':
     case 'nexus':
+    case 'hca':
     case 'passport': {
       const executors = await publicClient.readContract({
         abi: [

--- a/src/modules/validators/core.ts
+++ b/src/modules/validators/core.ts
@@ -41,8 +41,7 @@ interface WebauthnCredential {
 
 const OWNABLE_VALIDATOR_ADDRESS: Address =
   '0x000000000013fdb5234e4e3162a810f54d9f7e98'
-const ENS_VALIDATOR_ADDRESS: Address =
-  '0xdc38f07b060374b6480c4bf06231e7d10955bca4'
+const ENS_HCA_MODULE: Address = '0x432df07BA217077EF70356eD10eBB339CD14c625'
 const WEBAUTHN_VALIDATOR_ADDRESS: Address =
   '0x0000000000578c4cb0e472a5462da43c495c3f33'
 const SOCIAL_RECOVERY_VALIDATOR_ADDRESS: Address =
@@ -209,7 +208,7 @@ function getENSValidator(
     [BigInt(threshold), ownersWithExpiration],
   )
 
-  const moduleAddress = address ?? ENS_VALIDATOR_ADDRESS
+  const moduleAddress = address ?? ENS_HCA_MODULE
 
   return {
     address: moduleAddress,
@@ -398,7 +397,7 @@ function supportsEip712(validator: Module) {
 
 export {
   OWNABLE_VALIDATOR_ADDRESS,
-  ENS_VALIDATOR_ADDRESS,
+  ENS_HCA_MODULE,
   WEBAUTHN_VALIDATOR_ADDRESS,
   MULTI_FACTOR_VALIDATOR_ADDRESS,
   WEBAUTHN_V0_VALIDATOR_ADDRESS,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,14 @@ import type { WebAuthnAccount } from 'viem/account-abstraction'
 import type { ModuleType } from './modules/common'
 import type { AuxiliaryFunds, SettlementLayer } from './orchestrator/types'
 
-type AccountType = 'safe' | 'nexus' | 'kernel' | 'startale' | 'passport' | 'eoa'
+type AccountType =
+  | 'safe'
+  | 'nexus'
+  | 'kernel'
+  | 'startale'
+  | 'passport'
+  | 'eoa'
+  | 'hca'
 
 interface SafeAccount {
   type: 'safe'
@@ -33,6 +40,10 @@ interface PassportAccount {
   type: 'passport'
 }
 
+interface HcaAccount {
+  type: 'hca'
+}
+
 interface EoaAccount {
   type: 'eoa'
 }
@@ -43,6 +54,7 @@ type AccountProviderConfig =
   | KernelAccount
   | StartaleAccount
   | PassportAccount
+  | HcaAccount
   | EoaAccount
 
 interface OwnableValidatorConfig {
@@ -419,6 +431,7 @@ export type {
   KernelAccount,
   StartaleAccount,
   PassportAccount,
+  HcaAccount,
   EoaAccount,
   RhinestoneAccountConfig,
   RhinestoneSDKConfig,

--- a/test/deployment.ts
+++ b/test/deployment.ts
@@ -11,7 +11,13 @@ const anvil = getAnvil(sourceChain, getForkUrl(sourceChain))
 setupOrchestratorMock()
 setupViemMock(anvil, funderAccount)
 
-import { type Address, createPublicClient, http, zeroAddress } from 'viem'
+import {
+  type Address,
+  createPublicClient,
+  http,
+  maxUint48,
+  zeroAddress,
+} from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { base } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
@@ -234,6 +240,47 @@ export function runDeploymentTestCases() {
           //   args: ['0x3a5be8cb'],
           // })
           // expect(fallbackHandler[1]).toEqual(zeroAddress)
+        },
+      )
+
+      it(
+        'should deploy an HCA account using ENS owners',
+        {
+          timeout: 10_000,
+        },
+        async () => {
+          const ownerPrivateKey = generatePrivateKey()
+          const ownerAccount = privateKeyToAccount(ownerPrivateKey)
+
+          const rhinestone = new RhinestoneSDK({ apiKey: 'test' })
+          const rhinestoneAccount = await rhinestone.createAccount({
+            account: { type: 'hca' },
+            owners: {
+              type: 'ens',
+              accounts: [ownerAccount],
+              ownerExpirations: [Number(maxUint48)],
+            },
+          })
+
+          const publicClient = createPublicClient({
+            chain: sourceChain,
+            transport: http(),
+          })
+          const codeBefore = await publicClient.getCode({
+            address: rhinestoneAccount.getAddress(),
+          })
+          expect(codeBefore).toBeUndefined()
+
+          await rhinestoneAccount.sendTransaction({
+            chain: sourceChain,
+            calls: [
+              {
+                to: ownerAccount.address,
+                data: '0x',
+              },
+            ],
+            tokenRequests: [],
+          })
         },
       )
     })


### PR DESCRIPTION
## Description

Adds support for the ENS Hardware-Controlled Account (HCA), a Nexus-based smart account with locked-down module management designed for ENS hardware-backed signers. The HCA blocks `installModule`/`uninstallModule` after initialization and uses immutable default validator and executor modules set in the constructor.

Key additions:
- `src/accounts/hca.ts` — Full account implementation: factory initData encoding, Solady CREATE3 address derivation, EIP-712 domain, signature packing
- Wired HCA into all account routing (`getDeployArgs`, `getAddress`, `getEip712Domain`, `getEip1271Signature`, etc.)
- Renamed `ENS_VALIDATOR_ADDRESS` to `ENS_HCA_MODULE` with updated deployed address (`0x432df07B...`)
- 12 unit tests covering deploy args, CREATE3 determinism, install data, and signature packing
- Deployment integration test for HCA with ENS owners

> **Note:** Contract addresses (HCA implementation, factory, module) are placeholders for now and will be updated once final deployments are ready.

## Checklist

- [x] Changeset