### PR TITLE
refactor: drop ox dependency

### DIFF
--- a/.changeset/remove-ox-dep.md
+++ b/.changeset/remove-ox-dep.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Drop `ox` dependency by inlining the single type reference (`WebAuthnP256.SignMetadata`). The SDK had no runtime usage of `ox` — only a type-only import — so this has no behavioral impact. Consumers still get `ox` transitively through `viem` if needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Docs: https://docs.rhinestone.dev/smart-wallet
 - Language: TypeScript (strict mode)
 - Testing: Vitest
 - Linting: Biome
-- Dependencies: viem (peer), ox, solady
+- Dependencies: viem (peer), solady
 
 ## Structure
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,6 @@
       "version": "1.4.1",
       "dependencies": {
         "@rhinestone/shared-configs": "1.4.139",
-        "ox": "^0.11.3",
         "solady": "^0.1.26",
       },
       "peerDependencies": {

--- a/src/accounts/signing/common.ts
+++ b/src/accounts/signing/common.ts
@@ -1,4 +1,3 @@
-import type { WebAuthnP256 } from 'ox'
 import {
   type Account,
   type Address,
@@ -103,13 +102,21 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
   }
 }
 
+type WebAuthnSignMetadata = {
+  authenticatorData: Hex
+  challengeIndex?: number | undefined
+  clientDataJSON: string
+  typeIndex?: number | undefined
+  userVerificationRequired?: boolean | undefined
+}
+
 type SigningFunctions<T> = {
   signEcdsa: (account: Account, params: T, updateV: boolean) => Promise<Hex>
   signPasskey: (
     account: WebAuthnAccount,
     params: T,
   ) => Promise<{
-    webauthn: WebAuthnP256.SignMetadata
+    webauthn: WebAuthnSignMetadata
     signature: Hex
   }>
 }

--- a/src/package.json
+++ b/src/package.json
@@ -167,7 +167,6 @@
   },
   "dependencies": {
     "@rhinestone/shared-configs": "1.4.139",
-    "ox": "^0.11.3",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- The SDK had a single type-only import from `ox` (`WebAuthnP256.SignMetadata` at `src/accounts/signing/common.ts:112`). Replaced it with an inline structural type.
- Removed `ox` from `src/package.json` dependencies.

Impact:
- **Runtime**: zero — the import was `import type` and erased by `tsc`.
- **Install size** (packagephobia): drops ~11 MB — `ox` itself (~8.9 MB) plus its transitive deps (`@noble/*`, `@scure/*`, `abitype`, `@adraffy/ens-normalize`, `eventemitter3`, ~2 MB). Those transitive deps are overlapping with viem's deps, but since viem is a peer (not installed by packagephobia), they're currently pulled in solely via ox.
- **Types**: consumers still resolve WebAuthn-related types through `viem`, which already lists `ox` as a direct dep.

No version-skew risk: we no longer touch `ox` at all.