### PR TITLE
feat: support EC JWKs in createJwtSigner

### DIFF
--- a/.changeset/jwt-signer-ec-keys.md
+++ b/.changeset/jwt-signer-ec-keys.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Support EC JWKs in `createJwtSigner`. The JWS algorithm is now derived from the supplied JWK (`P-256` → `ES256`, `P-384` → `ES384`, `P-521` → `ES512`); RSA keys continue to sign as `RS256`. Unsupported `kty`/`crv` combinations throw at signer construction.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {

--- a/src/jwt-server/jwt-server.test.ts
+++ b/src/jwt-server/jwt-server.test.ts
@@ -3,6 +3,8 @@ import {
   decodeProtectedHeader,
   exportJWK,
   generateKeyPair,
+  importJWK,
+  jwtVerify,
 } from 'jose'
 import { describe, expect, it } from 'vitest'
 import { createAuthProvider } from '../auth/provider'
@@ -421,5 +423,94 @@ describe('createJwtSigner', () => {
     await expect(signer.getIntentExtensionToken(null)).rejects.toThrow(
       'intentInput must be a non-null object',
     )
+  })
+
+  async function makeEcTestConfig(alg: 'ES256' | 'ES384' | 'ES512') {
+    const { privateKey, publicKey } = await generateKeyPair(alg, {
+      extractable: true,
+    })
+    const privateJwk = await exportJWK(privateKey)
+    const publicJwk = await exportJWK(publicKey)
+    return {
+      config: {
+        jwt: {
+          privateKey: privateJwk,
+          integratorId: 'test-integrator',
+          projectId: 'test-project',
+          appId: 'test-app',
+          keyId: 'test-key',
+        },
+      },
+      publicJwk,
+    }
+  }
+
+  it.each(['ES256', 'ES384', 'ES512'] as const)(
+    'mints a %s-signed accessToken that verifies against the public JWK',
+    async (alg) => {
+      const { config, publicJwk } = await makeEcTestConfig(alg)
+      const signer = createJwtSigner(config)
+      const token = await signer.accessToken()
+
+      const header = decodeProtectedHeader(token)
+      expect(header.alg).toBe(alg)
+      expect(header.kid).toBe('test-key')
+
+      const publicKey = await importJWK(publicJwk, alg)
+      const { payload } = await jwtVerify(token, publicKey)
+      expect(payload.iss).toBe('test-integrator')
+      expect(payload.sub).toBe('test-project')
+    },
+  )
+
+  it('mints an ES256-signed intent extension token', async () => {
+    const { config } = await makeEcTestConfig('ES256')
+    const signer = createJwtSigner(config)
+    const token = await signer.getIntentExtensionToken({ amount: '1' })
+
+    const header = decodeProtectedHeader(token)
+    expect(header.alg).toBe('ES256')
+    expect(header.kid).toBe('test-key')
+  })
+
+  it('throws at construction for unsupported JWK kty (OKP)', () => {
+    const badJwk = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: 'AAAA',
+      d: 'AAAA',
+    } as unknown as JsonWebKey
+    expect(() =>
+      createJwtSigner({
+        jwt: {
+          privateKey: badJwk,
+          integratorId: 'i',
+          projectId: 'p',
+          appId: 'a',
+          keyId: 'k',
+        },
+      }),
+    ).toThrow(/Unsupported JWK kty/)
+  })
+
+  it('throws at construction for unsupported EC curve', () => {
+    const badJwk = {
+      kty: 'EC',
+      crv: 'P-999',
+      x: 'AAAA',
+      y: 'AAAA',
+      d: 'AAAA',
+    } as unknown as JsonWebKey
+    expect(() =>
+      createJwtSigner({
+        jwt: {
+          privateKey: badJwk,
+          integratorId: 'i',
+          projectId: 'p',
+          appId: 'a',
+          keyId: 'k',
+        },
+      }),
+    ).toThrow(/Unsupported EC curve/)
   })
 })

--- a/src/jwt-server/signer.ts
+++ b/src/jwt-server/signer.ts
@@ -20,6 +20,19 @@ export interface JwtSignerConfig {
   shouldSponsor?: SponsorshipFilter
 }
 
+type JwsAlg = 'RS256' | 'ES256' | 'ES384' | 'ES512'
+
+function pickAlg(jwk: JsonWebKey): JwsAlg {
+  if (jwk.kty === 'EC') {
+    if (jwk.crv === 'P-256') return 'ES256'
+    if (jwk.crv === 'P-384') return 'ES384'
+    if (jwk.crv === 'P-521') return 'ES512'
+    throw new Error(`Unsupported EC curve: ${jwk.crv}`)
+  }
+  if (jwk.kty === 'RSA') return 'RS256'
+  throw new Error(`Unsupported JWK kty: ${jwk.kty}`)
+}
+
 export function createJwtSigner(config: JwtSignerConfig): {
   accessToken: () => Promise<string>
   getIntentExtensionToken: (intentInput: unknown) => Promise<string>
@@ -36,11 +49,12 @@ export function createJwtSigner(config: JwtSignerConfig): {
     shouldSponsor: filters,
   } = config
 
+  const alg = pickAlg(privateKey)
   let cachedKey: CryptoKey | null = null
 
   async function getKey(): Promise<CryptoKey> {
     if (!cachedKey) {
-      cachedKey = (await importJWK(privateKey, 'RS256')) as CryptoKey
+      cachedKey = (await importJWK(privateKey, alg)) as CryptoKey
     }
     return cachedKey
   }
@@ -48,7 +62,7 @@ export function createJwtSigner(config: JwtSignerConfig): {
   async function accessToken(): Promise<string> {
     const key = await getKey()
     return new SignJWT({ typ: 'access', app_id: appId })
-      .setProtectedHeader({ alg: 'RS256', kid: keyId })
+      .setProtectedHeader({ alg, kid: keyId })
       .setIssuer(integratorId)
       .setSubject(projectId)
       .setAudience(audience)
@@ -80,7 +94,7 @@ export function createJwtSigner(config: JwtSignerConfig): {
         },
       },
     })
-      .setProtectedHeader({ alg: 'RS256', kid: keyId })
+      .setProtectedHeader({ alg, kid: keyId })
       .setIssuer(integratorId)
       .setSubject(projectId)
       .setAudience(audience)


### PR DESCRIPTION
## Description

`src/jwt-server/signer.ts` hardcoded `RS256` in both `importJWK` and the two `setProtectedHeader` calls, so EC keys (P-256/P-384/P-521) registered with the orchestrator couldn't be used — `importJWK` threw and the header would advertise the wrong alg anyway. This change derives the JWS alg from the supplied JWK once at signer construction (P-256→ES256, P-384→ES384, P-521→ES512; RSA stays on RS256) and threads it through the cached key import and both header calls. Unsupported `kty`/`crv` throws eagerly with a descriptive message. No public-API break: `privateKey: JsonWebKey` already permitted EC. Tests: parametrized EC sign-and-verify via \`jwtVerify\`, EC intent-extension header check, and construction-time guards for OKP and unknown curves.

## Checklist

- [x] Changeset