### PR TITLE
docs: expand AGENTS.md with auth, jwt-server, and API surface notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 End-to-end chain abstraction and modularity toolkit for Ethereum smart accounts.
 
-Uses the Rhinestone infrastructure for croscc-chain intent orchestration under the hood.
+Uses the Rhinestone infrastructure for cross-chain intent orchestration under the hood.
 
 Docs: https://docs.rhinestone.dev/smart-wallet
 
@@ -19,22 +19,25 @@ Docs: https://docs.rhinestone.dev/smart-wallet
 - Language: TypeScript (strict mode)
 - Testing: Vitest
 - Linting: Biome
-- Dependencies: viem (peer), solady
+- Dependencies: viem (peer), solady, jose (optional peer, for `jwt-server`)
 
 ## Structure
 
-- `/src` - Main package source (`@rhinestone/sdk`)
-- `/src/accounts` - Smart account implementations (Safe, Kernel, Nexus, Startale)
+- `/src` - Main package source (`@rhinestone/sdk`); `src/package.json` is the published manifest
+- `/src/accounts` - Smart account implementations (Safe, Kernel, Nexus, Startale, Passport)
 - `/src/actions` - Atomic account actions (ECDSA, passkeys, smart-sessions, recovery)
+- `/src/auth` - Auth provider (API key / JWT modes)
 - `/src/execution` - Transaction execution and signing
-- `/src/orchestrator` - Rhinestone API client
+- `/src/jwt-server` - Server-side JWT signer (Express + Web handlers)
 - `/src/modules` - Module validators and chain abstraction
+- `/src/orchestrator` - Rhinestone API client
 - `/test` - Integration tests
 
 ## Patterns
 
 - Use viem types for addresses, chains, and hex values
 - Account implementations live in `/src/accounts/*.ts`
+- Public API is the union of `src/index.ts` re-exports and the subpath exports in `src/package.json` (`/actions`, `/orchestrator`, `/jwt-server`, `/smart-sessions`, etc.) — adding, renaming, or removing exports is a breaking change
 - The project is using `changeset` to manage releases. Create a changeset file for each fix or feature.
 
 ## Testing


### PR DESCRIPTION
## Summary

- Fix `croscc-chain` typo
- Add `jose` to listed deps (optional peer for `jwt-server`)
- Add `auth/`, `jwt-server/`, and `Passport` to the structure list; note `src/package.json` is the published manifest
- Flag the public API surface (root re-exports + subpath exports) as a breaking-change boundary