### PR TITLE
chore: v2.0.0-beta prereq (ESM-only, surface trim, enter pre-mode)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@rhinestone/sdk": "1.5.0"
+  },
+  "changesets": []
+}

--- a/.changeset/v2-beta-prereq.md
+++ b/.changeset/v2-beta-prereq.md
@@ -1,0 +1,18 @@
+---
+'@rhinestone/sdk': major
+---
+
+ESM-only build and trimmed public surface.
+
+The SDK no longer ships a CommonJS build. `package.json` is now
+`"type": "module"` with a single `"exports"` block that resolves to ESM
+artifacts; `main` and the `require` conditions have been removed.
+
+Subpackage exports that leaked internal `./dist/src/*` paths have been
+dropped. Consumers should import from the curated entry points (`.`,
+`./actions`, `./actions/*`, `./signing/passkeys`, `./errors`, `./utils`,
+`./smart-sessions`, `./jwt-server`).
+
+Tooling implications: requires a Node / bundler that resolves ESM cleanly.
+Old CJS `require('@rhinestone/sdk')` call sites must move to `import` or
+use a bundler that bridges them.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "bun run clean && tsc",
+    "build": "bun run clean && tsc && tsc-esm-fix --target=src/dist",
     "clean": "rimraf src/dist",
     "test": "vitest",
     "check": "biome check",

--- a/src/jwt-server/express.ts
+++ b/src/jwt-server/express.ts
@@ -1,8 +1,11 @@
+import { createRequire } from 'node:module'
 import {
   createCoreAccessTokenHandler,
   createCoreExtensionTokenHandler,
   type JwtHandlerConfig,
 } from './handlers'
+
+const require = createRequire(import.meta.url)
 
 interface ExpressRequest {
   body?: unknown

--- a/src/package.json
+++ b/src/package.json
@@ -12,143 +12,60 @@
     "sdk"
   ],
   "license": "MIT",
-  "main": "./dist/src/index.js",
+  "type": "module",
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "require": "./dist/src/index.js"
+      "import": "./dist/src/index.js"
     },
     "./actions": {
       "types": "./dist/src/actions/index.d.ts",
-      "import": "./dist/src/actions/index.js",
-      "require": "./dist/src/actions/index.js"
+      "import": "./dist/src/actions/index.js"
     },
     "./actions/compact": {
       "types": "./dist/src/actions/compact.d.ts",
-      "import": "./dist/src/actions/compact.js",
-      "require": "./dist/src/actions/compact.js"
+      "import": "./dist/src/actions/compact.js"
     },
     "./actions/ecdsa": {
       "types": "./dist/src/actions/ecdsa.d.ts",
-      "import": "./dist/src/actions/ecdsa.js",
-      "require": "./dist/src/actions/ecdsa.js"
+      "import": "./dist/src/actions/ecdsa.js"
     },
     "./actions/mfa": {
       "types": "./dist/src/actions/mfa.d.ts",
-      "import": "./dist/src/actions/mfa.js",
-      "require": "./dist/src/actions/mfa.js"
+      "import": "./dist/src/actions/mfa.js"
     },
     "./actions/passkeys": {
       "types": "./dist/src/actions/passkeys.d.ts",
-      "import": "./dist/src/actions/passkeys.js",
-      "require": "./dist/src/actions/passkeys.js"
+      "import": "./dist/src/actions/passkeys.js"
     },
     "./signing/passkeys": {
       "types": "./dist/src/accounts/signing/passkeys.d.ts",
-      "import": "./dist/src/accounts/signing/passkeys.js",
-      "require": "./dist/src/accounts/signing/passkeys.js"
+      "import": "./dist/src/accounts/signing/passkeys.js"
     },
     "./actions/smart-sessions": {
       "types": "./dist/src/actions/smart-sessions.d.ts",
-      "import": "./dist/src/actions/smart-sessions.js",
-      "require": "./dist/src/actions/smart-sessions.js"
+      "import": "./dist/src/actions/smart-sessions.js"
     },
     "./actions/recovery": {
       "types": "./dist/src/actions/recovery.d.ts",
-      "import": "./dist/src/actions/recovery.js",
-      "require": "./dist/src/actions/recovery.js"
+      "import": "./dist/src/actions/recovery.js"
     },
     "./errors": {
       "types": "./dist/src/errors/index.d.ts",
-      "import": "./dist/src/errors/index.js",
-      "require": "./dist/src/errors/index.js"
+      "import": "./dist/src/errors/index.js"
     },
     "./utils": {
       "types": "./dist/src/utils/index.d.ts",
-      "import": "./dist/src/utils/index.js",
-      "require": "./dist/src/utils/index.js"
-    },
-    "./dist/src/actions": {
-      "types": "./dist/src/actions/index.d.ts",
-      "import": "./dist/src/actions/index.js",
-      "require": "./dist/src/actions/index.js"
-    },
-    "./dist/src/actions/compact": {
-      "types": "./dist/src/actions/compact.d.ts",
-      "import": "./dist/src/actions/compact.js",
-      "require": "./dist/src/actions/compact.js"
-    },
-    "./dist/src/actions/ecdsa": {
-      "types": "./dist/src/actions/ecdsa.d.ts",
-      "import": "./dist/src/actions/ecdsa.js",
-      "require": "./dist/src/actions/ecdsa.js"
-    },
-    "./dist/src/actions/mfa": {
-      "types": "./dist/src/actions/mfa.d.ts",
-      "import": "./dist/src/actions/mfa.js",
-      "require": "./dist/src/actions/mfa.js"
-    },
-    "./dist/src/actions/passkeys": {
-      "types": "./dist/src/actions/passkeys.d.ts",
-      "import": "./dist/src/actions/passkeys.js",
-      "require": "./dist/src/actions/passkeys.js"
-    },
-    "./dist/src/actions/smart-sessions": {
-      "types": "./dist/src/actions/smart-sessions.d.ts",
-      "import": "./dist/src/actions/smart-sessions.js",
-      "require": "./dist/src/actions/smart-sessions.js"
-    },
-    "./dist/src/actions/recovery": {
-      "types": "./dist/src/actions/recovery.d.ts",
-      "import": "./dist/src/actions/recovery.js",
-      "require": "./dist/src/actions/recovery.js"
-    },
-    "./dist/src/errors": {
-      "types": "./dist/src/errors/index.d.ts",
-      "import": "./dist/src/errors/index.js",
-      "require": "./dist/src/errors/index.js"
-    },
-    "./dist/src/utils": {
-      "types": "./dist/src/utils/index.d.ts",
-      "import": "./dist/src/utils/index.js",
-      "require": "./dist/src/utils/index.js"
-    },
-    "./dist/src/orchestrator": {
-      "types": "./dist/src/orchestrator/index.d.ts",
-      "import": "./dist/src/orchestrator/index.js",
-      "require": "./dist/src/orchestrator/index.js"
-    },
-    "./dist/src/orchestrator/types": {
-      "types": "./dist/src/orchestrator/types.d.ts",
-      "import": "./dist/src/orchestrator/types.js",
-      "require": "./dist/src/orchestrator/types.js"
-    },
-    "./dist/src/execution/compact": {
-      "types": "./dist/src/execution/compact.d.ts",
-      "import": "./dist/src/execution/compact.js",
-      "require": "./dist/src/execution/compact.js"
-    },
-    "./dist/src/execution/permit2": {
-      "types": "./dist/src/execution/permit2.d.ts",
-      "import": "./dist/src/execution/permit2.js",
-      "require": "./dist/src/execution/permit2.js"
-    },
-    "./dist/src/execution/singleChainOps": {
-      "types": "./dist/src/execution/singleChainOps.d.ts",
-      "import": "./dist/src/execution/singleChainOps.js",
-      "require": "./dist/src/execution/singleChainOps.js"
+      "import": "./dist/src/utils/index.js"
     },
     "./smart-sessions": {
       "types": "./dist/src/modules/validators/smart-sessions.d.ts",
-      "import": "./dist/src/modules/validators/smart-sessions.js",
-      "require": "./dist/src/modules/validators/smart-sessions.js"
+      "import": "./dist/src/modules/validators/smart-sessions.js"
     },
     "./jwt-server": {
       "types": "./dist/src/jwt-server/index.d.ts",
-      "import": "./dist/src/jwt-server/index.js",
-      "require": "./dist/src/jwt-server/index.js"
+      "import": "./dist/src/jwt-server/index.js"
     }
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "ES2022",
     "moduleResolution": "node",
     // Checks
     "esModuleInterop": true,


### PR DESCRIPTION
First step of the v2.0.0-beta migration. Ships on its own so the prerelease pipeline gets exercised before any larger v2 work lands on top. No API changes — purely packaging and surface trim.

## Summary

- **ESM-only.** `src/package.json` is now `"type": "module"`. `main` and every `require` condition removed. `tsconfig.json` switches `"module": "commonjs"` → `"ES2022"`.
- **Build pipeline.** `bun run build` now runs `tsc-esm-fix --target=src/dist` after `tsc` so relative imports in the emitted ESM carry the `.js` extensions Node needs to resolve at runtime.
- **`src/jwt-server/express.ts`.** The top-level `require('express')` (used to lazy-load Express so it stays an optional peer) becomes `createRequire(import.meta.url)`. Same lazy-load semantics, ESM-safe.
- **Surface trim.** Dropped the 14 leaked `./dist/src/*` subpackage exports. Curated public entries preserved: `.`, `./actions`, `./actions/{compact,ecdsa,mfa,passkeys,smart-sessions,recovery}`, `./signing/passkeys`, `./errors`, `./utils`, `./smart-sessions`, `./jwt-server`.
- **Pre-mode entered.** `bunx changeset pre enter beta` → `.changeset/pre.json` committed. Major changeset added so the version PR will land on `2.0.0-beta.0`.

## Verifications (local)

- `bun run typecheck` clean.
- `bun run build` emits ESM with proper `.js` extensions on relative imports.
- `bun run check` (biome) clean (one pre-existing warning unrelated to this change).
- `bunx publint` from `src/`: "All good!"
- ESM smoke (`node` against the packed tarball): root + `/utils` + `/actions/ecdsa` + `/smart-sessions` subpath imports all resolve.
- CJS smoke (`require('@rhinestone/sdk')`) fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, as expected.

## Process notes

- Branched off `release` (not `main`) and PR'd onto `release`. Reasons: `.changeset/pre.json` only makes sense on `release` (snapshot mode and pre-mode don't compose cleanly on `main`), and a major break shouldn't ship as a `0.0.0-dev-<sha>` snapshot under the `dev` tag where the version doesn't signal "breaking".
- After merge, the `changesets/action` should open a version PR bumping to `2.0.0-beta.0` and publish under the `beta` dist-tag once that lands.
- Existing CJS/ESM integration tests will break on the CJS side; fine to fix later.
- After v2 GA later: `bunx changeset pre exit`, then sync `release` → `main`.