### PR TITLE
ci: route release workflow and changesets to v1 branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "updateInternalDependencies": "patch",
   "linked": [],
   "access": "public",
-  "baseBranch": "release",
+  "baseBranch": "v1",
   "ignore": [],
   "changelog": "@changesets/cli/changelog"
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - release
+      - v1
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Currently the v1 branch ships nothing because:

- `.github/workflows/release.yaml` triggers on push to `release`, not `v1`.
- `.changeset/config.json` has `baseBranch: release`, so changesets is comparing v1 work against the wrong base.

This swaps both to `v1` so a future changeset landing on this branch will produce a "Release" PR and publish to npm under the default `latest` tag (v1 isn't in pre-release mode).