### PR TITLE
fix: chain id in bridgeFill

### DIFF
--- a/.changeset/cool-moles-press.md
+++ b/.changeset/cool-moles-press.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Fix BridgeFill.destinationChainId type

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -10,6 +10,7 @@ import {
 import type {
   AccountAccessList,
   AuxiliaryFunds,
+  BridgeFill,
   Cost,
   CostTokenEntry,
   IntentInput,
@@ -335,8 +336,14 @@ function decodeQuote(route: any): Quote {
     tokenRequirements: route.tokenRequirements
       ? decodeTokenRequirements(route.tokenRequirements)
       : undefined,
-    bridgeFill: route.bridgeFill,
+    bridgeFill: decodeBridgeFill(route.bridgeFill),
   }
+}
+
+// Normalizes CAIP-2 strings to numeric IDs for consistency with BridgeFill decodeCostTokenEntry, and getIntent
+function decodeBridgeFill(bf: any): BridgeFill | undefined {
+  if (!bf) return undefined
+  return { ...bf, destinationChainId: parseChainId(bf.destinationChainId) }
 }
 
 function decodeCost(cost: any): Cost {


### PR DESCRIPTION
## Description
Normalize bridgeFill.destinationChainId via parseChainId so consumers get a number as the type declares, instead of the wire-format CAIP-2 string

## Checklist

- [x] Changeset
