### PR TITLE
feat: expose sourceCalls on Transaction for preclaim executions

### DIFF
--- a/.changeset/source-calls-input.md
+++ b/.changeset/source-calls-input.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Expose `sourceCalls` on `Transaction` so callers can supply per-chain source-side executions that are bundled into the intent at routing time.

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -15,6 +15,7 @@ import {
 import {
   ExecutionError,
   IntentFailedError,
+  InvalidSourceCallsError,
   isExecutionError,
   OrderPathRequiredForIntentsError,
   SessionChainRequiredError,
@@ -71,6 +72,7 @@ export {
   isExecutionError,
   ExecutionError,
   IntentFailedError,
+  InvalidSourceCallsError,
   OrderPathRequiredForIntentsError,
   SessionChainRequiredError,
   SignerNotSupportedError,

--- a/src/execution/error.ts
+++ b/src/execution/error.ts
@@ -102,6 +102,23 @@ class IntentStatusTimeoutError extends ExecutionError {
   }
 }
 
+class InvalidSourceCallsError extends ExecutionError {
+  constructor(params?: {
+    chainId?: number
+    context?: any
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        params?.chainId !== undefined
+          ? `sourceCalls includes chainId ${params.chainId} which is not in sourceChains (or the target chain for same-chain transactions)`
+          : 'sourceCalls includes a chainId not in sourceChains (or the target chain for same-chain transactions)',
+      ...params,
+    })
+  }
+}
+
 class Eip7702InitSignatureRequiredError extends ExecutionError {
   constructor(params?: {
     context?: any
@@ -124,6 +141,7 @@ export {
   isExecutionError,
   ExecutionError,
   Eip7702InitSignatureRequiredError,
+  InvalidSourceCallsError,
   OrderPathRequiredForIntentsError,
   SessionChainRequiredError,
   IntentFailedError,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -37,6 +37,7 @@ import {
   ExecutionError,
   IntentFailedError,
   IntentStatusTimeoutError,
+  InvalidSourceCallsError,
   isExecutionError,
   OrderPathRequiredForIntentsError,
   SessionChainRequiredError,
@@ -83,6 +84,7 @@ async function sendTransaction(
     'chain' in transaction ? transaction.chain : transaction.targetChain
   const {
     calls,
+    sourceCalls,
     gasLimit,
     tokenRequests,
     recipient,
@@ -99,6 +101,7 @@ async function sendTransaction(
   }
   return await sendTransactionInternal(config, sourceChains, targetChain, {
     callInputs: calls,
+    sourceCalls,
     gasLimit,
     initialTokenRequests: tokenRequests,
     recipient,
@@ -136,6 +139,7 @@ async function sendTransactionInternal(
   targetChain: Chain,
   options: {
     callInputs?: CallInput[]
+    sourceCalls?: Record<number, CallInput[]>
     gasLimit?: bigint
     initialTokenRequests?: TokenRequest[]
     recipient?: RhinestoneAccountConfig | Address
@@ -179,6 +183,7 @@ async function sendTransactionInternal(
       options.sourceAssets,
       options.feeAsset,
       options.lockFunds,
+      options.sourceCalls,
     )
   }
 }
@@ -232,6 +237,7 @@ async function sendTransactionAsIntent(
   sourceAssets?: SourceAssetInput,
   feeAsset?: Address | TokenSymbol,
   lockFunds?: boolean,
+  sourceCalls?: Record<number, CallInput[]>,
 ) {
   const prepared = await prepareTransactionAsIntent(
     config,
@@ -250,6 +256,7 @@ async function sendTransactionAsIntent(
     undefined,
     undefined,
     signers,
+    sourceCalls,
   )
   if (!prepared) {
     throw new OrderPathRequiredForIntentsError()
@@ -461,6 +468,7 @@ export {
   ExecutionError,
   IntentFailedError,
   IntentStatusTimeoutError,
+  InvalidSourceCallsError,
   OrderPathRequiredForIntentsError,
   SessionChainRequiredError,
   SignerNotSupportedError,

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -175,6 +175,7 @@ describe('prepareTransactionAsIntent', () => {
       auxiliaryFunds,
       undefined,
       undefined,
+      undefined,
     )
 
     expect(mockGetIntentRoute).toHaveBeenCalledOnce()
@@ -200,6 +201,7 @@ describe('prepareTransactionAsIntent', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -345,6 +347,7 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       signers,
+      undefined,
     )
 
     const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
@@ -397,6 +400,7 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       signers,
+      undefined,
     )
 
     const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
@@ -440,6 +444,7 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       signers,
+      undefined,
     )
 
     const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
@@ -477,6 +482,7 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       signers,
+      undefined,
     )
 
     const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
@@ -534,6 +540,7 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       signers,
+      undefined,
     )
 
     const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
@@ -543,5 +550,259 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       DUMMY_PRECLAIMOP_TARGET,
     )
     expect(intentInput.preClaimExecutions![arbitrum.id]).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sourceCalls in routing request
+// ---------------------------------------------------------------------------
+
+describe('prepareTransactionAsIntent — sourceCalls', () => {
+  beforeEach(() => {
+    mockGetIntentRoute.mockReset()
+    mockGetIntentRoute.mockResolvedValue({ intentOp: {}, intentCost: {} })
+  })
+
+  const callA = {
+    to: '0x1111111111111111111111111111111111111111' as `0x${string}`,
+    value: 0n,
+    data: '0xaaaa' as `0x${string}`,
+  }
+  const callB = {
+    to: '0x2222222222222222222222222222222222222222' as `0x${string}`,
+    value: 1n,
+    data: '0xbbbb' as `0x${string}`,
+  }
+
+  test('user-provided sourceCalls flow into preClaimExecutions', async () => {
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { [arbitrum.id]: [callA, callB] },
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.preClaimExecutions).toBeDefined()
+    expect(intentInput.preClaimExecutions![arbitrum.id]).toEqual([callA, callB])
+  })
+
+  test('sourceCalls on the target chain (same-chain) are accepted', async () => {
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [base],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { [base.id]: [callA] },
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.preClaimExecutions![base.id]).toEqual([callA])
+  })
+
+  test('throws when sourceCalls references a chain not in sourceChains', async () => {
+    await expect(
+      prepareTransactionAsIntent(
+        {
+          owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+          apiKey: 'test',
+        },
+        [arbitrum],
+        base,
+        [],
+        undefined,
+        [{ address: zeroAddress, amount: 1n }],
+        undefined,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { [optimism.id]: [callA] },
+      ),
+    ).rejects.toThrow(/optimism|10|sourceChains/i)
+  })
+
+  test('lazy CallInput.resolve is invoked with the per-chain context', async () => {
+    const resolve = vi.fn(async ({ chain }: { chain: any }) => ({
+      to: '0x3333333333333333333333333333333333333333' as `0x${string}`,
+      value: 0n,
+      data: `0x${chain.id.toString(16).padStart(8, '0')}` as `0x${string}`,
+    }))
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum, optimism],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        [arbitrum.id]: [{ resolve }],
+        [optimism.id]: [{ resolve }],
+      },
+    )
+
+    expect(resolve).toHaveBeenCalledTimes(2)
+    const chainIds = resolve.mock.calls.map((c: any[]) => c[0].chain.id).sort()
+    expect(chainIds).toEqual([arbitrum.id, optimism.id].sort())
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.preClaimExecutions![arbitrum.id]).toHaveLength(1)
+    expect(intentInput.preClaimExecutions![optimism.id]).toHaveLength(1)
+  })
+
+  test('user sourceCalls merge after the dummy session preclaimop on the same chain', async () => {
+    vi.spyOn(validators, 'isSessionEnabled').mockResolvedValue(false)
+
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: {
+        chain: base,
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        actions: [
+          {
+            target:
+              '0x1111111111111111111111111111111111111111' as `0x${string}`,
+            selector: '0xdeadbeef' as `0x${string}`,
+          },
+        ],
+      },
+      enableData: makeEnableData(),
+    }
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [base],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      signers,
+      { [base.id]: [callA] },
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    const ops = intentInput.preClaimExecutions![base.id]
+    expect(ops).toHaveLength(2)
+    expect(ops[0].to).toBe(DUMMY_PRECLAIMOP_TARGET)
+    expect(ops[0].data).toBe(DUMMY_PRECLAIMOP_SELECTOR)
+    expect(ops[1]).toEqual(callA)
+  })
+
+  test('omits preClaimExecutions when sourceCalls is undefined and no session', async () => {
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.preClaimExecutions).toBeUndefined()
+  })
+
+  test('empty sourceCalls entry is dropped', async () => {
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { [arbitrum.id]: [] },
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.preClaimExecutions).toBeUndefined()
   })
 })

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -123,6 +123,7 @@ import type {
 import { getCompactTypedData } from './compact'
 import {
   Eip7702InitSignatureRequiredError,
+  InvalidSourceCallsError,
   SignerNotSupportedError,
 } from './error'
 import { getTypedData as getPermit2TypedData } from './permit2'
@@ -238,6 +239,7 @@ async function prepareTransaction(
     auxiliaryFunds,
     account,
     recipient,
+    sourceCalls,
   } = getTransactionParams(transaction)
   const accountAddress = getAddress(config)
 
@@ -267,6 +269,7 @@ async function prepareTransaction(
     auxiliaryFunds,
     account,
     signers,
+    sourceCalls,
   )
 
   return {
@@ -697,6 +700,7 @@ function getTransactionParams(transaction: Transaction) {
   const auxiliaryFunds = transaction.auxiliaryFunds
   const account = transaction.experimental_accountOverride
   const recipient = transaction.recipient
+  const sourceCalls = transaction.sourceCalls
 
   const tokenRequests = getTokenRequests(targetChain, initialTokenRequests)
 
@@ -715,6 +719,7 @@ function getTransactionParams(transaction: Transaction) {
     auxiliaryFunds,
     account,
     recipient,
+    sourceCalls,
   }
 }
 
@@ -831,6 +836,7 @@ async function prepareTransactionAsIntent(
       }
     | undefined,
   signers: SignerSet | undefined,
+  sourceCalls: Record<number, CallInput[]> | undefined,
 ) {
   const calls = parseCalls(callInputs, targetChain.id)
   const accountAccessList = createAccountAccessList(sourceChains, sourceAssets)
@@ -910,6 +916,38 @@ async function prepareTransactionAsIntent(
           value: 0n,
           data: DUMMY_PRECLAIMOP_SELECTOR,
         },
+      ]
+    }
+  }
+
+  if (sourceCalls) {
+    const accountAddress = getAddress(config)
+    const allowedChainIds = new Set<number>([
+      ...(sourceChains ?? []).map((c) => c.id),
+      targetChain.id,
+    ])
+    for (const [chainIdStr, calls] of Object.entries(sourceCalls)) {
+      const chainId = Number(chainIdStr)
+      if (!allowedChainIds.has(chainId)) {
+        throw new InvalidSourceCallsError({ chainId })
+      }
+      const chain =
+        sourceChains?.find((c) => c.id === chainId) ??
+        (targetChain.id === chainId ? targetChain : undefined)
+      if (!chain) {
+        throw new InvalidSourceCallsError({ chainId })
+      }
+      const resolved = await resolveCallInputs(
+        calls,
+        config,
+        chain,
+        accountAddress,
+      )
+      const userExecutions = parseCalls(resolved, chainId)
+      if (userExecutions.length === 0) continue
+      preClaimExecutions[chainId] = [
+        ...(preClaimExecutions[chainId] ?? []),
+        ...userExecutions,
       ]
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -441,6 +441,19 @@ type Sponsorship =
 
 interface BaseTransaction {
   calls?: CallInput[]
+  /**
+   * Per-chain executions to run on the source side, before the claim.
+   * Keyed by chain ID (must be present in `sourceChains`, or equal the
+   * target chain for same-chain transactions). Bundled into the intent
+   * at routing time and covered by the user's mandate signature.
+   *
+   * Caveat: only executes if the orchestrator creates an element on the
+   * matching chain — i.e. when the intent actually moves tokens from
+   * that source. Sponsored / no-op fills with no source movement skip
+   * the source element entirely, and `sourceCalls` keyed on that chain
+   * are silently dropped.
+   */
+  sourceCalls?: Record<number, CallInput[]>
   tokenRequests?: TokenRequests
   recipient?: RhinestoneAccountConfig | Address
   gasLimit?: bigint


### PR DESCRIPTION
## Summary

Expose `sourceCalls` on `Transaction` so callers can supply per-chain executions to run on the source side of an intent. The orchestrator already accepted these via `IntentInput.preClaimExecutions` for internal session-enable use, but they weren't reachable from the public API.

## API

```ts
import { installModule } from '@rhinestone/sdk/actions'

await account.sendTransaction({
  sourceChains: [base, arbitrum],
  targetChain: optimism,
  calls: [...],                              // destination calls
  sourceCalls: {                              // NEW — keyed by chain id
    [base.id]:     [installModule(module)],
    [arbitrum.id]: [{ to, value, data }],    // raw call also accepted
  },
})
```

Available on every `Transaction` (same- and cross-chain) since the field lives on `BaseTransaction`. `CallInput[]` shape, so values flow through the same resolution pipeline as `calls` — actions from `./actions/*` plug straight in alongside raw calls.

### Design choices

**Naming.** The orchestrator wire field is `preClaimExecutions` and the on-chain mandate field is `preClaimOps`, but neither is a good public name — "preclaim" is internal vocabulary that leaks the source/destination claim split into a user-facing surface. Picked **`sourceCalls`** to mirror `calls` (destination-chain executions) and pair with the existing `sourceChains` field. Read together as `{sourceChains, sourceCalls, calls, targetChain}` the API tells you where things run without explaining the intent lifecycle.

**Typing.** `Record<number, CallInput[]>` keyed by chain id. Two things considered and rejected:

- `CallInput[]` (matches `calls`) instead of `Execution[]` (matches the orchestrator field): user-facing input runs through the same resolution path as `calls`, so devs can pass in `./actions` helpers directly. Per-chain map keys give those helpers the right `chain` context when they need it.
- Compile-time validation that keys ⊂ `sourceChains`: would require generic-typing every `Transaction` over its source chain set, which is invasive and viral. Settled for runtime validation in `prepareTransactionAsIntent` via a new `InvalidSourceCallsError`, with unit tests covering the case.

**Merge with the auto-injected session dummy preclaim op.** Where both apply on the same chain, dummy goes first, user ops follow. Dummy is failure-tolerant by construction so order isn't strictly required, but pinning it makes the behavior testable.

### Caveat

Documented inline on the field: source ops only execute when the orchestrator creates an element on the matching chain — i.e. when the intent moves real tokens from that source. Sponsored / no-op fills with no source movement skip the source element entirely, and `sourceCalls` keyed on that chain are silently dropped (per orchestrator `injectOpsAndSign`).

## Test plan

- [x] 7 new unit tests in `src/execution/utils.test.ts` covering: ops flow into `preClaimExecutions`, same-chain target accepted, runtime validation rejects non-source chains, resolved per-chain context, dummy-then-user merge order, undefined and empty inputs both omit the field. Suite is 260/260 green.
- [x] E2E matrix (14 cases: same/cross × dest:none/call × 0/1/2-on-1/2-on-2 source calls) on testnet against the prod orchestrator. All green.
- [x] On-chain trace via Tenderly for `cross / dest:none / src:1`: source-chain claim tx `0x7aafb8e0…` shows the smart account calling `NOOP_TARGET` at `absolute_position 13113` — confirms the user's source op is signed into the mandate and executed by the on-chain claim flow.

Closes [RHI-3868](https://linear.app/rhinestone/issue/RHI-3868).

🤖 Generated with [Claude Code](https://claude.com/claude-code)