### PR TITLE
revert: PR #447 (blanc bridgeFill) — wrong target branch

### DIFF
--- a/.changeset/tall-mirrors-pay.md
+++ b/.changeset/tall-mirrors-pay.md
@@ -1,5 +1,0 @@
----
-"@rhinestone/sdk": patch
----
-
-Add bridgeFill param as response

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,6 @@ import {
 import {
   type ApprovalRequired,
   type AuxiliaryFunds,
-  type BridgeFill,
   getAllSupportedChainsAndTokens,
   getSupportedTokens,
   getTokenAddress,
@@ -668,7 +667,6 @@ export type {
   SignedUserOperationData,
   UserOperationResult,
   AuxiliaryFunds,
-  BridgeFill,
   IntentInput,
   IntentOp,
   IntentOpStatus,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -45,7 +45,6 @@ import {
 import type {
   ApprovalRequired,
   AuxiliaryFunds,
-  BridgeFill,
   Execution,
   IntentInput,
   IntentOp,
@@ -86,7 +85,6 @@ function getOrchestrator(
 
 export type {
   AuxiliaryFunds,
-  BridgeFill,
   Execution,
   IntentInput,
   IntentOp,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -240,19 +240,6 @@ export interface ElementSwapOrigin {
   price: number
 }
 
-// Per-intent tracking handle for layers that hand off to a third-party bridge.
-type BridgeFill =
-  | { type: 'OFT'; destinationChainId: number }
-  | { type: 'RELAY'; destinationChainId: number; requestId: string }
-  | { type: 'NEAR'; destinationChainId: number; depositAddress: Address }
-  | { type: 'RHINO'; destinationChainId: number; commitmentId: string }
-  | {
-      type: 'CCTP'
-      destinationChainId: number
-      sourceDomainId: number
-      destinationDomainId: number
-    }
-
 interface IntentOpElementMandate {
   recipient: Address
   tokenOut: [[string, string]]
@@ -273,7 +260,6 @@ interface IntentOpElementMandate {
         exchangeRate: bigint
         overhead: bigint
       }
-      bridgeFill?: BridgeFill
     }
     encodedVal: Hex
   }
@@ -501,7 +487,6 @@ export type {
   Account,
   AccountType,
   AuxiliaryFunds,
-  BridgeFill,
   TokenConfig,
   SupportedChain,
   SettlementLayer,


### PR DESCRIPTION
PR #447 was merged into `main` but the changes target the `blanc` API / v2 SDK and belong on `release`, not `main` (v1).

Reverts the merge commit cleanly (single `git revert -m 1`).

The fix itself is preserved on `release` independently via #450 (commits `0fe6218` + `db826fe`), so v2 keeps the functionality.

Reverts #447.