### PR TITLE
chore: bump @rhinestone/shared-configs to 1.5.1

### DIFF
--- a/.changeset/bump-shared-configs.md
+++ b/.changeset/bump-shared-configs.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Bump @rhinestone/shared-configs to 1.5.1

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -25,9 +26,9 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.6",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.4.139",
+        "@rhinestone/shared-configs": "1.5.1",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -709,8 +710,6 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@rhinestone/sdk/@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.4.139", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-ogN9gBu76BcmYMSZ5oymPonUsPDi6uT+EG6kxQt7h94jSNcpuA1WeKZq3AipJEMjVUl48Fpa4ubwhFk8mRw+Ig=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -26,7 +26,7 @@ function getWethAddress(chain: Chain): Address {
     throw new UnsupportedTokenError('WETH', chain.id)
   }
 
-  return wethToken.address
+  return wethToken.address as Address
 }
 
 function getWrappedTokenAddress(chain: Chain): Address {
@@ -41,7 +41,7 @@ function getWrappedTokenAddress(chain: Chain): Address {
   if (!token) {
     throw new UnsupportedTokenError('WETH', chain.id)
   }
-  return token.address
+  return token.address as Address
 }
 
 function getTokenSymbol(
@@ -71,7 +71,7 @@ function getTokenAddress(tokenSymbol: TokenSymbol, chainId: number): Address {
     throw new UnsupportedTokenError(tokenSymbol, chainId)
   }
 
-  return token.address
+  return token.address as Address
 }
 
 function getChainById(chainId: number): Chain {

--- a/src/package.json
+++ b/src/package.json
@@ -79,7 +79,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.4.139",
+    "@rhinestone/shared-configs": "1.5.1",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
Picks up the RHINO settlement layer and updated TokenEntry shape (address widened to string for multi-VM support; casted at the EVM-only registry boundary).

## Description

## Checklist

- [x] Changeset
