### PR TITLE
chore: bump @rhinestone/shared-configs

### DIFF
--- a/.changeset/bump-shared-configs-rhino.md
+++ b/.changeset/bump-shared-configs-rhino.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Bump @rhinestone/shared-configs to pick up the RHINO settlement layer.

--- a/bun.lock
+++ b/bun.lock
@@ -1,9 +1,10 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "1.4.142",
+        "@rhinestone/shared-configs": "1.5.1",
         "viem": "^2.40.1",
       },
       "devDependencies": {
@@ -25,9 +26,9 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.4.139",
+        "@rhinestone/shared-configs": "1.5.1",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -178,7 +179,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.4.142", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-qCfErxGx/h03GlUFqPN8+81rhuZoffxsx7L35Sjf2npj/f5VdM4+rRct7pLUXujhWBIlSQB/dG/nv8xenPOkbA=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.5.1", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-RtbhW8oQPZeipov1NF3pd4tXvR+C5cac7yhYC0pd2aoE3iBb53U256yvmfyAJ9/s9E0UauT1sNFC/LrLJC+uvA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 
@@ -709,8 +710,6 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@rhinestone/sdk/@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.4.139", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-ogN9gBu76BcmYMSZ5oymPonUsPDi6uT+EG6kxQt7h94jSNcpuA1WeKZq3AipJEMjVUl48Fpa4ubwhFk8mRw+Ig=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "1.4.142",
+    "@rhinestone/shared-configs": "1.5.1",
     "viem": "^2.40.1"
   },
   "devDependencies": {

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -27,7 +27,7 @@ function getWethAddress(chain: Chain): Address {
     throw new UnsupportedTokenError('WETH', chain.id)
   }
 
-  return wethToken.address
+  return wethToken.address as Address
 }
 
 function getWrappedTokenAddress(chain: Chain): Address {
@@ -42,7 +42,7 @@ function getWrappedTokenAddress(chain: Chain): Address {
   if (!token) {
     throw new UnsupportedTokenError('WETH', chain.id)
   }
-  return token.address
+  return token.address as Address
 }
 
 function getTokenSymbol(
@@ -72,7 +72,7 @@ function getTokenAddress(tokenSymbol: TokenSymbol, chainId: number): Address {
     throw new UnsupportedTokenError(tokenSymbol, chainId)
   }
 
-  return token.address
+  return token.address as Address
 }
 
 function getTokenDecimals(tokenSymbol: TokenSymbol, chainId: number): number {
@@ -119,7 +119,10 @@ function getSupportedTokens(chainId: number): TokenConfig[] {
     throw new UnsupportedChainError(chainId)
   }
 
-  return chainEntry.tokens
+  return chainEntry.tokens.map((token) => ({
+    ...token,
+    address: token.address as Address,
+  }))
 }
 
 function getDefaultAccountAccessList(onTestnets?: boolean) {

--- a/src/package.json
+++ b/src/package.json
@@ -166,7 +166,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.4.139",
+    "@rhinestone/shared-configs": "1.5.1",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description

Bumps `@rhinestone/shared-configs` to `1.5.1`, picking up the `RHINO` settlement layer.

Also casts shared-config token addresses at the EVM SDK registry boundary because the new shared-config token shape widens `address` to `string` for multi-VM support.

## Verification

- `npm view @rhinestone/shared-configs version dist-tags --json` confirmed `latest` is `1.5.1`
- `bun run typecheck`
- `bun run build`
- `bun run test -- src/orchestrator/registry.test.ts`
- `bun run check` exited 0 with an existing warning in `src/accounts/json-rpc/providers.ts`
- Confirmed installed shared-config types include `SettlementLayer = ... | 'RHINO' | ...`


## Checklist
- [x] Changeset