### PR TITLE
dynamic sigMode selection

### DIFF
--- a/.changeset/signature-mode-sync.md
+++ b/.changeset/signature-mode-sync.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Sync intent `signatureMode` with the bytes shape the SDK actually signs: EOAs and non-session smart accounts now emit `SIG_MODE_ERC1271` (1), claim-only sessions emit `SIG_MODE_EMISSARY` (0), and sessions with `verifyExecutions=true` continue to emit the dual-sig `SIG_MODE_EMISSARY_EXECUTION_ERC1271` (5). Previously the SDK always picked a hybrid mode, wasting an on-chain call attempt on the wrong validator path.
+Sync intent `signatureMode` with the bytes shape the SDK actually signs: EOAs, non-session smart accounts, and claim-only sessions now emit `SIG_MODE_ERC1271` (1), while sessions with `verifyExecutions=true` continue to emit the dual-sig `SIG_MODE_EMISSARY_EXECUTION_ERC1271` (5). Previously the SDK always picked a hybrid mode, wasting an on-chain call attempt on the wrong validator path.

--- a/.changeset/signature-mode-sync.md
+++ b/.changeset/signature-mode-sync.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Sync intent `signatureMode` with the bytes shape the SDK actually signs: EOAs and non-session smart accounts now emit `SIG_MODE_ERC1271` (1), claim-only sessions emit `SIG_MODE_EMISSARY` (0), and sessions with `verifyExecutions=true` continue to emit the dual-sig `SIG_MODE_EMISSARY_EXECUTION_ERC1271` (5). Previously the SDK always picked a hybrid mode, wasting an on-chain call attempt on the wrong validator path.

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -9,7 +9,6 @@ import {
 } from '../modules/validators'
 import {
   type IntentInput,
-  SIG_MODE_EMISSARY,
   SIG_MODE_EMISSARY_EXECUTION_ERC1271,
   SIG_MODE_ERC1271,
 } from '../orchestrator/types'
@@ -221,6 +220,53 @@ describe('prepareTransactionAsIntent', () => {
     expect(mockGetIntentRoute).toHaveBeenCalledOnce()
     const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
     expect(intentInput.options.auxiliaryFunds).toBeUndefined()
+  })
+
+  test('claim-only session sends SIG_MODE_ERC1271 in routing request', async () => {
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+    vi.spyOn(validators, 'isSessionEnabled').mockResolvedValue(false)
+
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: {
+        chain: base,
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+      },
+      enableData: {
+        userSignature: '0xdeadbeef',
+        hashesAndChainIds: [],
+        sessionToEnableIndex: 0,
+      },
+    }
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [base],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      signers,
+      undefined,
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.signatureMode).toBe(SIG_MODE_ERC1271)
   })
 })
 
@@ -915,7 +961,7 @@ describe('resolveSignatureMode', () => {
     expect(mode).toBe(SIG_MODE_EMISSARY_EXECUTION_ERC1271)
   })
 
-  test('claim-only session returns SIG_MODE_EMISSARY', async () => {
+  test('claim-only session returns SIG_MODE_ERC1271', async () => {
     const signers: SessionSignerSet = {
       type: 'experimental_session',
       session: claimOnlySession,
@@ -926,7 +972,7 @@ describe('resolveSignatureMode', () => {
       [base],
       base,
     )
-    expect(mode).toBe(SIG_MODE_EMISSARY)
+    expect(mode).toBe(SIG_MODE_ERC1271)
   })
 
   test('claim-only session with verifyExecutions=true override returns SIG_MODE_EMISSARY_EXECUTION_ERC1271', async () => {
@@ -944,7 +990,7 @@ describe('resolveSignatureMode', () => {
     expect(mode).toBe(SIG_MODE_EMISSARY_EXECUTION_ERC1271)
   })
 
-  test('session with actions and verifyExecutions=false override returns SIG_MODE_EMISSARY', async () => {
+  test('session with actions and verifyExecutions=false override returns SIG_MODE_ERC1271', async () => {
     const signers: SessionSignerSet = {
       type: 'experimental_session',
       session: sessionWithActions,
@@ -956,7 +1002,7 @@ describe('resolveSignatureMode', () => {
       [base],
       base,
     )
-    expect(mode).toBe(SIG_MODE_EMISSARY)
+    expect(mode).toBe(SIG_MODE_ERC1271)
   })
 
   test('multi-chain session with divergent verifyExecutions returns SIG_MODE_EMISSARY_EXECUTION_ERC1271', async () => {

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -7,12 +7,18 @@ import {
   DUMMY_PRECLAIMOP_SELECTOR,
   DUMMY_PRECLAIMOP_TARGET,
 } from '../modules/validators'
-import type { IntentInput } from '../orchestrator/types'
-import type { SessionSignerSet } from '../types'
+import {
+  type IntentInput,
+  SIG_MODE_EMISSARY,
+  SIG_MODE_EMISSARY_EXECUTION_ERC1271,
+  SIG_MODE_ERC1271,
+} from '../orchestrator/types'
+import type { RhinestoneConfig, SessionSignerSet, SignerSet } from '../types'
 import {
   hashErc7739TypedDataForSolady,
   prepareTransactionAsIntent,
   resolveSessionForChain,
+  resolveSignatureMode,
 } from './utils'
 
 const mockGetIntentRoute = vi.fn()
@@ -492,9 +498,10 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
   test('injects only for not-yet-enabled chains when multiple source chains', async () => {
     // base: not enabled → gets dummy preclaimop
     // arbitrum: already enabled → skipped
-    isSessionEnabledSpy
-      .mockResolvedValueOnce(false) // base
-      .mockResolvedValueOnce(true) // arbitrum
+    isSessionEnabledSpy.mockImplementation(
+      async (_address: any, _provider: any, session: any) =>
+        session.chain.id === arbitrum.id,
+    )
 
     const makeSessionWithActions = (chainId: number) => ({
       ...makeSession(chainId),
@@ -804,5 +811,168 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
 
     const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
     expect(intentInput.preClaimExecutions).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveSignatureMode
+// ---------------------------------------------------------------------------
+
+describe('resolveSignatureMode', () => {
+  beforeEach(() => {
+    vi.spyOn(validators, 'isSessionEnabled').mockResolvedValue(false)
+  })
+
+  const ownerSigners: SignerSet = {
+    type: 'owner',
+    kind: 'ecdsa',
+    accounts: [accountA],
+  } as unknown as SignerSet
+
+  const guardianSigners: SignerSet = {
+    type: 'guardians',
+    guardians: [accountA],
+  } as unknown as SignerSet
+
+  const smartAccountConfig: RhinestoneConfig = {
+    owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+    apiKey: 'test',
+  } as unknown as RhinestoneConfig
+
+  const eoaAccountConfig: RhinestoneConfig = {
+    account: { type: 'eoa' },
+    owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+    apiKey: 'test',
+  } as unknown as RhinestoneConfig
+
+  const sessionWithActions: SessionSignerSet['session'] = {
+    chain: base,
+    owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+    actions: [
+      {
+        target: '0x1111111111111111111111111111111111111111' as `0x${string}`,
+        selector: '0xdeadbeef' as `0x${string}`,
+      },
+    ],
+  } as unknown as SessionSignerSet['session']
+
+  const claimOnlySession: SessionSignerSet['session'] = {
+    chain: base,
+    owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+  } as unknown as SessionSignerSet['session']
+
+  test('EOA returns SIG_MODE_ERC1271', async () => {
+    const mode = await resolveSignatureMode(
+      eoaAccountConfig,
+      undefined,
+      [arbitrum],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_ERC1271)
+  })
+
+  test('smart account with undefined signers returns SIG_MODE_ERC1271', async () => {
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      undefined,
+      [arbitrum],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_ERC1271)
+  })
+
+  test('smart account with owner signers returns SIG_MODE_ERC1271', async () => {
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      ownerSigners,
+      [arbitrum],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_ERC1271)
+  })
+
+  test('smart account with guardian signers returns SIG_MODE_ERC1271', async () => {
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      guardianSigners,
+      [arbitrum],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_ERC1271)
+  })
+
+  test('session with actions returns SIG_MODE_EMISSARY_EXECUTION_ERC1271', async () => {
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: sessionWithActions,
+    }
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      signers,
+      [base],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_EMISSARY_EXECUTION_ERC1271)
+  })
+
+  test('claim-only session returns SIG_MODE_EMISSARY', async () => {
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: claimOnlySession,
+    }
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      signers,
+      [base],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_EMISSARY)
+  })
+
+  test('claim-only session with verifyExecutions=true override returns SIG_MODE_EMISSARY_EXECUTION_ERC1271', async () => {
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: claimOnlySession,
+      verifyExecutions: true,
+    }
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      signers,
+      [base],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_EMISSARY_EXECUTION_ERC1271)
+  })
+
+  test('session with actions and verifyExecutions=false override returns SIG_MODE_EMISSARY', async () => {
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: sessionWithActions,
+      verifyExecutions: false,
+    }
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      signers,
+      [base],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_EMISSARY)
+  })
+
+  test('multi-chain session with divergent verifyExecutions returns SIG_MODE_EMISSARY_EXECUTION_ERC1271', async () => {
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      sessions: {
+        [base.id]: { session: sessionWithActions },
+        [arbitrum.id]: { session: claimOnlySession },
+      },
+    }
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      signers,
+      [base, arbitrum],
+      base,
+    )
+    expect(mode).toBe(SIG_MODE_EMISSARY_EXECUTION_ERC1271)
   })
 })

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -95,7 +95,6 @@ import {
   type Account as OrchestratorAccount,
   type OriginSignature,
   type SettlementLayer,
-  SIG_MODE_EMISSARY,
   SIG_MODE_EMISSARY_EXECUTION_ERC1271,
   SIG_MODE_ERC1271,
   type SignatureMode,
@@ -205,7 +204,7 @@ async function resolveSignatureMode(
   // verifyExecutions=true, so mode 5 is the right hybrid.
   return anyVerifyExecutions
     ? SIG_MODE_EMISSARY_EXECUTION_ERC1271
-    : SIG_MODE_EMISSARY
+    : SIG_MODE_ERC1271
 }
 
 function resolveSessionForChain(

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -95,8 +95,10 @@ import {
   type Account as OrchestratorAccount,
   type OriginSignature,
   type SettlementLayer,
+  SIG_MODE_EMISSARY,
   SIG_MODE_EMISSARY_EXECUTION_ERC1271,
-  SIG_MODE_ERC1271_EMISSARY,
+  SIG_MODE_ERC1271,
+  type SignatureMode,
   type SupportedChain,
 } from '../orchestrator/types'
 import { convertBigIntFields } from '../orchestrator/utils'
@@ -166,6 +168,44 @@ async function resolveSignersForChain(
     enableData,
     verifyExecutions,
   } satisfies ResolvedSessionSignerSet
+}
+
+// Picks the single signature mode that matches the bytes shape the SDK will
+// actually sign, so the on-chain dispatcher hits the right validator on the
+// first try instead of falling through a hybrid.
+async function resolveSignatureMode(
+  config: RhinestoneConfig,
+  signers: SignerSet | undefined,
+  sourceChains: Chain[] | undefined,
+  targetChain: Chain,
+): Promise<SignatureMode> {
+  if (config.account?.type === 'eoa') {
+    return SIG_MODE_ERC1271
+  }
+  if (signers?.type !== 'experimental_session') {
+    return SIG_MODE_ERC1271
+  }
+  const chainIds = [
+    ...new Set([...(sourceChains ?? []).map((c) => c.id), targetChain.id]),
+  ]
+  const resolvedSet = await Promise.all(
+    chainIds.map((chainId) => resolveSignersForChain(config, signers, chainId)),
+  )
+  let anyVerifyExecutions = false
+  for (const resolved of resolvedSet) {
+    if (!isResolvedSessionSignerSet(resolved)) {
+      return SIG_MODE_ERC1271
+    }
+    // Conservative: one chain with verifyExecutions=true forces mode 5 across
+    // all origin signatures — a single mode field can't describe divergence.
+    if (resolved.verifyExecutions) anyVerifyExecutions = true
+  }
+  // Mode 4 (pure emissary-execution) is unused: signIntentTypedData always
+  // emits a dual sig for the intent's origin/destination signatures when
+  // verifyExecutions=true, so mode 5 is the right hybrid.
+  return anyVerifyExecutions
+    ? SIG_MODE_EMISSARY_EXECUTION_ERC1271
+    : SIG_MODE_EMISSARY
 }
 
 function resolveSessionForChain(
@@ -888,10 +928,12 @@ async function prepareTransactionAsIntent(
     }),
   }
   const recipient = getRecipient(recipientInput)
-  const signatureMode =
-    signers?.type === 'experimental_session'
-      ? SIG_MODE_EMISSARY_EXECUTION_ERC1271
-      : SIG_MODE_ERC1271_EMISSARY
+  const signatureMode = await resolveSignatureMode(
+    config,
+    signers,
+    sourceChains,
+    targetChain,
+  )
 
   // For session signers that need enabling, pass a dummy preclaimop per source chain
   // so the orchestrator bakes it into the bundle before computing its HMAC. The filler
@@ -1894,6 +1936,7 @@ export {
   getTargetExecutionSignature,
   hashErc7739TypedDataForSolady,
   resolveSessionForChain,
+  resolveSignatureMode,
 }
 export type {
   InternalSignerSet,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -513,6 +513,7 @@ export type {
   MappedChainTokenAccessList,
   UnmappedChainTokenAccessList,
   OriginSignature,
+  SignatureMode,
   TokenRequirements,
   WrapRequired,
   ApprovalRequired,


### PR DESCRIPTION
## Summary

- Replaces the unconditional hybrid pick at `src/execution/utils.ts:891-894` with a `resolveSignatureMode` helper that names the *single* validator path matching the bytes the SDK actually emits.
- EOA + every non-session smart account → `SIG_MODE_ERC1271` (1). Claim-only session → `SIG_MODE_EMISSARY` (0). Session with `verifyExecutions=true` → `SIG_MODE_EMISSARY_EXECUTION_ERC1271` (5) (the only case that genuinely produces a dual sig).
- Multi-chain divergence (`PerChainSessionSignerSet`) resolves conservatively to mode 5 — a single mode field can't describe per-origin divergence.
- Unit tests cover every leaf of the decision tree (EOA / undefined signers / owner / guardians / session-with-actions / claim-only session / both override directions / multi-chain divergent).
- Validated end-to-end against prod orchestrator + testnet contracts: mode-1 traces show only `account.isValidSignature`, no emissary calls; mode-5 traces show `SmartSessionEmissary.verifyExecution` + the internal 1271 dispatch; mode-0 branches are pinned via prepare-only assertions (full settle requires Compact bootstrap that's out of scope).

Closes [RHI-3937](https://linear.app/rhinestone/issue/RHI-3937/v1-sdk).