### PR TITLE
fix: use public viem/account-abstraction subpath

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -1,5 +1,5 @@
 import { type Address, type Chain, createPublicClient, type Hex } from 'viem'
-import type { UserOperationReceipt } from 'viem/_types/account-abstraction'
+import type { UserOperationReceipt } from 'viem/account-abstraction'
 import { deploy, getAddress } from '../accounts'
 import { createTransport, getBundlerClient } from '../accounts/utils'
 import { type AuthProvider, createAuthProvider } from '../auth/provider'


### PR DESCRIPTION
## Summary

`viem/_types/...` is viem's internal types directory, not part of its package.json `exports`. Strict module resolution (e.g. `moduleResolution: 'bundler'`) rejects it.

Surfaced while typechecking sdk-examples against the SDK as a sibling repo path-mapped to source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)