### PR TITLE
fix: correct getPolicyData('time-frame') encoding and arg order

### DIFF
--- a/.changeset/fix-time-frame-policy-encoding.md
+++ b/.changeset/fix-time-frame-policy-encoding.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `getPolicyData('time-frame')` to match the deployed `TimeFramePolicy` contract. Was emitting `encodePacked(['uint48','uint48'], [validUntil, validAfter])`; now emits `encodeAbiParameters([uint48, uint48], [validAfter, validUntil])`. Sessions installed with a `time-frame` policy through the SDK now behave as intended.

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -94,14 +94,14 @@ describe('getPolicyData', () => {
     expect(result.initData).toBe(expected)
   })
 
-  test('time-frame encodes validUntil/validAfter in seconds (ms → s)', () => {
+  test('time-frame encodes (validAfter, validUntil) as ABI uint48 pair in seconds (ms → s)', () => {
     const validUntil = 1_800_000_000_000
     const validAfter = 1_700_000_000_000
     const result = getPolicyData({ type: 'time-frame', validUntil, validAfter })
     expect(result.policy).toBe(TIME_FRAME_POLICY_ADDRESS)
-    const expected = encodePacked(
-      ['uint48', 'uint48'],
-      [Math.floor(validUntil / 1000), Math.floor(validAfter / 1000)],
+    const expected = encodeAbiParameters(
+      [{ type: 'uint48' }, { type: 'uint48' }],
+      [Math.floor(validAfter / 1000), Math.floor(validUntil / 1000)],
     )
     expect(result.initData).toBe(expected)
   })

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -961,11 +961,11 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
     case 'time-frame': {
       return {
         policy: TIME_FRAME_POLICY_ADDRESS,
-        initData: encodePacked(
-          ['uint48', 'uint48'],
+        initData: encodeAbiParameters(
+          [{ type: 'uint48' }, { type: 'uint48' }],
           [
-            Math.floor(policy.validUntil / 1000),
             Math.floor(policy.validAfter / 1000),
+            Math.floor(policy.validUntil / 1000),
           ],
         ),
       }


### PR DESCRIPTION
## Summary

- Was emitting `encodePacked(['uint48','uint48'], [validUntil, validAfter])` for the `TimeFramePolicy` `initData`. The deployed policy expects `encodeAbiParameters([uint48, uint48], [validAfter, validUntil])` — wrong on both encoding form and field order.
- Sessions installed with a `time-frame` policy through the SDK were not enforcing the intended validity window.
- Test updated to assert against the corrected encoding.

Closes [RHI-3968](https://linear.app/rhinestone/issue/RHI-3968). Parent: [RHI-3967](https://linear.app/rhinestone/issue/RHI-3967). Companion PR for v1 (`main`) coming separately.