### PR TITLE
chore: bump @rhinestone/shared-configs to 1.6.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "1.6.3",
+        "@rhinestone/shared-configs": "1.6.5",
         "viem": "^2.40.1",
       },
       "devDependencies": {
@@ -28,7 +28,7 @@
       "name": "@rhinestone/sdk",
       "version": "1.5.0",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.5.1",
+        "@rhinestone/shared-configs": "1.6.5",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -179,7 +179,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.3", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-ABoDM/4TM9Iadsof8OQnG0MvyBJpLUCimncqPa53ragLVSCJpH+N3VWzNEcJLdfoDq842g5yjF7/mZZ3zI+BNw=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.5", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-PCLTIMTwZf/foggoKzDMoOFH9CSR7BUDU2n1Iw1UGMn3L8ji650AZjdIm5HGqegQvLvQWip/aqYmBGA1z73psA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 
@@ -710,8 +710,6 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@rhinestone/sdk/@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.5.1", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-RtbhW8oQPZeipov1NF3pd4tXvR+C5cac7yhYC0pd2aoE3iBb53U256yvmfyAJ9/s9E0UauT1sNFC/LrLJC+uvA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "1.6.3",
+    "@rhinestone/shared-configs": "1.6.5",
     "viem": "^2.40.1"
   },
   "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -166,7 +166,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.5.1",
+    "@rhinestone/shared-configs": "1.6.5",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Bumps \`@rhinestone/shared-configs\` from \`1.5.1\` → \`1.6.5\` in the published \`src/package.json\` (and from \`1.6.3\` → \`1.6.5\` in the workspace root).
