### PR TITLE
fix: trim FeeBreakdown to wire fields (gas/bridge/swap)

### DIFF
--- a/.changeset/trim-fee-breakdown.md
+++ b/.changeset/trim-fee-breakdown.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': major
+---
+
+- Drop `protocol` and `settlement` from `FeeBreakdown`. The orchestrator only returns `gas`, `bridge`, and `swap`.

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -46,9 +46,7 @@ const mockQuote = {
       breakdown: {
         gas: { usd: 0 },
         bridge: { usd: 0 },
-        protocol: { usd: 0 },
         swap: { usd: 0 },
-        settlement: { usd: 0 },
       },
     },
   },

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -182,9 +182,7 @@ interface CostTokenEntry {
 interface FeeBreakdown {
   gas: UsdAmount
   bridge: UsdAmount
-  protocol: UsdAmount
   swap: UsdAmount
-  settlement: UsdAmount
 }
 
 interface Fees {


### PR DESCRIPTION
The orchestrator's quote response only populates `gas`, `bridge`, and `swap` on the fee breakdown — `protocol` and `settlement` are never set. Drop them from the public `FeeBreakdown` type and update the test fixture.