### PR TITLE
fix: wait for terminal intent state in waitForExecution

### DIFF
--- a/.changeset/wait-for-terminal-state.md
+++ b/.changeset/wait-for-terminal-state.md
@@ -1,0 +1,8 @@
+---
+'@rhinestone/sdk': major
+---
+
+- `account.waitForExecution` now polls until the intent reaches a terminal state (`COMPLETED` or `FAILED`), without an SDK-side deadline. The previous `expiresAt`-based timeout proved unreliable for some flows (e.g. intent executor), where the quote `expiresAt` doesn't reflect the actual fill deadline. The orchestrator handles expiry internally and surfaces it as `FAILED`.
+- Removed the `IntentExpiredError` class — expiry now surfaces as `IntentFailedError` (inspect `operations[].failureReason` for the cause).
+- Removed the `expiresAt` field from `TransactionResult`.
+- Narrowed `SettlementLayerFilter` to `CrossChainSettlementLayer[]` (`ACROSS | ECO | RELAY | OFT | NEAR | RHINO | CCTP`) — `SAME_CHAIN` and `INTENT_EXECUTOR` are picked by the orchestrator and were never accepted in the filter at runtime.

--- a/src/execution/error.ts
+++ b/src/execution/error.ts
@@ -89,19 +89,6 @@ class IntentFailedError extends ExecutionError {
   }
 }
 
-class IntentExpiredError extends ExecutionError {
-  constructor(params?: {
-    context?: any
-    errorType?: string
-    traceId?: string
-  }) {
-    super({
-      message: 'Intent expired before being filled',
-      ...params,
-    })
-  }
-}
-
 class QuoteNotInPreparedTransactionError extends ExecutionError {
   constructor(params?: {
     context?: { intentId?: string }
@@ -142,6 +129,5 @@ export {
   QuoteNotInPreparedTransactionError,
   SessionChainRequiredError,
   IntentFailedError,
-  IntentExpiredError,
   SignerNotSupportedError,
 }

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -34,7 +34,6 @@ import type {
 } from '../types'
 import {
   ExecutionError,
-  IntentExpiredError,
   IntentFailedError,
   isExecutionError,
   OrderPathRequiredForIntentsError,
@@ -258,22 +257,12 @@ async function waitForExecution(
     case 'intent': {
       let intentStatus: IntentOpStatus | null = null
       const startTs = Date.now()
-      const deadlineMs = result.expiresAt * 1000
       let nextDelayMs = POLL_INITIAL_MS
       let errorBackoffMs = POLL_ERROR_BACKOFF_MS
       while (
         intentStatus === null ||
         !terminalStatuses.has(intentStatus.status)
       ) {
-        const now = Date.now()
-        if (now >= deadlineMs) {
-          throw new IntentExpiredError({
-            context: {
-              intentId: result.id,
-              expiresAt: result.expiresAt,
-            },
-          })
-        }
         const orchestrator = getOrchestrator(
           config._authProvider ?? createAuthProvider(config),
           config.endpointUrl,
@@ -402,7 +391,6 @@ export {
   // Errors
   isExecutionError,
   ExecutionError,
-  IntentExpiredError,
   IntentFailedError,
   OrderPathRequiredForIntentsError,
   QuoteNotInPreparedTransactionError,

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -241,7 +241,6 @@ interface TransactionResult {
   id: string
   sourceChains?: number[]
   targetChain: number
-  expiresAt: number
 }
 
 interface PreparedQuotes {
@@ -1581,7 +1580,6 @@ async function submitIntentInternal(
     id: response.intentId,
     sourceChains: sourceChains?.map((chain) => chain.id),
     targetChain: getChainId(targetChain),
-    expiresAt: quote.expiresAt,
   }
 }
 

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -322,8 +322,8 @@ function encodeOptions(options: IntentOptions): Record<string, unknown> {
   return wire
 }
 
-// Inversion universe for `{ exclude }`. Drop once the orchestrator accepts the
-// union natively; RHINO/CCTP are listed despite not being in `SettlementLayer`.
+// Inversion universe for `{ exclude }` — must mirror the orchestrator's
+// cross-chain settlement layer enum.
 const KNOWN_SETTLEMENT_LAYERS = [
   'ACROSS',
   'ECO',

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -1,3 +1,4 @@
+import type { SettlementLayer as CrossChainSettlementLayer } from '@rhinestone/shared-configs'
 import type { Address } from 'viem'
 import type { AuthProvider } from '../auth/provider'
 import { fromCaip2, isCaip2, toCaip2 } from './caip2'
@@ -332,7 +333,7 @@ const KNOWN_SETTLEMENT_LAYERS = [
   'NEAR',
   'RHINO',
   'CCTP',
-] as const
+] as const satisfies readonly CrossChainSettlementLayer[]
 
 export function encodeSettlementLayers(
   filter: SettlementLayerFilter,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -99,8 +99,8 @@ type SettlementLayer =
   | CrossChainSettlementLayer
 
 type SettlementLayerFilter =
-  | { include: SettlementLayer[] }
-  | { exclude: SettlementLayer[] }
+  | { include: CrossChainSettlementLayer[] }
+  | { exclude: CrossChainSettlementLayer[] }
 
 const SIG_MODE_EMISSARY = 0
 const SIG_MODE_ERC1271 = 1


### PR DESCRIPTION
## Summary

- `account.waitForExecution` now polls until the intent reaches a terminal state (`COMPLETED` or `FAILED`), with no SDK-side deadline. The previous `expiresAt`-based timeout was unreliable when the intent executor was involved — the quote `expiresAt` did not reflect the actual fill deadline.
- Expiry now surfaces as `IntentFailedError` (inspect `operations[].failureReason`). The orchestrator folds `EXPIRED` into `FAILED` on its public surface, so the SDK doesn't need a separate state.
- Removed `IntentExpiredError` and `TransactionResult.expiresAt`.
- Narrowed `SettlementLayerFilter` to `CrossChainSettlementLayer[]` — `SAME_CHAIN` / `INTENT_EXECUTOR` were typed but never accepted in the filter at runtime.

## Testing

Ran 5 prod-orchestrator + testnet scenarios via `sdk-examples/src/debug/tmp_terminal_state.ts` — all completed:

| Scenario | Status | Elapsed |
|---|---|---|
| same-chain-base | COMPLETED | 4065ms |
| same-chain-arb | COMPLETED | 1761ms |
| cross-chain-arb-to-base | COMPLETED | 3072ms |
| cross-chain-multi-source | COMPLETED | 3771ms |
| cross-chain-sepolia-to-op | COMPLETED | 3766ms |

Closes [RHI-4015](https://linear.app/rhinestone/issue/RHI-4015).