### PR TITLE
ci: bump shared-configs in src/package.json, not root

### DIFF
--- a/.github/workflows/update-shared-configs.yaml
+++ b/.github/workflows/update-shared-configs.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           echo "install_command=${{ steps.pm.outputs.add }} @rhinestone/shared-configs@${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "files=package.json ${{ steps.pm.outputs.lockfile }}" >> "$GITHUB_OUTPUT"
+          echo "files=src/package.json ${{ steps.pm.outputs.lockfile }}" >> "$GITHUB_OUTPUT"
 
       - name: Check for existing branch
         id: check
@@ -95,6 +95,7 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: |
           git checkout -b "${{ steps.vars.outputs.branch }}"
+          cd src
           eval "${{ steps.vars.outputs.install_command }}"
 
       - name: Commit and push

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,6 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "1.6.3",
         "viem": "^2.40.1",
       },
       "devDependencies": {
@@ -179,7 +178,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.3", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-ABoDM/4TM9Iadsof8OQnG0MvyBJpLUCimncqPa53ragLVSCJpH+N3VWzNEcJLdfoDq842g5yjF7/mZZ3zI+BNw=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.5.1", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-RtbhW8oQPZeipov1NF3pd4tXvR+C5cac7yhYC0pd2aoE3iBb53U256yvmfyAJ9/s9E0UauT1sNFC/LrLJC+uvA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 
@@ -710,8 +709,6 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@rhinestone/sdk/@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.5.1", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-RtbhW8oQPZeipov1NF3pd4tXvR+C5cac7yhYC0pd2aoE3iBb53U256yvmfyAJ9/s9E0UauT1sNFC/LrLJC+uvA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "1.6.3",
     "viem": "^2.40.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The auto-bump workflow (#495 was the latest example) was running \`bun add\` from the repo root, so it only touched the root \`package.json\`. But the published package is \`src/\` — and grepping the repo confirms only files under \`src/\` import \`@rhinestone/shared-configs\`. The root entry was dead weight, and the bumps weren't actually reaching the published deps.

- Workflow now runs \`bun add\` inside \`src/\` and commits \`src/package.json\` + the root \`bun.lock\`.
- Drops the stale root \`@rhinestone/shared-configs\` entry; \`bun install\` collapses the duplicate resolution in the lockfile.