### PR TITLE
ci: use sudo when upgrading npm globally

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Use OIDC-capable npm
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@latest
 
       - name: Install the npm dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
The first OIDC publish run on \`main\` ([26104013219](https://github.com/rhinestonewtf/sdk/actions/runs/26104013219)) failed at the \`Use OIDC-capable npm\` step:

\`\`\`
npm error code EACCES
npm error path /usr/local/share/man/man7
\`\`\`

The pre-installed npm on ubuntu-latest is owned by root, so a non-root \`npm install -g\` cannot link binaries. Prefix with \`sudo\` (passwordless on GH-hosted runners). Same fix is being applied to #502 (the release-branch mirror).