### PR TITLE
ci: mint release-bot token from GitHub App for release PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,8 +48,18 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Mint release-bot token
+        if: github.ref == 'refs/heads/release'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Check out the repo
         uses: "actions/checkout@v4"
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -80,10 +90,10 @@ jobs:
           publish: bun run changeset:release
           version: bun run changeset:version
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Label release PR
         if: github.ref == 'refs/heads/release' && steps.changesets.outputs.pullRequestNumber != ''
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label ship

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,8 +53,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check out the repo
         uses: "actions/checkout@v4"


### PR DESCRIPTION
Replaces \`secrets.GH_TOKEN\` (a long-lived user PAT) with a short-lived token minted at runtime from the existing \`rhinestone-automations\` GitHub App (same App + same secret names as \`rhinestonewtf/infra\`). The bot identity opens the Release PR, pushes the version bumps, and applies the \`ship\` label.

Also fixes a latent permission gap: the job's default \`GITHUB_TOKEN\` is locked to \`contents: read\` (needed for OIDC), which would silently break \`git push\` from \`changesets/action\` whenever it has to push a version-bump commit. Passing the App token to \`actions/checkout\` so the persisted git creds use the bot identity resolves it.

**Snapshot (\`main\`) path** is unchanged — no git push happens there, so it stays on the default \`GITHUB_TOKEN\`.

---

### Prereq (must be done before merge)

Ask an org admin to add \`rhinestonewtf/sdk\` to the *selected repositories* list of the existing org-level secrets \`APP_ID\` and \`APP_PRIVATE_KEY\` (currently scoped to \`infra\`). No new App or new secrets needed; the \`rhinestone-automations\` App is already installed on this repo.

Companion PR for \`release\`: #505.