### PR TITLE
ci: mint release-bot token from GitHub App for release PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,8 +53,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check out the repo
         uses: "actions/checkout@v4"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,14 +48,24 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Mint release-bot token
+        if: github.ref == 'refs/heads/release'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Check out the repo
         uses: "actions/checkout@v4"
+        with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
       - name: Use OIDC-capable npm
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@latest
 
       - name: Install the npm dependencies
         run: bun install --frozen-lockfile
@@ -80,10 +90,10 @@ jobs:
           publish: bun run changeset:release
           version: bun run changeset:version
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Label release PR
         if: github.ref == 'refs/heads/release' && steps.changesets.outputs.pullRequestNumber != ''
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label ship


### PR DESCRIPTION
Mirrors #504 onto \`release\`. Also includes the \`sudo npm install -g\` fix that landed on \`main\` in #503 but wasn't ported here yet.

Replaces \`secrets.GH_TOKEN\` (user PAT) with a short-lived token minted at runtime from the existing \`rhinestone-automations\` GitHub App (same App + same secret names as \`rhinestonewtf/infra\`). The bot identity opens the Release PR, pushes the version bumps, and applies the \`ship\` label.

Also fixes a latent permission gap: the job's default \`GITHUB_TOKEN\` is locked to \`contents: read\` (needed for OIDC), which would silently break \`git push\` from \`changesets/action\` when it has to push a version-bump commit. Passing the App token to \`actions/checkout\` so the persisted git creds use the bot identity resolves it.

---

### Prereq (must be done before merge)

Same as #504. Once the org-level \`APP_ID\` / \`APP_PRIVATE_KEY\` are exposed to \`sdk\`, both PRs can be merged.