### PR TITLE
docs(ci): add header comment explaining release workflow branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,10 @@
 name: Release
 
+# Push to main publishes a snapshot (@dev tag); push to release runs
+# changesets/action to open a Release PR or publish (@latest tag).
+# Publishes to npm via OIDC trusted publishing; release PRs are opened
+# by the rhinestone-automations GitHub App.
+
 on:
   push:
     branches:


### PR DESCRIPTION
Adds a brief header comment to \`release.yaml\` documenting the per-branch behaviour. No behaviour change.

Useful side effect: the merge will trigger a fresh \`release.yaml\` run on \`main\`, exercising the post-#504 workflow end-to-end (the previous run failed at startup because \`actions/create-github-app-token@v1\` wasn't allowlisted at the org — now resolved).