### PR TITLE
docs(ci): add header comment explaining release workflow branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,10 @@
 name: Release
 
+# Push to main publishes a snapshot (@dev tag); push to release runs
+# changesets/action to open a Release PR or publish (@latest tag).
+# Publishes to npm via OIDC trusted publishing; release PRs are opened
+# by the rhinestone-automations GitHub App.
+
 on:
   push:
     branches:


### PR DESCRIPTION
Mirrors #507 onto \`release\`. No behaviour change — adds a header comment.

Merging triggers a fresh \`release.yaml\` run on \`release\`, which is the first time the post-#505 workflow exercises end-to-end:
- mints a token via \`rhinestone-automations\` App (\`Mint release-bot token\` step)
- \`actions/checkout\` uses the App token
- \`changesets/action\` runs with the App token (will be a no-op publish if no pending changesets on this branch — that's fine for the test)