### PR TITLE
fix: install session via emissary on first use

### DIFF
--- a/.changeset/install-session-via-emissary-on-first-use.md
+++ b/.changeset/install-session-via-emissary-on-first-use.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix claim-only sessions failing on first use after the `verifyExecutions` derivation change. `resolveSignersForChain` now forces `verifyExecutions=true` whenever the session is not yet enabled on-chain, regardless of `hasExplicitPermissions`. This routes the first intent through the emissary's `verifyExecution` path (mode 5, ENABLE-mode signature, dummy preClaimOp) so the session gets installed via `setConfig`. Subsequent intents on an already-enabled claim-only session drop back to mode 1.

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -236,7 +236,44 @@ describe('prepareTransactionAsIntent', () => {
     expect(intentInput.options.auxiliaryFunds).toBeUndefined()
   })
 
-  test('claim-only session sends SIG_MODE_ERC1271 in routing request', async () => {
+  test('claim-only session already enabled sends SIG_MODE_ERC1271 in routing request', async () => {
+    mockCreateQuote.mockResolvedValue({ routes: [mockQuote] })
+    vi.spyOn(validators, 'isSessionEnabled').mockResolvedValue(true)
+
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: toSession({
+        chain: base,
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+      }),
+    }
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [base],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      signers,
+    )
+
+    const intentInput: IntentInput = mockCreateQuote.mock.calls[0][0]
+    expect(intentInput.options.signatureMode).toBe(SIG_MODE_ERC1271)
+  })
+
+  test('claim-only session not yet enabled escalates to SIG_MODE_EMISSARY_EXECUTION_ERC1271 to install', async () => {
     mockCreateQuote.mockResolvedValue({ routes: [mockQuote] })
     vi.spyOn(validators, 'isSessionEnabled').mockResolvedValue(false)
 
@@ -275,7 +312,9 @@ describe('prepareTransactionAsIntent', () => {
     )
 
     const intentInput: IntentInput = mockCreateQuote.mock.calls[0][0]
-    expect(intentInput.options.signatureMode).toBe(SIG_MODE_ERC1271)
+    expect(intentInput.options.signatureMode).toBe(
+      SIG_MODE_EMISSARY_EXECUTION_ERC1271,
+    )
   })
 })
 
@@ -510,13 +549,53 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
     expect(intentInput.preClaimExecutions).toBeUndefined()
   })
 
-  test('omits preClaimExecutions when session has no explicit actions (verifyExecutions=false)', async () => {
+  test('injects preClaimExecutions for claim-only session that still needs install', async () => {
+    // Claim-only sessions have no actions to validate, but on first use we still
+    // route through the emissary's verifyExecution path because that's the only
+    // mechanism that consumes enableData and writes the session via setConfig.
     const signers: SessionSignerSet = {
       type: 'experimental_session',
       session: toSession({
         chain: base,
         owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
-        // no actions → verifyExecutions defaults to false
+      }),
+      enableData: makeEnableData(),
+    }
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [base],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      signers,
+    )
+
+    const intentInput: IntentInput = mockCreateQuote.mock.calls[0][0]
+    expect(intentInput.preClaimExecutions).toBeDefined()
+    expect(intentInput.preClaimExecutions![base.id]).toHaveLength(1)
+  })
+
+  test('omits preClaimExecutions when claim-only session is already enabled', async () => {
+    isSessionEnabledSpy.mockResolvedValue(true)
+
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: toSession({
+        chain: base,
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
       }),
       enableData: makeEnableData(),
     }
@@ -706,7 +785,24 @@ describe('resolveSignatureMode', () => {
     expect(mode).toBe(SIG_MODE_EMISSARY_EXECUTION_ERC1271)
   })
 
-  test('claim-only session returns SIG_MODE_ERC1271', async () => {
+  test('claim-only session not yet enabled returns SIG_MODE_EMISSARY_EXECUTION_ERC1271 to install', async () => {
+    // The default mock in beforeEach has isSessionEnabled → false.
+    const signers: SessionSignerSet = {
+      type: 'experimental_session',
+      session: claimOnlySession,
+    }
+    const mode = await resolveSignatureMode(
+      smartAccountConfig,
+      signers,
+      [base],
+      base.id,
+    )
+    expect(mode).toBe(SIG_MODE_EMISSARY_EXECUTION_ERC1271)
+  })
+
+  test('claim-only session already enabled returns SIG_MODE_ERC1271', async () => {
+    vi.spyOn(validators, 'isSessionEnabled').mockResolvedValue(true)
+
     const signers: SessionSignerSet = {
       type: 'experimental_session',
       session: claimOnlySession,

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -171,7 +171,11 @@ async function resolveSignersForChain(
     type: 'experimental_session',
     session: resolved.session,
     enableData,
-    verifyExecutions: resolved.session.hasExplicitPermissions,
+    // First use of any session must go through the emissary's verifyExecution
+    // path: that's the only mechanism that consumes enableData + calls setConfig
+    // to install the session on-chain. Once installed, steady-state signing can
+    // drop to mode 1 unless the session has explicit permissions to enforce.
+    verifyExecutions: !enabled || resolved.session.hasExplicitPermissions,
   } satisfies ResolvedSessionSignerSet
 }
 


### PR DESCRIPTION
## Summary
- Claim-only smart-session intents revert on-chain on first use after PR #476: `resolveSignersForChain` overrides the caller-supplied `verifyExecutions` with `session.hasExplicitPermissions`, which drops the install side-effect (dummy preClaimOp + ENABLE-mode signature bytes that the emissary consumes via `setConfig`).
- This patch escalates `verifyExecutions` to `true` whenever the session isn't yet enabled on-chain, so first use routes through the emissary path. Steady-state signing for claim-only sessions still falls back to mode 1.

## Repro

Reference Tenderly: [7afd60c6](https://dashboard.tenderly.co/shared/simulation/7afd60c6-2723-4810-a592-57d7c95383da). Repro Tenderly (matched call frame): [cc1088ed](https://www.tdly.co/shared/simulation/cc1088ed-3308-4355-be1e-b371b8bcae67).

End-to-end validation against prod orchestrator on Arb Sepolia → Base Sepolia with a fresh account on the patched SDK:
- First use → `signatureMode: 5`, dual sig, COMPLETED ([source](https://sepolia.arbiscan.io/tx/0x8529ca2ce26bd35c95ac6121b3cbd8ee049123b0b82c2a76a749f288e38e09c4), [target](https://sepolia.basescan.org/tx/0x06174d0cf37b7095b7e322261602cd7bc611b5fadb32ad78a8923c23bc1e9ffc))
- Second use (same account) → `signatureMode: 1`, single sig, COMPLETED ([source](https://sepolia.arbiscan.io/tx/0x60d130962e4568aca1b5bc3e02cbeca0677a259a818b4f94985027889ba4023a), [target](https://sepolia.basescan.org/tx/0xe24a50eb23ece9439fa218c26497f2e49b0d54f0b23fd28499fd5fffe28ece53))