### PR TITLE
fix: scoped session enable and SentinelList uninstall on Nexus

### DIFF
--- a/.changeset/fix-enable-session-preserve-permissions.md
+++ b/.changeset/fix-enable-session-preserve-permissions.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `experimental_enableSession` dropping `permissions` for scoped sessions. The function accepted `SessionInput` and re-ran `toSession` on it inside `resolve`, but callers pass a resolved `Session` (which carries the derived `actions` but not the original `SessionDefinition.permissions`). The re-resolution treated `permissions` as undefined and replaced the action set with a sole `sudoAction`, so the on-chain digest computed by `SmartSessionLens.getAndVerifyDigest` no longer matched the digest signed in `getSessionDetails` and the emissary rejected the enable. The parameter type is now `Session` and the resolved value is passed straight to `getEnableSessionCall`.

--- a/.changeset/fix-uninstall-module-sentinel-list-prev.md
+++ b/.changeset/fix-uninstall-module-sentinel-list-prev.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `uninstallModule` reverting on Nexus, Safe7579, and Startale accounts. These ERC-7579 accounts store validators in a `SentinelList` and decode `uninstallModule`'s `deInitData` arg as `(address prev, bytes moduleDeInit)`. The SDK was passing module-level `deInitData` (typically `'0x'`) straight into that slot, which fails `abi.decode` before the linked list pop can run. `getModuleUninstallationCalls` now reads the live validator list, computes the prev pointer, and wraps `module.deInitData` as `abi.encode(prev, module.deInitData)` for validator-type uninstalls on SentinelList accounts. Kernel and EOA paths are untouched (Kernel treats the slot as raw module bytes; EOA has no modules).
+
+Affects every existing disable action — `ecdsa.disable`, `passkeys.disable`, `mfa.disable`, `experimental_disable` (smart sessions), and the generic `uninstallModule(module)` — all of which were silently broken on Nexus before.

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -1,4 +1,5 @@
 import {
+  type Address,
   type Chain,
   concat,
   createPublicClient,
@@ -20,7 +21,8 @@ import {
   waitForExecution,
 } from '../execution'
 import { getIntentExecutor, getSetup } from '../modules'
-import type { Module } from '../modules/common'
+import { MODULE_TYPE_ID_VALIDATOR, type Module } from '../modules/common'
+import { getValidators as getValidatorsInternal } from '../modules/read'
 import { getOwnerValidator } from '../modules/validators'
 import { getSocialRecoveryValidator } from '../modules/validators/core'
 import type { ResolvedSessionSignerSet } from '../modules/validators/smart-sessions'
@@ -278,11 +280,24 @@ function getModuleInstallationCalls(
   }))
 }
 
-function getModuleUninstallationCalls(
+// SentinelList head pointer used by ERC-7579 module managers (Nexus, Safe7579,
+// Startale). Validator/executor uninstall on these accounts decodes the
+// `deInitData` slot as `(address prev, bytes moduleDeInit)`, where `prev`
+// identifies the preceding linked-list entry to repair on removal.
+const SENTINEL_LIST_HEAD: Address = '0x0000000000000000000000000000000000000001'
+
+async function getModuleUninstallationCalls(
   config: RhinestoneConfig,
+  chain: Chain,
   module: Module,
-): Call[] {
+): Promise<Call[]> {
   const address = getAddress(config)
+  const onChainDeInitData = await resolveOnChainDeInitData(
+    config,
+    chain,
+    address,
+    module,
+  )
   const data = encodeFunctionData({
     abi: [
       {
@@ -307,9 +322,62 @@ function getModuleUninstallationCalls(
       },
     ],
     functionName: 'uninstallModule',
-    args: [module.type, module.address, module.deInitData],
+    args: [module.type, module.address, onChainDeInitData],
   })
   return [{ to: address, data, value: 0n }]
+}
+
+/**
+ * Build the value the account expects in `uninstallModule`'s third argument.
+ *
+ * `Module.deInitData` carries module-level bytes (mirroring `Module.initData`,
+ * what the module's `onUninstall` sees). ERC-7579 accounts that store
+ * validators / executors in a SentinelList — Nexus, Safe7579, Startale —
+ * require an account-level wrapper `abi.encode(prev, moduleDeInit)` so they
+ * can pop the entry from the linked list. Kernel uses different storage and
+ * treats this slot as raw module bytes, so we pass `module.deInitData` through
+ * unchanged.
+ *
+ * Scope: validator type only — there are no public actions to disable
+ * executor modules today.
+ */
+async function resolveOnChainDeInitData(
+  config: RhinestoneConfig,
+  chain: Chain,
+  account: Address,
+  module: Module,
+): Promise<Hex> {
+  if (module.type !== MODULE_TYPE_ID_VALIDATOR) {
+    return module.deInitData
+  }
+  const accountType = getAccountProvider(config).type
+  if (
+    accountType !== 'nexus' &&
+    accountType !== 'safe' &&
+    accountType !== 'startale'
+  ) {
+    return module.deInitData
+  }
+
+  const validators = await getValidatorsInternal(
+    accountType,
+    account,
+    chain,
+    config.provider,
+  )
+  const targetLower = module.address.toLowerCase()
+  const index = validators.findIndex((v) => v.toLowerCase() === targetLower)
+  if (index === -1) {
+    // Not installed; pass through unchanged. The account's `uninstallModule`
+    // will surface a `ModuleNotInstalled` revert with the original module
+    // address, which is more useful than a silent abi.decode mismatch.
+    return module.deInitData
+  }
+  const prev = index === 0 ? SENTINEL_LIST_HEAD : validators[index - 1]
+  return encodeAbiParameters(
+    [{ type: 'address' }, { type: 'bytes' }],
+    [prev, module.deInitData],
+  )
 }
 
 function getAddress(config: RhinestoneConfig) {

--- a/src/actions/ecdsa.test.ts
+++ b/src/actions/ecdsa.test.ts
@@ -1,5 +1,6 @@
+import { encodeAbiParameters, encodeFunctionData } from 'viem'
 import { base } from 'viem/chains'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { accountA } from '../../test/consts'
 import { RhinestoneSDK } from '..'
 import { resolveCallInputs } from '../execution/utils'
@@ -10,6 +11,53 @@ import {
   enable as enableEcdsa,
   removeOwner,
 } from './ecdsa'
+
+// `getModuleUninstallationCalls` reads the on-chain validator list to compute
+// the SentinelList `prev` pointer for the uninstall. The test account isn't
+// deployed, so stub the read with a known single-validator list. The address
+// is inlined because `vi.mock` is hoisted above any module-scope `const`.
+vi.mock('../modules/read', async (importActual) => {
+  const actual = await importActual<typeof import('../modules/read')>()
+  return {
+    ...actual,
+    getValidators: vi
+      .fn()
+      .mockResolvedValue(['0x000000000013fdb5234e4e3162a810f54d9f7e98']),
+  }
+})
+
+const OWNABLE_VALIDATOR_ADDRESS =
+  '0x000000000013fdb5234e4e3162a810f54d9f7e98' as const
+
+const UNINSTALL_MODULE_ABI = [
+  {
+    type: 'function',
+    name: 'uninstallModule',
+    inputs: [
+      { type: 'uint256', name: 'moduleTypeId' },
+      { type: 'address', name: 'module' },
+      { type: 'bytes', name: 'deInitData' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const
+
+const SENTINEL = '0x0000000000000000000000000000000000000001' as const
+
+function expectedUninstallValidatorCalldata(validator: `0x${string}`) {
+  // Validator is at head of the mocked SentinelList → prev = SENTINEL,
+  // moduleDeInit = '0x'.
+  const deInitData = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'bytes' }],
+    [SENTINEL, '0x'],
+  )
+  return encodeFunctionData({
+    abi: UNINSTALL_MODULE_ABI,
+    functionName: 'uninstallModule',
+    args: [1n, validator, deInitData],
+  })
+}
 
 const MOCK_OWNER_A = '0xd1aefebdceefc094f1805b241fa5e6db63a9181a'
 const MOCK_OWNER_B = '0xeddfcb50d18f6d3d51c4f7cbca5ed6bdebc59817'
@@ -95,7 +143,7 @@ describe('ECDSA Actions', () => {
         {
           to: accountAddress,
           value: 0n,
-          data: '0xa71763a80000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000013fdb5234e4e3162a810f54d9f7e9800000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000',
+          data: expectedUninstallValidatorCalldata(OWNABLE_VALIDATOR_ADDRESS),
         },
       ])
     })

--- a/src/actions/ecdsa.ts
+++ b/src/actions/ecdsa.ts
@@ -31,8 +31,8 @@ function enable(owners: Address[], threshold = 1): LazyCallInput {
 function disable(): LazyCallInput {
   const module = getOwnableValidator(1, [])
   return {
-    async resolve({ config }) {
-      return getModuleUninstallationCalls(config, module)
+    async resolve({ chain, config }) {
+      return getModuleUninstallationCalls(config, chain, module)
     },
   }
 }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -28,8 +28,8 @@ function installModule(module: ModuleInput): LazyCallInput {
 function uninstallModule(module: ModuleInput): LazyCallInput {
   const moduleData: Module = getModule(module)
   return {
-    async resolve({ config }) {
-      return getModuleUninstallationCalls(config, moduleData)
+    async resolve({ chain, config }) {
+      return getModuleUninstallationCalls(config, chain, moduleData)
     },
   }
 }

--- a/src/actions/mfa.ts
+++ b/src/actions/mfa.ts
@@ -66,8 +66,8 @@ function changeThreshold(newThreshold: number): CalldataInput {
 function disable(): LazyCallInput {
   const module = getMultiFactorValidator(1, [])
   return {
-    async resolve({ config }) {
-      return getModuleUninstallationCalls(config, module)
+    async resolve({ chain, config }) {
+      return getModuleUninstallationCalls(config, chain, module)
     },
   }
 }

--- a/src/actions/passkeys.test.ts
+++ b/src/actions/passkeys.test.ts
@@ -1,5 +1,6 @@
+import { encodeAbiParameters, encodeFunctionData } from 'viem'
 import { base } from 'viem/chains'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { accountA, passkeyAccount } from '../../test/consts'
 import { RhinestoneSDK } from '..'
 import { resolveCallInputs } from '../execution/utils'
@@ -7,6 +8,53 @@ import {
   disable as disablePasskeys,
   enable as enablePasskeys,
 } from './passkeys'
+
+// `getModuleUninstallationCalls` reads the on-chain validator list to compute
+// the SentinelList `prev` pointer for the uninstall. The test account isn't
+// deployed, so stub the read with a known single-validator list. The address
+// is inlined because `vi.mock` is hoisted above any module-scope `const`.
+vi.mock('../modules/read', async (importActual) => {
+  const actual = await importActual<typeof import('../modules/read')>()
+  return {
+    ...actual,
+    getValidators: vi
+      .fn()
+      .mockResolvedValue(['0x0000000000578c4cb0e472a5462da43c495c3f33']),
+  }
+})
+
+const WEBAUTHN_VALIDATOR_ADDRESS =
+  '0x0000000000578c4cb0e472a5462da43c495c3f33' as const
+
+const UNINSTALL_MODULE_ABI = [
+  {
+    type: 'function',
+    name: 'uninstallModule',
+    inputs: [
+      { type: 'uint256', name: 'moduleTypeId' },
+      { type: 'address', name: 'module' },
+      { type: 'bytes', name: 'deInitData' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const
+
+const SENTINEL = '0x0000000000000000000000000000000000000001' as const
+
+function expectedUninstallValidatorCalldata(validator: `0x${string}`) {
+  // Validator is at head of the mocked SentinelList → prev = SENTINEL,
+  // moduleDeInit = '0x'.
+  const deInitData = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'bytes' }],
+    [SENTINEL, '0x'],
+  )
+  return encodeFunctionData({
+    abi: UNINSTALL_MODULE_ABI,
+    functionName: 'uninstallModule',
+    args: [1n, validator, deInitData],
+  })
+}
 
 const accountAddress = '0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0'
 
@@ -62,7 +110,7 @@ describe('Passkeys Actions', () => {
         {
           to: accountAddress,
           value: 0n,
-          data: '0xa71763a800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000578c4cb0e472a5462da43c495c3f3300000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000',
+          data: expectedUninstallValidatorCalldata(WEBAUTHN_VALIDATOR_ADDRESS),
         },
       ])
     })

--- a/src/actions/passkeys.ts
+++ b/src/actions/passkeys.ts
@@ -39,8 +39,8 @@ function disable(): LazyCallInput {
     },
   ])
   return {
-    async resolve({ config }) {
-      return getModuleUninstallationCalls(config, module)
+    async resolve({ chain, config }) {
+      return getModuleUninstallationCalls(config, chain, module)
     },
   }
 }

--- a/src/actions/smart-sessions.ts
+++ b/src/actions/smart-sessions.ts
@@ -31,12 +31,12 @@ function experimental_enable(): LazyCallInput {
  */
 function experimental_disable(): LazyCallInput {
   return {
-    async resolve({ config }) {
+    async resolve({ chain, config }) {
       const module = getSmartSessionValidator(config)
       if (!module) {
         return []
       }
-      return getModuleUninstallationCalls(config, module)
+      return getModuleUninstallationCalls(config, chain, module)
     },
   }
 }

--- a/src/actions/smart-sessions.ts
+++ b/src/actions/smart-sessions.ts
@@ -6,9 +6,8 @@ import {
 import {
   getEnableSessionCall,
   getSmartSessionValidator,
-  toSession,
 } from '../modules/validators/smart-sessions'
-import type { LazyCallInput, SessionInput } from '../types'
+import type { LazyCallInput, Session } from '../types'
 
 /**
  * Enable smart sessions
@@ -44,11 +43,19 @@ function experimental_disable(): LazyCallInput {
 
 /**
  * Enable a smart session
- * @param session session to enable
+ *
+ * The `session` must be a resolved `Session` (the return value of
+ * `toSession(...)`). Re-resolving it here would drop the explicit
+ * `permissions` — a `Session` only carries the derived `actions`, not the
+ * original `SessionDefinition.permissions` — which makes the on-chain digest
+ * computed by `SmartSessionLens.getAndVerifyDigest` diverge from the one
+ * signed in `getSessionDetails`, causing the emissary to reject the enable.
+ *
+ * @param session resolved session to enable
  * @returns Calls to enable the smart session
  */
 function experimental_enableSession(
-  session: SessionInput,
+  session: Session,
   enableSessionSignature: Hex,
   hashesAndChainIds: {
     chainId: bigint
@@ -57,16 +64,10 @@ function experimental_enableSession(
   sessionToEnableIndex: number,
 ): LazyCallInput {
   return {
-    async resolve({ accountAddress, chain, config }) {
+    async resolve({ accountAddress, config }) {
       return getEnableSessionCall(
         accountAddress,
-        toSession(
-          {
-            ...session,
-            chain,
-          },
-          { useDevContracts: config.useDevContracts },
-        ),
+        session,
         enableSessionSignature,
         hashesAndChainIds,
         sessionToEnableIndex,


### PR DESCRIPTION
Two independent bugs that surfaced while building an SSX e2e matrix against the orchestrator.

## 1. `experimental_enableSession` dropped scoped permissions

The function declared `session: SessionInput` and re-ran `toSession({ ...session, chain }, ...)` inside `resolve`. Callers pass a resolved `Session` (the return value of `toSession`) — `Session` carries the derived `actions` but not the original `SessionDefinition.permissions`. The re-resolution treated `permissions` as undefined and replaced the action set with the fallback `sudoAction`, so the on-chain digest computed by `SmartSessionLens.getAndVerifyDigest` no longer matched what `getSessionDetails` / `signEnableSession` had signed. The emissary then rejected the enable with a bundle simulation failure for any scoped session.

Parameter type is now `Session` and the resolved value passes straight to `getEnableSessionCall`. Unscoped sessions were unaffected because their action set already reduces to `[sudoAction]` either way; scoped sessions (single or multi) are now installable.

## 2. `uninstallModule` reverted before the SentinelList pop on Nexus / Safe7579 / Startale

These ERC-7579 accounts decode `uninstallModule(typeId, module, deInitData)`'s third argument as `(address prev, bytes moduleDeInit)`, where `prev` identifies the SentinelList neighbour to repair on removal. The SDK was passing module-level `deInitData` (`'0x'` in every call site) straight into that slot, so `abi.decode` reverted before the pop ran.

`getModuleUninstallationCalls` now reads the live validator list, derives the prev pointer (`SENTINEL` if the module is at the head), and wraps `module.deInitData` as `abi.encode(prev, module.deInitData)` for validator-type uninstalls on SentinelList accounts. Kernel and EOA paths are untouched — Kernel treats this slot as raw module bytes, EOA has no modules.

Every existing disable action — `ecdsa.disable`, `passkeys.disable`, `mfa.disable`, `experimental_disable` (smart sessions), and the generic `uninstallModule(module)` — was broken on Nexus before this. Scope here is validator type only; there are no public actions to disable executor modules today.

## Notes

- The `getModuleUninstallationCalls` signature is now async and takes a `Chain` — internal-only, no public API change. Consumers go through the `LazyCallInput` factories (`uninstallModule`, `ecdsa.disable`, etc.), whose `resolve()` already has chain context.
- Tested live against Base Sepolia (prod orchestrator). Same-chain scoped-single and scoped-multi enables now succeed; uninstall lifecycle now completes cleanly.
- Untested on Safe7579 and Startale — both implement the same ERC-7579 SentinelList contract as Nexus, so the wrapping should apply unchanged.