### PR TITLE
fix(execution): convert 7702 authorization chainId to CAIP-2 string

### DIFF
--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -87,6 +87,7 @@ import {
   type Quote,
   type SignData,
 } from '../orchestrator'
+import { toCaip2 } from '../orchestrator/caip2'
 import {
   type DestinationChain,
   getChainId,
@@ -1556,7 +1557,7 @@ async function submitIntentInternal(
     ...(authorizations.length > 0 && {
       authorizations: {
         sponsor: authorizations.map((authorization) => ({
-          chainId: authorization.chainId,
+          chainId: toCaip2(authorization.chainId),
           address: authorization.address,
           nonce: authorization.nonce,
           yParity: authorization.yParity ?? 0,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -237,7 +237,7 @@ interface QuoteResponse {
 type OriginSignature = Hex | { notarizedClaimSig: Hex; preClaimSig: Hex }
 
 interface SignedAuthorization {
-  chainId: number
+  chainId: string
   address: Address
   nonce: number
   yParity: number


### PR DESCRIPTION
The orchestrator's blanc version transform recursively converts every `chainId` field from CAIP-2 strings to numbers. The SDK was sending 7702 authorizations with `chainId` as a raw number (from viem), causing the orchestrator to throw `Invalid CAIP-2 chain id (expected string): 84532`.

This converts `authorization.chainId` with `toCaip2()` before including it in the submit request, and relaxes the local `SignedAuthorization` type to accept `number | string` for the wire shape.