### PR TITLE
fix(smart-sessions): pack time-frame initData as bytes16 || bytes16 (32 bytes)

### DIFF
--- a/.changeset/fix-time-frame-policy-encoding.md
+++ b/.changeset/fix-time-frame-policy-encoding.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Fix `getPolicyData('time-frame')` to match the deployed `TimeFramePolicy` contract. Was emitting `encodePacked(['uint48','uint48'], [validUntil, validAfter])`; now emits `encodeAbiParameters([uint48, uint48], [validAfter, validUntil])`. Sessions installed with a `time-frame` policy through the SDK now behave as intended.
+Fix `getPolicyData('time-frame')` to match the deployed `TimeFramePolicy` contract. Now emits `encodePacked(['uint128','uint128'], [validUntil, validAfter])` — a 32-byte `bytes16 validUntil || bytes16 validAfter` payload — instead of the previous 12-byte `uint48`/`uint48` packing (reverted on `initializeWithMultiplexer`) and the intermediate 64-byte ABI-encoded variant (init succeeded but wrote zeros so the policy always reverted at use time). Sessions installed with a `time-frame` policy through the SDK now behave as intended.

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -94,16 +94,21 @@ describe('getPolicyData', () => {
     expect(result.initData).toBe(expected)
   })
 
-  test('time-frame encodes (validAfter, validUntil) as ABI uint48 pair in seconds (ms → s)', () => {
+  test('time-frame packs (validUntil, validAfter) as bytes16 || bytes16 in seconds (ms → s)', () => {
     const validUntil = 1_800_000_000_000
     const validAfter = 1_700_000_000_000
     const result = getPolicyData({ type: 'time-frame', validUntil, validAfter })
     expect(result.policy).toBe(TIME_FRAME_POLICY_ADDRESS)
-    const expected = encodeAbiParameters(
-      [{ type: 'uint48' }, { type: 'uint48' }],
-      [Math.floor(validAfter / 1000), Math.floor(validUntil / 1000)],
+    const expected = encodePacked(
+      ['uint128', 'uint128'],
+      [
+        BigInt(Math.floor(validUntil / 1000)),
+        BigInt(Math.floor(validAfter / 1000)),
+      ],
     )
     expect(result.initData).toBe(expected)
+    // 32 bytes total (matches deployed TimeFramePolicy's `bytes16 || bytes16` layout)
+    expect((expected.length - 2) / 2).toBe(32)
   })
 
   test('usage-limit encodes limit as uint128', () => {

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -959,13 +959,14 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
       }
     }
     case 'time-frame': {
+      // Deployed TimeFramePolicy reads `bytes16 validUntil || bytes16 validAfter` (32 bytes).
       return {
         policy: TIME_FRAME_POLICY_ADDRESS,
-        initData: encodeAbiParameters(
-          [{ type: 'uint48' }, { type: 'uint48' }],
+        initData: encodePacked(
+          ['uint128', 'uint128'],
           [
-            Math.floor(policy.validAfter / 1000),
-            Math.floor(policy.validUntil / 1000),
+            BigInt(Math.floor(policy.validUntil / 1000)),
+            BigInt(Math.floor(policy.validAfter / 1000)),
           ],
         ),
       }


### PR DESCRIPTION
## Summary

The deployed `TimeFramePolicy` at `0x8177451511de0577b911c254e9551d981c26dc72` expects a 32-byte `initData` laid out as `bytes16 validUntil || bytes16 validAfter`. Our prior `encodeAbiParameters([uint48, uint48], [validAfter, validUntil])` produced 64 bytes whose first 16 and second 16 are both zero, so `initializeWithMultiplexer` wrote an empty config and every later policy check reverted with `PolicyNotInitialized`. (Before that, v1's `encodePacked(['uint48','uint48'], …)` produced 12 bytes and reverted at init outright — same revert reported by users on 1.5.1.)

Switch to `encodePacked(['uint128', 'uint128'], [validUntilSec, validAfterSec])` which produces exactly the 32-byte payload the deployed contract reads.

## Evidence

- Tenderly sim with 12-byte initData (`encodePacked(uint48,uint48)`) → reverts at `initializeWithMultiplexer` (sim `1d8513fa-4b1d-42e9-91c2-99f23b03b82f`)
- Tenderly sim with 64-byte initData (`encodeAbiParameters([uint48,uint48])`) → init succeeds but writes `validUntil=0, validAfter=0` (sim `0a09de90-af25-4893-abdb-7c4fb9384ee8`)
- Tenderly sim with the new 32-byte `bytes16 || bytes16` payload → succeeds with non-zero validUntil (sim `1f0bef10-eddd-43ef-b8f6-634f2316024a`)
- End-to-end repro in `sdk-examples/src/debug/tmp_time_frame_policy_v2.ts`: session enables and the fill lands on Base Sepolia (`0x461bc8ed07c898977fec9ae05b5e5a0526e638adf1c7be7a0121e92aed811fdd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)