### PR TITLE
chore(changeset): split out 32-byte time-frame fix into a new changeset

### DIFF
--- a/.changeset/fix-time-frame-policy-encoding.md
+++ b/.changeset/fix-time-frame-policy-encoding.md
@@ -1,5 +1,0 @@
----
-'@rhinestone/sdk': patch
----
-
-Fix `getPolicyData('time-frame')` to match the deployed `TimeFramePolicy` contract. Now emits `encodePacked(['uint128','uint128'], [validUntil, validAfter])` — a 32-byte `bytes16 validUntil || bytes16 validAfter` payload — instead of the previous 12-byte `uint48`/`uint48` packing (reverted on `initializeWithMultiplexer`) and the intermediate 64-byte ABI-encoded variant (init succeeded but wrote zeros so the policy always reverted at use time). Sessions installed with a `time-frame` policy through the SDK now behave as intended.

--- a/.changeset/time-frame-policy-32-bytes.md
+++ b/.changeset/time-frame-policy-32-bytes.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `getPolicyData('time-frame')` to match the deployed `TimeFramePolicy` contract. Now emits `encodePacked(['uint128','uint128'], [validUntil, validAfter])` — a 32-byte `bytes16 validUntil || bytes16 validAfter` payload. The previous 64-byte `encodeAbiParameters([uint48, uint48], …)` (shipped in 1.6.3) succeeded at `initializeWithMultiplexer` but wrote a zero config, so every later policy check reverted with `PolicyNotInitialized`. Sessions installed with a `time-frame` policy through the SDK now behave as intended.


### PR DESCRIPTION
## Summary

Repairs the modify/delete conflict on \`.changeset/fix-time-frame-policy-encoding.md\` in #527 (main → v1 port).

That changeset file was originally created for the intermediate 64-byte \`encodeAbiParameters([uint48, uint48], …)\` "fix" and was already consumed when v1 published 1.6.3 — so it no longer exists on the \`v1\` branch. My #526 edited the file in place to describe the new 32-byte fix, but since \`main\` had never run a release that consumed it, the file still existed and got carried forward as a modification. That puts \`main\` and \`v1\` in a modify/delete state.

This PR:

- Deletes \`.changeset/fix-time-frame-policy-encoding.md\` (matching v1's state).
- Adds a fresh \`.changeset/time-frame-policy-32-bytes.md\` describing only the new fix.

Verified locally that \`git merge origin/v1\` from this branch is now clean. Once this is merged, #527 should refresh without the conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)