### PR TITLE
ci(integration): add dev orchestrator target

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,6 +11,14 @@ on:
         options:
           - smoke
           - all
+      target:
+        description: "Orchestrator environment to run against"
+        required: true
+        default: "prod"
+        type: choice
+        options:
+          - prod
+          - dev
 
 concurrency:
   group: live-integration-tests
@@ -21,7 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      INTEGRATION_RHINESTONE_API_KEY: ${{ secrets.INTEGRATION_RHINESTONE_API_KEY }}
+      # When target=dev, point the SDK at the dev orchestrator. The SDK then
+      # auto-enables dev contract addresses (see createIntegrationSDK), so
+      # bundles simulate against the matching dev deployment. Empty for prod
+      # falls back to the SDK's built-in prod URL + prod contracts.
+      INTEGRATION_ORCHESTRATOR_URL: ${{ inputs.target == 'dev' && 'https://dev.v1.orchestrator.rhinestone.dev' || '' }}
+      INTEGRATION_RHINESTONE_API_KEY: ${{ inputs.target == 'dev' && secrets.INTEGRATION_RHINESTONE_API_KEY_DEV || secrets.INTEGRATION_RHINESTONE_API_KEY }}
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,9 +34,32 @@ jobs:
       # bundles simulate against the matching dev deployment. Empty for prod
       # falls back to the SDK's built-in prod URL + prod contracts.
       INTEGRATION_ORCHESTRATOR_URL: ${{ inputs.target == 'dev' && 'https://dev.v1.orchestrator.rhinestone.dev' || '' }}
-      INTEGRATION_RHINESTONE_API_KEY: ${{ inputs.target == 'dev' && secrets.INTEGRATION_RHINESTONE_API_KEY_DEV || secrets.INTEGRATION_RHINESTONE_API_KEY }}
 
     steps:
+      # Resolve the API key explicitly per target. A ternary like
+      # `target == 'dev' && DEV || PROD` would silently fall back to the prod
+      # key when the dev secret is unset (empty is falsy), sending the wrong
+      # credential to the dev endpoint. Fail fast instead.
+      - name: Resolve integration API key
+        env:
+          TARGET: ${{ inputs.target }}
+          PROD_API_KEY: ${{ secrets.INTEGRATION_RHINESTONE_API_KEY }}
+          DEV_API_KEY: ${{ secrets.INTEGRATION_RHINESTONE_API_KEY_DEV }}
+        run: |
+          if [ "$TARGET" = "dev" ]; then
+            if [ -z "$DEV_API_KEY" ]; then
+              echo "::error::target=dev requires the INTEGRATION_RHINESTONE_API_KEY_DEV secret"
+              exit 1
+            fi
+            echo "INTEGRATION_RHINESTONE_API_KEY=$DEV_API_KEY" >> "$GITHUB_ENV"
+          else
+            if [ -z "$PROD_API_KEY" ]; then
+              echo "::error::target=prod requires the INTEGRATION_RHINESTONE_API_KEY secret"
+              exit 1
+            fi
+            echo "INTEGRATION_RHINESTONE_API_KEY=$PROD_API_KEY" >> "$GITHUB_ENV"
+          fi
+
       - name: Check out the repo
         uses: actions/checkout@v4
 

--- a/test/integration/config/environment.ts
+++ b/test/integration/config/environment.ts
@@ -1,6 +1,7 @@
 import { RhinestoneSDK } from '../../../src/index'
 
 const API_KEY_ENV = 'INTEGRATION_RHINESTONE_API_KEY'
+const ORCHESTRATOR_URL_ENV = 'INTEGRATION_ORCHESTRATOR_URL'
 
 export function getIntegrationApiKey(): string {
   const apiKey = process.env[API_KEY_ENV]
@@ -10,8 +11,28 @@ export function getIntegrationApiKey(): string {
   return apiKey
 }
 
+// Optional endpoint override (e.g. dev orchestrator). Defaults to the SDK's
+// built-in prod URL when unset. Trailing slash trimmed so request URLs don't
+// double up on `/`.
+export function getIntegrationOrchestratorUrl(): string | undefined {
+  const url = process.env[ORCHESTRATOR_URL_ENV]
+  return url ? url.replace(/\/+$/, '') : undefined
+}
+
+// When pointing at the dev orchestrator, the SDK must also build bundles with
+// dev contract addresses (IntentExecutor etc.); otherwise the dev orchestrator
+// simulates against mismatched contracts and bundle submission fails. Tie the
+// two together: set dev contracts whenever a custom endpoint is configured, or
+// force it explicitly via INTEGRATION_USE_DEV_CONTRACTS.
+export function getIntegrationUseDevContracts(): boolean {
+  if (process.env.INTEGRATION_USE_DEV_CONTRACTS === 'true') return true
+  return getIntegrationOrchestratorUrl() !== undefined
+}
+
 export function createIntegrationSDK(): RhinestoneSDK {
   return new RhinestoneSDK({
     apiKey: getIntegrationApiKey(),
+    endpointUrl: getIntegrationOrchestratorUrl(),
+    useDevContracts: getIntegrationUseDevContracts(),
   })
 }


### PR DESCRIPTION
## Summary
Lets the integration suite run against the **dev** orchestrator, not just prod — so SDK changes can be validated against dev (which often has paired orchestrator changes deployed ahead of prod).

- `createIntegrationSDK` now reads `INTEGRATION_ORCHESTRATOR_URL` (endpoint override, trailing slash trimmed) and **auto-enables `useDevContracts`** whenever a custom endpoint is set (or explicitly via `INTEGRATION_USE_DEV_CONTRACTS=true`). Without dev contracts the SDK builds bundles with prod addresses (e.g. prod IntentExecutor) that the dev orchestrator can't simulate → bundle submission fails. Both default to prod/off, so **existing prod runs are unchanged**.
- `integration-tests.yaml` gains a `target` (prod/dev) input that wires the dev URL + `INTEGRATION_RHINESTONE_API_KEY_DEV` secret. Defaults to `prod`.

## Why
Validating PR #516 (mock-sig 1271 shape) end-to-end required the dev orchestrator + dev contracts. Running the suite against dev with only an endpoint override failed at bundle simulation because the SDK still used prod contract addresses. Tying `useDevContracts` to the endpoint override fixes that.

## Validation
With this change, the full SSX scenario (`ssx.itest.ts`, 20 cases incl. all `enabled`/steady-state paths) passes against dev:
```
INTEGRATION_ORCHESTRATOR_URL=https://dev.v1.orchestrator.rhinestone.dev \
INTEGRATION_RHINESTONE_API_KEY=<dev-key> \
bun run test:integration -- --run test/integration/scenarios/ssx.itest.ts
→ Tests 20 passed (20)
```

## Required before the dev target works in CI
Add the **`INTEGRATION_RHINESTONE_API_KEY_DEV`** secret in repo settings. Until then, dispatching with `target=dev` will fail at `getIntegrationApiKey` (missing key). The prod path is unaffected.

## Test plan
- [x] `tsc --noEmit` clean
- [x] SSX scenario 20/20 against dev (local)
- [ ] Add `INTEGRATION_RHINESTONE_API_KEY_DEV` repo secret
- [ ] Dispatch `Integration Tests` with `target=dev`, `suite=smoke` to confirm CI wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)