### PR TITLE
fix: validate sponsored execution inputs

### DIFF
--- a/src/jwt-server/jwt-server.test.ts
+++ b/src/jwt-server/jwt-server.test.ts
@@ -279,6 +279,45 @@ describe('shouldSponsor', () => {
       shouldSponsor({ destinationChainId: 'not-a-number' }, {}),
     ).rejects.toThrow('intentInput.destinationChainId must be a number')
   })
+
+  it('rejects malformed execution entries before calling filters', async () => {
+    let callsFilterCalled = false
+
+    await expect(
+      shouldSponsor(
+        {
+          ...validIntentInput,
+          destinationExecutions: [{ to: 'not-an-address', value: '0', data: '0x' }],
+        },
+        {
+          calls: () => {
+            callsFilterCalled = true
+            return true
+          },
+        },
+      ),
+    ).rejects.toThrow('intentInput.destinationExecutions[0].to must be an address')
+
+    expect(callsFilterCalled).toBe(false)
+  })
+
+  it('rejects non-hex execution calldata before calling filters', async () => {
+    await expect(
+      shouldSponsor(
+        {
+          ...validIntentInput,
+          destinationExecutions: [
+            {
+              to: '0xaaaa000000000000000000000000000000000000',
+              value: '0',
+              data: 'transfer()',
+            },
+          ],
+        },
+        {},
+      ),
+    ).rejects.toThrow('intentInput.destinationExecutions[0].data must be hex')
+  })
 })
 
 describe('createJwtSigner', () => {

--- a/src/jwt-server/sponsorship.ts
+++ b/src/jwt-server/sponsorship.ts
@@ -1,4 +1,4 @@
-import type { Address, Hex } from 'viem'
+import { isAddress, isHex, type Address, type Hex } from 'viem'
 
 export class SponsorshipDeniedError extends Error {
   constructor() {
@@ -49,13 +49,37 @@ function parseIntentInput(intentInput: unknown): ParsedIntentInput {
     throw new Error('intentInput.destinationExecutions must be an array')
   }
 
-  const calls = executions.map(
-    (exec: { to: string; value: string | number; data: string }) => ({
-      to: exec.to as Address,
+  const calls = executions.map((execution, index) => {
+    if (typeof execution !== 'object' || execution === null) {
+      throw new Error(
+        `intentInput.destinationExecutions[${index}] must be a non-null object`,
+      )
+    }
+
+    const exec = execution as Record<string, unknown>
+
+    if (typeof exec.to !== 'string' || !isAddress(exec.to)) {
+      throw new Error(
+        `intentInput.destinationExecutions[${index}].to must be an address`,
+      )
+    }
+    if (typeof exec.data !== 'string' || !isHex(exec.data)) {
+      throw new Error(
+        `intentInput.destinationExecutions[${index}].data must be hex`,
+      )
+    }
+    if (typeof exec.value !== 'string' && typeof exec.value !== 'number') {
+      throw new Error(
+        `intentInput.destinationExecutions[${index}].value must be a string or number`,
+      )
+    }
+
+    return {
+      to: exec.to,
       value: BigInt(exec.value),
-      data: exec.data as Hex,
-    }),
-  )
+      data: exec.data,
+    }
+  })
 
   return {
     chain: { id: chainId },


### PR DESCRIPTION
Validates sponsored execution entries before passing them to sponsorship filters.

Previously `shouldSponsor` only checked that `destinationExecutions` was an array, then cast each entry and coerced `value` with `BigInt`. That meant malformed `to` or `data` fields could reach user-defined sponsorship filters as if they were typed `Address`/`Hex`.

This adds explicit checks for each execution object, recipient address, hex calldata, and value type before filters run. It also adds regression coverage for malformed addresses and non-hex calldata.

Checked with:
- `git diff --check`

I could not run the Bun test suite locally because this machine does not have `bun` installed.