### PR TITLE
Expose orchestrator trace IDs from response headers

### DIFF
--- a/.changeset/trace-id-responses.md
+++ b/.changeset/trace-id-responses.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Expose orchestrator `traceId` values on successful quote, split, submit, and intent-status responses.

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -62,6 +62,8 @@ const POLL_ERROR_BACKOFF_MS = 1000
 const POLL_ERROR_BACKOFF_MAX_MS = 10000
 
 interface TransactionStatus {
+  /** OpenTelemetry trace ID for correlating the status response. */
+  traceId: IntentOpStatus['traceId']
   /** High-level intent status. */
   status: IntentOpStatus['status']
   /** The account address that owns this intent. */
@@ -328,6 +330,7 @@ async function waitForExecution(
         })
       }
       return {
+        traceId: intentStatus.traceId,
         status: intentStatus.status,
         accountAddress: intentStatus.accountAddress,
         operations: intentStatus.operations,
@@ -375,6 +378,7 @@ async function getIntentStatus(
   const orchestrator = getOrchestrator(authProvider, endpointUrl, headers)
   const internalStatus = await orchestrator.getIntent(intentId)
   return {
+    traceId: internalStatus.traceId,
     status: internalStatus.status,
     accountAddress: internalStatus.accountAddress,
     operations: internalStatus.operations,

--- a/src/execution/trace-id.test.ts
+++ b/src/execution/trace-id.test.ts
@@ -9,10 +9,10 @@ const authProvider = {
   getSubmitHeaders: async () => ({ 'x-api-key': 'test-key' }),
 }
 
-function mockJsonResponse(body: unknown) {
+function mockJsonResponse(body: unknown, traceId: string) {
   return new Response(JSON.stringify(body), {
     status: 200,
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', 'x-trace-id': traceId },
   })
 }
 
@@ -24,10 +24,12 @@ describe('execution trace IDs', () => {
 
   it('preserves traceId on submitted intent results without posting it', async () => {
     const fetch = vi.fn().mockResolvedValue(
-      mockJsonResponse({
-        traceId: 'trace-submit',
-        intentId: '123',
-      }),
+      mockJsonResponse(
+        {
+          intentId: '123',
+        },
+        'trace-submit',
+      ),
     )
     vi.stubGlobal('fetch', fetch)
 
@@ -55,12 +57,14 @@ describe('execution trace IDs', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        mockJsonResponse({
-          traceId: 'trace-status',
-          status: INTENT_STATUS_COMPLETED,
-          accountAddress: '0x0000000000000000000000000000000000000001',
-          operations: [],
-        }),
+        mockJsonResponse(
+          {
+            status: INTENT_STATUS_COMPLETED,
+            accountAddress: '0x0000000000000000000000000000000000000001',
+            operations: [],
+          },
+          'trace-status',
+        ),
       ),
     )
 
@@ -78,12 +82,14 @@ describe('execution trace IDs', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        mockJsonResponse({
-          traceId: 'trace-wait',
-          status: INTENT_STATUS_COMPLETED,
-          accountAddress: '0x0000000000000000000000000000000000000001',
-          operations: [],
-        }),
+        mockJsonResponse(
+          {
+            status: INTENT_STATUS_COMPLETED,
+            accountAddress: '0x0000000000000000000000000000000000000001',
+            operations: [],
+          },
+          'trace-wait',
+        ),
       ),
     )
 

--- a/src/execution/trace-id.test.ts
+++ b/src/execution/trace-id.test.ts
@@ -1,0 +1,108 @@
+import { mainnet } from 'viem/chains'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { INTENT_STATUS_COMPLETED } from '../orchestrator'
+import { getIntentStatus, waitForExecution } from './index'
+import { submitIntentInternal } from './utils'
+
+const authProvider = {
+  getHeaders: async () => ({ 'x-api-key': 'test-key' }),
+  getSubmitHeaders: async () => ({ 'x-api-key': 'test-key' }),
+}
+
+function mockJsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('execution trace IDs', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('preserves traceId on submitted intent results without posting it', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        traceId: 'trace-submit',
+        intentId: '123',
+      }),
+    )
+    vi.stubGlobal('fetch', fetch)
+
+    const result = await submitIntentInternal(
+      {
+        _authProvider: authProvider,
+        endpointUrl: 'https://orchestrator.test',
+      } as any,
+      undefined,
+      mainnet,
+      { intentId: '123', expiresAt: 9999999999 } as any,
+      [],
+      '0xdeadbeef',
+      undefined,
+      [],
+      false,
+    )
+
+    expect(result.traceId).toBe('trace-submit')
+    const [, init] = fetch.mock.calls[0]
+    expect(JSON.parse(init.body)).not.toHaveProperty('traceId')
+  })
+
+  it('preserves traceId on public getIntentStatus', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          traceId: 'trace-status',
+          status: INTENT_STATUS_COMPLETED,
+          accountAddress: '0x0000000000000000000000000000000000000001',
+          operations: [],
+        }),
+      ),
+    )
+
+    const status = await getIntentStatus(
+      authProvider,
+      'https://orchestrator.test',
+      '123',
+    )
+
+    expect(status.traceId).toBe('trace-status')
+  })
+
+  it('preserves traceId on public waitForExecution intent status', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          traceId: 'trace-wait',
+          status: INTENT_STATUS_COMPLETED,
+          accountAddress: '0x0000000000000000000000000000000000000001',
+          operations: [],
+        }),
+      ),
+    )
+
+    const promise = waitForExecution(
+      {
+        _authProvider: authProvider,
+        endpointUrl: 'https://orchestrator.test',
+      } as any,
+      {
+        type: 'intent',
+        id: '123',
+        traceId: 'trace-submit',
+        targetChain: mainnet.id,
+        expiresAt: 9999999999,
+      },
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(promise).resolves.toMatchObject({ traceId: 'trace-wait' })
+  })
+})

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -245,6 +245,7 @@ interface TransactionResult {
 }
 
 interface PreparedQuotes {
+  traceId: string
   best: Quote
   all: Quote[]
 }
@@ -1074,13 +1075,13 @@ async function prepareTransactionAsIntent(
     config.endpointUrl,
     config.headers,
   )
-  const { routes } = await orchestrator.createQuote(metaIntent)
+  const { routes, traceId } = await orchestrator.createQuote(metaIntent)
   const best = routes[0]
   if (!best) {
     throw new Error('Orchestrator returned no quote')
   }
   return {
-    quotes: { best, all: routes } satisfies PreparedQuotes,
+    quotes: { traceId, best, all: routes } satisfies PreparedQuotes,
     intentInput: serializedIntent,
   }
 }

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -239,6 +239,7 @@ interface UserOperationResult {
 interface TransactionResult {
   type: 'intent'
   id: string
+  traceId: string
   sourceChains?: number[]
   targetChain: number
   expiresAt: number
@@ -1580,6 +1581,7 @@ async function submitIntentInternal(
   return {
     type: 'intent',
     id: response.intentId,
+    traceId: response.traceId,
     sourceChains: sourceChains?.map((chain) => chain.id),
     targetChain: getChainId(targetChain),
     expiresAt: quote.expiresAt,

--- a/src/orchestrator/client.test.ts
+++ b/src/orchestrator/client.test.ts
@@ -6,10 +6,13 @@ const authProvider = {
   getSubmitHeaders: async () => ({ 'x-api-key': 'test-key' }),
 }
 
-function mockJsonResponse(body: unknown) {
+function mockJsonResponse(body: unknown, traceId?: string, status = 200) {
   return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { 'content-type': 'application/json' },
+    status,
+    headers: {
+      'content-type': 'application/json',
+      ...(traceId ? { 'x-trace-id': traceId } : {}),
+    },
   })
 }
 
@@ -22,19 +25,21 @@ describe('Orchestrator trace IDs', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        mockJsonResponse({
-          traceId: 'trace-quote',
-          routes: [
-            {
-              intentId: '1',
-              expiresAt: 123,
-              estimatedFillTime: { seconds: 3 },
-              settlementLayer: 'ACROSS',
-              signData: { origin: [], destination: null },
-              cost: { input: [], output: [], fees: {} },
-            },
-          ],
-        }),
+        mockJsonResponse(
+          {
+            routes: [
+              {
+                intentId: '1',
+                expiresAt: 123,
+                estimatedFillTime: { seconds: 3 },
+                settlementLayer: 'ACROSS',
+                signData: { origin: [], destination: null },
+                cost: { input: [], output: [], fees: {} },
+              },
+            ],
+          },
+          'trace-quote',
+        ),
       ),
     )
     const orchestrator = new Orchestrator(
@@ -60,10 +65,12 @@ describe('Orchestrator trace IDs', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        mockJsonResponse({
-          traceId: 'trace-split',
-          intents: [{ '0x0000000000000000000000000000000000000001': '1' }],
-        }),
+        mockJsonResponse(
+          {
+            intents: [{ '0x0000000000000000000000000000000000000001': '1' }],
+          },
+          'trace-split',
+        ),
       ),
     )
     const orchestrator = new Orchestrator(
@@ -83,12 +90,14 @@ describe('Orchestrator trace IDs', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        mockJsonResponse({
-          traceId: 'trace-status',
-          status: 'PENDING',
-          accountAddress: '0x0000000000000000000000000000000000000001',
-          operations: [],
-        }),
+        mockJsonResponse(
+          {
+            status: 'PENDING',
+            accountAddress: '0x0000000000000000000000000000000000000001',
+            operations: [],
+          },
+          'trace-status',
+        ),
       ),
     )
     const orchestrator = new Orchestrator(
@@ -105,10 +114,12 @@ describe('Orchestrator trace IDs', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        mockJsonResponse({
-          traceId: 'trace-submit',
-          intentId: '1',
-        }),
+        mockJsonResponse(
+          {
+            intentId: '1',
+          },
+          'trace-submit',
+        ),
       ),
     )
     const orchestrator = new Orchestrator(
@@ -119,6 +130,31 @@ describe('Orchestrator trace IDs', () => {
     const result = await orchestrator.createIntent({ intentId: '1' } as any)
 
     expect(result.traceId).toBe('trace-submit')
+  })
+
+  it('prefers x-trace-id over error body traceId', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse(
+          {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid request',
+            traceId: 'trace-body',
+          },
+          'trace-header',
+          400,
+        ),
+      ),
+    )
+    const orchestrator = new Orchestrator(
+      'https://orchestrator.test',
+      authProvider,
+    )
+
+    await expect(orchestrator.getIntent('1')).rejects.toMatchObject({
+      traceId: 'trace-header',
+    })
   })
 })
 

--- a/src/orchestrator/client.test.ts
+++ b/src/orchestrator/client.test.ts
@@ -1,15 +1,136 @@
-import { describe, expect, test } from 'vitest'
-import { encodeSettlementLayers } from './client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { encodeSettlementLayers, Orchestrator } from './client'
+
+const authProvider = {
+  getHeaders: async () => ({ 'x-api-key': 'test-key' }),
+  getSubmitHeaders: async () => ({ 'x-api-key': 'test-key' }),
+}
+
+function mockJsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('Orchestrator trace IDs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('preserves traceId on quote responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          traceId: 'trace-quote',
+          routes: [
+            {
+              intentId: '1',
+              expiresAt: 123,
+              estimatedFillTime: { seconds: 3 },
+              settlementLayer: 'ACROSS',
+              signData: { origin: [], destination: null },
+              cost: { input: [], output: [], fees: {} },
+            },
+          ],
+        }),
+      ),
+    )
+    const orchestrator = new Orchestrator(
+      'https://orchestrator.test',
+      authProvider,
+    )
+
+    const result = await orchestrator.createQuote({
+      account: {
+        address: '0x0000000000000000000000000000000000000001',
+        type: 'smartAccount',
+      },
+      destinationChainId: 1,
+      destinationExecutions: [],
+      tokenRequests: [],
+      options: {},
+    } as any)
+
+    expect(result.traceId).toBe('trace-quote')
+  })
+
+  it('preserves traceId on split responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          traceId: 'trace-split',
+          intents: [{ '0x0000000000000000000000000000000000000001': '1' }],
+        }),
+      ),
+    )
+    const orchestrator = new Orchestrator(
+      'https://orchestrator.test',
+      authProvider,
+    )
+
+    const result = await orchestrator.getSplit({
+      chain: { id: 1 },
+      tokens: { '0x0000000000000000000000000000000000000001': 1n },
+    } as any)
+
+    expect(result.traceId).toBe('trace-split')
+  })
+
+  it('preserves traceId on intent status responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          traceId: 'trace-status',
+          status: 'PENDING',
+          accountAddress: '0x0000000000000000000000000000000000000001',
+          operations: [],
+        }),
+      ),
+    )
+    const orchestrator = new Orchestrator(
+      'https://orchestrator.test',
+      authProvider,
+    )
+
+    const result = await orchestrator.getIntent('1')
+
+    expect(result.traceId).toBe('trace-status')
+  })
+
+  it('preserves traceId on submit responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          traceId: 'trace-submit',
+          intentId: '1',
+        }),
+      ),
+    )
+    const orchestrator = new Orchestrator(
+      'https://orchestrator.test',
+      authProvider,
+    )
+
+    const result = await orchestrator.createIntent({ intentId: '1' } as any)
+
+    expect(result.traceId).toBe('trace-submit')
+  })
+})
 
 describe('encodeSettlementLayers', () => {
-  test('include passes through unchanged', () => {
+  it('include passes through unchanged', () => {
     expect(encodeSettlementLayers({ include: ['ACROSS', 'ECO'] })).toEqual([
       'ACROSS',
       'ECO',
     ])
   })
 
-  test('exclude inverts against the known-layers universe', () => {
+  it('exclude inverts against the known-layers universe', () => {
     expect(encodeSettlementLayers({ exclude: ['RELAY'] })).toEqual([
       'ACROSS',
       'ECO',
@@ -20,7 +141,7 @@ describe('encodeSettlementLayers', () => {
     ])
   })
 
-  test('exclude with unknown layer is a no-op against the universe', () => {
+  it('exclude with unknown layer is a no-op against the universe', () => {
     // SAME_CHAIN isn't user-selectable on the orchestrator. Excluding it
     // should leave the universe intact rather than narrowing further.
     expect(encodeSettlementLayers({ exclude: ['SAME_CHAIN'] })).toEqual([

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -190,6 +190,7 @@ export class Orchestrator {
 
   private async fetch(url: string, options?: RequestInit): Promise<any> {
     const response = await fetch(url, options)
+    const traceId = response.headers?.get?.('x-trace-id') ?? undefined
 
     if (!response.ok) {
       let body: any
@@ -202,6 +203,7 @@ export class Orchestrator {
           traceId: '',
         }
       }
+      body = { ...body, traceId: traceId ?? body.traceId ?? '' }
       const retryAfter = response.headers?.get?.('retry-after') ?? undefined
       throw parseErrorEnvelope(
         body as ErrorEnvelope,
@@ -210,7 +212,11 @@ export class Orchestrator {
       )
     }
 
-    return response.json()
+    const body = await response.json()
+    if (body && typeof body === 'object' && !Array.isArray(body)) {
+      return { ...body, traceId: traceId ?? body.traceId }
+    }
+    return body
   }
 }
 

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -119,6 +119,7 @@ export class Orchestrator {
       body: JSON.stringify(body),
     })
     return {
+      traceId: json.traceId,
       intents: (json.intents as Record<string, string>[]).map(
         parseTokenAmountsRecord,
       ),
@@ -148,6 +149,7 @@ export class Orchestrator {
       headers: await this.getHeaders(),
     })
     return {
+      traceId: json.traceId,
       status: json.status,
       accountAddress: json.accountAddress,
       // Flatten orchestrator's per-chain items[] to one entry per chain.
@@ -344,7 +346,7 @@ export function encodeSettlementLayers(
 
 function decodeQuoteResponse(json: any): QuoteResponse {
   const routes = (json.routes ?? []) as any[]
-  return { routes: routes.map(decodeQuote) }
+  return { traceId: json.traceId, routes: routes.map(decodeQuote) }
 }
 
 function decodeQuote(route: any): Quote {

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -233,6 +233,7 @@ interface Quote {
 }
 
 interface QuoteResponse {
+  traceId: string
   routes: Quote[]
 }
 
@@ -272,6 +273,7 @@ interface IntentSubmitRequestInternal extends IntentSubmitRequest {
 }
 
 interface IntentSubmitResponse {
+  traceId: string
   intentId: string
 }
 
@@ -371,6 +373,7 @@ interface SplitIntentsInput {
 }
 
 interface SplitIntentsResult {
+  traceId: string
   intents: Record<Address, bigint>[]
 }
 
@@ -381,6 +384,8 @@ interface SplitIntentsResult {
  * orchestrator's per-chain `items[]` to a single entry per chain.
  */
 interface IntentOpStatus {
+  /** OpenTelemetry trace ID for correlating this orchestrator response. */
+  traceId: string
   /** High-level intent status. */
   status: IntentStatus
   /** The smart-account address that owns this intent. */


### PR DESCRIPTION
This updates the SDK to expose orchestrator trace IDs while treating x-trace-id as the source of truth from the HTTP response headers.

The SDK transport reads x-trace-id on successful and failed responses, attaches it to decoded SDK return objects, and passes it into orchestrator errors. This preserves the current SDK ergonomics for clients while keeping trace IDs out of orchestrator domain response bodies and out of all signed/submitted intent payloads.

Public flows carry the metadata through preparedTransaction.quotes, TransactionResult, getIntentStatus, and waitForExecution. Tests cover success responses, error precedence from headers, public submit/status flows, and verify that traceId is not posted in submit bodies.