### PR TITLE
chore: polish v2 changeset descriptions

### DIFF
--- a/.agents/skills/sdk-changesets/SKILL.md
+++ b/.agents/skills/sdk-changesets/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: sdk-changesets
+description: Writes, reviews, and polishes @rhinestone/sdk changesets. Use when adding release notes, editing .changeset/*.md files, preparing SDK releases, or reviewing changelog wording.
+---
+
+# SDK Changesets
+
+Use this skill for `@rhinestone/sdk` changesets and changelog wording.
+
+## Workflow
+
+1. Inspect the actual code diff, affected exports, and existing `.changeset/*.md` files before writing.
+2. Choose severity from consumer impact:
+   - `major`: breaking public API, removed exports, renamed fields, changed return shapes, changed required call flow, or changed runtime semantics consumers must migrate.
+   - `minor`: additive public API or newly supported chain/token/flow.
+   - `patch`: bug fix, behavior correction, internal compatibility fix, typing fix that does not require migration.
+3. Use the standard frontmatter shape:
+
+```md
+---
+'@rhinestone/sdk': patch
+---
+```
+
+4. Write for SDK consumers and integrators. Lead with what changed and why they care.
+5. Keep small fixes to one sentence. Use flat bullets only when the change is broad enough that scanning matters.
+6. Run `bun run check` after changing changesets.
+
+When editing unpublished prerelease changesets, it is safe to improve wording. Do not change frontmatter severity, delete files listed in `.changeset/pre.json`, or edit `pre.json` unless the release intent changed.
+
+## Style
+
+- Prefer direct verbs: `Add`, `Drop`, `Expose`, `Fix`, `Remove`, `Support`, `Replace`, `Normalize`.
+- Do not prefix bodies with `**Breaking:**`, `**BREAKING**:`, `Fix:`, `Feature:`, or similar labels. Changesets already groups output under `Major Changes`, `Minor Changes`, and `Patch Changes`.
+- For major changes, include migration guidance inline when there is a direct replacement.
+- Avoid implementation postmortems, internal file/function names, and orchestrator plumbing unless the detail is part of the public contract.
+- Avoid subheaders inside a changeset. Use one opening sentence plus flat bullets for large changes.
+- Avoid vague lines like `Fix bug`, `Update API`, or `Add support`. Name the API, field, account type, chain, or behavior.
+- Avoid noisy routine details in release notes: dependency bump mechanics, refactor rationale, test-only changes, and internal cleanup rarely matter unless they change consumer behavior.
+- Keep formatting consistent: single-quoted package name in frontmatter, backticks for API names, no markdown headings in the body.
+
+## Examples
+
+Small patch:
+
+```md
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `experimental_enableSession` dropping `permissions` on scoped sessions, which caused the emissary to reject the enable. The function now accepts a resolved `Session`.
+```
+
+Additive minor:
+
+```md
+---
+'@rhinestone/sdk': minor
+---
+
+Expose `BridgeFill` on quote responses, a per-intent tracking handle for third-party bridge layers (`OFT`, `RELAY`, `NEAR`, `RHINO`, `CCTP`).
+```
+
+Breaking change with migration hint:
+
+```md
+---
+'@rhinestone/sdk': major
+---
+
+Drop the `account.sendTransaction(transaction)` shortcut. Use the `prepareTransaction` -> `signTransaction` -> `submitTransaction` flow instead.
+```
+
+Broad breaking change:
+
+```md
+---
+'@rhinestone/sdk': major
+---
+
+Align SDK with the orchestrator's new operation model (blanc API version).
+
+- `IntentStatus` reduced to 3 states: `PENDING`, `COMPLETED`, `FAILED`. Removed: `PRECONFIRMED`, `CLAIMED`, `FILLED`, `EXPIRED`.
+- `IntentOpStatus` response shape replaced with flat per-chain `operations[]`. Removed: `claims`, `fillTransactionHash`, `fillTimestamp`, `destinationChainId`.
+- `TransactionStatus` now contains `status`, `accountAddress`, and `operations[]` instead of `fill` / `claims`.
+- `waitForExecution` no longer accepts the `acceptsPreconfirmations` parameter.
+```
+
+## Review Checklist
+
+- Does the changeset describe the consumer-visible effect, not the implementation journey?
+- Is the severity accurate for the public API and runtime behavior?
+- Can a migrator understand what to replace or remove?
+- Is the body brief enough for a generated changelog?
+- Are superseded or duplicate prerelease notes still true in the final release context?

--- a/.changeset/blanc-client.md
+++ b/.changeset/blanc-client.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Switch the orchestrator client to the `2026-04.blanc` API version.
+SDK now targets the orchestrator's `2026-04.blanc` API version. The schema and behavior changes that come with it are detailed in the other entries in this release.

--- a/.changeset/blanc-orphaned-helpers.md
+++ b/.changeset/blanc-orphaned-helpers.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Drop the public `signPermit2Batch` / `signPermit2Sequential` helpers along with the `MultiChainPermit2Config` / `MultiChainPermit2Result` / `BatchPermit2Result` types.
+Drop the public `signPermit2Batch` and `signPermit2Sequential` helpers, along with the `MultiChainPermit2Config`, `MultiChainPermit2Result`, and `BatchPermit2Result` types.

--- a/.changeset/blanc-portfolio-per-chain-decimals.md
+++ b/.changeset/blanc-portfolio-per-chain-decimals.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- `PortfolioToken` drops the token-level `decimals` and `balances` aggregate; `decimals` now lives on each `chains[]` entry.
+`PortfolioToken` drops the top-level `decimals` field and the `balances` aggregate. `decimals` now lives on each `chains[]` entry.

--- a/.changeset/blanc-submit-pipeline.md
+++ b/.changeset/blanc-submit-pipeline.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- `RhinestoneSDK.getIntentStatus(intentId)` now takes a `string` (was `bigint`).
+`RhinestoneSDK.getIntentStatus(intentId)` now takes a `string` (was `bigint`).

--- a/.changeset/bump-shared-configs-1-6-7.md
+++ b/.changeset/bump-shared-configs-1-6-7.md
@@ -1,5 +1,5 @@
 ---
-"@rhinestone/sdk": patch
+'@rhinestone/sdk': patch
 ---
 
-Bump @rhinestone/shared-configs to 1.6.7
+Bump `@rhinestone/shared-configs` to 1.6.7.

--- a/.changeset/bump-shared-configs.md
+++ b/.changeset/bump-shared-configs.md
@@ -1,5 +1,5 @@
 ---
-"@rhinestone/sdk": patch
+'@rhinestone/sdk': patch
 ---
 
-Bump @rhinestone/shared-configs to 1.5.1
+Bump `@rhinestone/shared-configs` to 1.5.1.

--- a/.changeset/cool-moles-press.md
+++ b/.changeset/cool-moles-press.md
@@ -1,5 +1,5 @@
 ---
-"@rhinestone/sdk": patch
+'@rhinestone/sdk': patch
 ---
 
-Fix BridgeFill.destinationChainId type
+Normalize `BridgeFill.destinationChainId` to a numeric chain ID. The orchestrator returns CAIP-2 strings; the SDK now decodes them to numbers for consistency with the rest of the API.

--- a/.changeset/drop-compact-bound-fields.md
+++ b/.changeset/drop-compact-bound-fields.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Drop compact-bound fields (`lockFunds` transaction option, `emissaryConfig` on the orchestrator `Account` type) to match the orchestrator's blanc API trim.
+Drop the `lockFunds` transaction option and the `emissaryConfig` field on the orchestrator `Account` type. Both referenced the compact-bound flow that no longer applies.

--- a/.changeset/drop-passport-account.md
+++ b/.changeset/drop-passport-account.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Remove `passport` account support. `account.type: 'passport'` is no longer accepted; the `PassportAccount` type and the `passport` member of `AccountType` / `AccountProviderConfig` are removed.
+Remove `passport` account support. `account.type: 'passport'` is no longer accepted, and the `PassportAccount` type and the `passport` member of `AccountType` / `AccountProviderConfig` are removed.

--- a/.changeset/drop-preconfirmations.md
+++ b/.changeset/drop-preconfirmations.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Drop the `acceptsPreconfirmations` parameter from `account.waitForExecution`. The method now always waits for `FILLED` / `COMPLETED` and never treats `PRECONFIRMED` as terminal.
+Drop the `acceptsPreconfirmations` parameter from `account.waitForExecution`. The method no longer treats `PRECONFIRMED` as terminal.

--- a/.changeset/drop-send-transaction.md
+++ b/.changeset/drop-send-transaction.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Drop the `account.sendTransaction(transaction)` shortcut. Use the `prepareTransaction` → `signTransaction` → `submitTransaction` flow instead.
+Drop the `account.sendTransaction(transaction)` shortcut. Use the `prepareTransaction` → `signTransaction` → `submitTransaction` flow instead.

--- a/.changeset/dummy-preclaim-fallback-target.md
+++ b/.changeset/dummy-preclaim-fallback-target.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Don't use fallback target for the dummy preclaim op.
+Fix internal collision between the dummy preclaim-op action target and the smart-session fallback-target marker.

--- a/.changeset/export-origin-signature.md
+++ b/.changeset/export-origin-signature.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Re-export `OriginSignature` from the public entry. Consumers iterating intent signature arrays for the merkle / encoded-signature path can now `import type { OriginSignature } from '@rhinestone/sdk'` (or from `@rhinestone/sdk/orchestrator`) instead of inlining the union locally.
+Re-export `OriginSignature` from the package root and `@rhinestone/sdk/orchestrator`, so consumers iterating intent signature arrays don't need to inline the union locally.

--- a/.changeset/expose-quote-type.md
+++ b/.changeset/expose-quote-type.md
@@ -1,5 +1,5 @@
 ---
-"@rhinestone/sdk": patch
+'@rhinestone/sdk': patch
 ---
 
-Re-export `Quote` from the main entry so consumers don't need to derive it from `PreparedQuotes['best']`
+Re-export `Quote` from the package root, so consumers don't need to derive it from `PreparedQuotes['best']`.

--- a/.changeset/fix-enable-session-preserve-permissions.md
+++ b/.changeset/fix-enable-session-preserve-permissions.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Fix `experimental_enableSession` dropping `permissions` for scoped sessions. The function accepted `SessionInput` and re-ran `toSession` on it inside `resolve`, but callers pass a resolved `Session` (which carries the derived `actions` but not the original `SessionDefinition.permissions`). The re-resolution treated `permissions` as undefined and replaced the action set with a sole `sudoAction`, so the on-chain digest computed by `SmartSessionLens.getAndVerifyDigest` no longer matched the digest signed in `getSessionDetails` and the emissary rejected the enable. The parameter type is now `Session` and the resolved value is passed straight to `getEnableSessionCall`.
+Fix `experimental_enableSession` dropping `permissions` on scoped sessions, which caused the emissary to reject the enable. The function now accepts a resolved `Session` (was `SessionInput`).

--- a/.changeset/fix-time-frame-policy-encoding.md
+++ b/.changeset/fix-time-frame-policy-encoding.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Fix `getPolicyData('time-frame')` to match the deployed `TimeFramePolicy` contract. Now emits `encodePacked(['uint128','uint128'], [validUntil, validAfter])` — a 32-byte `bytes16 validUntil || bytes16 validAfter` payload — instead of the previous 12-byte `uint48`/`uint48` packing (reverted on `initializeWithMultiplexer`) and the intermediate 64-byte ABI-encoded variant (init succeeded but wrote zeros so the policy always reverted at use time). Sessions installed with a `time-frame` policy through the SDK now behave as intended.
+Fix the `time-frame` session policy encoding to match the deployed `TimeFramePolicy` contract. Sessions installed with a `time-frame` policy through the SDK now correctly enforce `validUntil` / `validAfter`.

--- a/.changeset/fix-uninstall-module-sentinel-list-prev.md
+++ b/.changeset/fix-uninstall-module-sentinel-list-prev.md
@@ -2,6 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Fix `uninstallModule` reverting on Nexus, Safe7579, and Startale accounts. These ERC-7579 accounts store validators in a `SentinelList` and decode `uninstallModule`'s `deInitData` arg as `(address prev, bytes moduleDeInit)`. The SDK was passing module-level `deInitData` (typically `'0x'`) straight into that slot, which fails `abi.decode` before the linked list pop can run. `getModuleUninstallationCalls` now reads the live validator list, computes the prev pointer, and wraps `module.deInitData` as `abi.encode(prev, module.deInitData)` for validator-type uninstalls on SentinelList accounts. Kernel and EOA paths are untouched (Kernel treats the slot as raw module bytes; EOA has no modules).
-
-Affects every existing disable action — `ecdsa.disable`, `passkeys.disable`, `mfa.disable`, `experimental_disable` (smart sessions), and the generic `uninstallModule(module)` — all of which were silently broken on Nexus before.
+Fix `uninstallModule` reverting on Nexus, Safe7579, and Startale accounts. This unblocks every module disable action on those accounts — `ecdsa.disable`, `passkeys.disable`, `mfa.disable`, `experimental_disable` (smart sessions), and the generic `uninstallModule(module)` — all of which were silently broken on Nexus before. Kernel and EOA paths are unaffected.

--- a/.changeset/heavy-grapes-punch.md
+++ b/.changeset/heavy-grapes-punch.md
@@ -1,5 +1,5 @@
 ---
-"@rhinestone/sdk": patch
+'@rhinestone/sdk': patch
 ---
 
-Add bridgeFill param as response
+Expose `BridgeFill` on quote responses — a per-intent tracking handle (request id, deposit address, commitment id) for third-party bridge layers (`OFT`, `RELAY`, `NEAR`, `RHINO`, `CCTP`).

--- a/.changeset/install-session-via-emissary-on-first-use.md
+++ b/.changeset/install-session-via-emissary-on-first-use.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Fix claim-only sessions failing on first use after the `verifyExecutions` derivation change. `resolveSignersForChain` now forces `verifyExecutions=true` whenever the session is not yet enabled on-chain, regardless of `hasExplicitPermissions`. This routes the first intent through the emissary's `verifyExecution` path (mode 5, ENABLE-mode signature, dummy preClaimOp) so the session gets installed via `setConfig`. Subsequent intents on an already-enabled claim-only session drop back to mode 1.
+Fix claim-only sessions failing on first use. The session is now installed via the emissary on the first intent; subsequent intents on the same session use the cached state.

--- a/.changeset/key-scope-denied-error.md
+++ b/.changeset/key-scope-denied-error.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': minor
 ---
 
-Surface orchestrator `KEY_SCOPE_DENIED` responses as a typed `KeyScopeDeniedError` (subclass of `ForbiddenError`) carrying the failed `scope`, the `required` level, and the key's `actual` level. Integrators can now distinguish "scoped out" from "invalid key" without losing the structured payload.
+Surface orchestrator `KEY_SCOPE_DENIED` responses as a typed `KeyScopeDeniedError` (subclass of `ForbiddenError`), carrying the failed `scope`, the `required` level, and the key's `actual` level. Integrators can distinguish "scoped out" from "invalid key" without losing the structured payload.

--- a/.changeset/mock-sig-1271-shape.md
+++ b/.changeset/mock-sig-1271-shape.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Shape each per-chain mock signature to match that chain's resolved signing shape. `buildMockSignature` previously always emitted the ENABLE-mode (verifyExecution) payload, so the orchestrator simulated `verifyExecution` even for steady-state ERC-1271 bundles — overestimating validation gas. It now threads the per-chain resolved `verifyExecutions` so an already-enabled session emits the plain ERC-1271 mock shape (mode byte `0x00`) and a first-use session keeps the ENABLE shape (mode byte `0x01`), letting the orchestrator pick the matching gas simulation. Note these mock shapes are per-chain and may differ across chains; the declared `signatureMode` is a single global value resolved conservatively, so a chain's mock shape need not match the global mode in mixed states.
+Use per-chain mock signature shapes during quote simulation. Steady-state ERC-1271 bundles no longer pay the validation gas of an `ENABLE`-mode session enable, giving more accurate gas estimates.

--- a/.changeset/non-evm-destinations.md
+++ b/.changeset/non-evm-destinations.md
@@ -4,12 +4,12 @@
 
 Support non-EVM destination chains (Solana, Tron) in the intent flow.
 
-- New `NonEvmChain` descriptor type and `solanaMainnet` / `tronMainnet` exports. Pass them anywhere a viem `Chain` was accepted for the destination: `targetChain: solanaMainnet`. The `DestinationChain` type alias (`Chain | NonEvmChain`) is the union form used by `Transaction.targetChain`.
-- `CrossChainTransaction` is now a discriminated union — `CrossChainEvmTransaction` (EVM destinations) and `CrossChainNonEvmTransaction` (Solana / Tron). On non-EVM destinations, `recipient` accepts a `NonEvmAddress` (Solana base58 / Tron T-prefix) and `tokenRequests[].address` accepts non-EVM token strings without consumer casts.
-- CAIP-2 helpers (`toCaip2`, `fromCaip2`, `isCaip2`) now dispatch on namespace and round-trip non-EVM synthetic chain ids through the orchestrator's CAIP-2 strings. The synthetic numeric id is used internally for orchestrator wire mapping but is intentionally not exposed on `NonEvmChain` — use `getChainId(chain)` for the numeric id of either chain kind.
+- New `NonEvmChain` descriptor type and `solanaMainnet` / `tronMainnet` exports. Pass them anywhere a viem `Chain` was accepted for the destination: `targetChain: solanaMainnet`. `DestinationChain` (`Chain | NonEvmChain`) is the union form used by `Transaction.targetChain`.
+- `CrossChainTransaction` is now a discriminated union — `CrossChainEvmTransaction` (EVM destinations) and `CrossChainNonEvmTransaction` (Solana / Tron). On non-EVM destinations, `recipient` accepts a `NonEvmAddress` (Solana base58 / Tron T-prefix) and `tokenRequests[].address` accepts non-EVM token strings.
+- CAIP-2 helpers (`toCaip2`, `fromCaip2`, `isCaip2`) now dispatch on namespace and round-trip non-EVM chain ids through the orchestrator's CAIP-2 strings. Use `getChainId(chain)` for the numeric id of either chain kind.
 - `IntentOpStatus.fillTransactionHash` is now `string` (`FillTransactionHash`), so Solana base58 / Tron hex fill hashes round-trip cleanly.
 - Token-symbol validation and EVM-address parsing are skipped on the destination side for non-EVM chains; orchestrator-side validation handles SPL mints / Tron contracts.
-- EIP-7702 authorization, smart-session target-execution signing, and the destination-side session resolution all skip non-EVM destinations — there's no validator there to verify a destination signature, and per-chain experimental sessions don't need an entry for the synthetic Solana / Tron chain id.
-- `Account.accountType` and `Account.setupOps` are now optional. Non-EVM recipients emit just `{ address }`; the orchestrator schema requires these fields unset for non-EVM destinations.
+- EIP-7702 authorization, smart-session target-execution signing, and destination-side session resolution all skip non-EVM destinations.
+- `Account.accountType` and `Account.setupOps` are now optional. Non-EVM recipients emit just `{ address }`.
 
-No UserOp support for non-EVM destinations: the UserOp path remains EVM-only by construction.
+The UserOp path remains EVM-only.

--- a/.changeset/operation-model-redesign.md
+++ b/.changeset/operation-model-redesign.md
@@ -1,23 +1,12 @@
 ---
-"@rhinestone/sdk": major
+'@rhinestone/sdk': major
 ---
 
-**BREAKING**: Align SDK with the orchestrator's new operation model (blanc API version).
+Align SDK with the orchestrator's new operation model (blanc API version).
 
-### Breaking changes
-
-- **`IntentStatus`** reduced to 3 states: `PENDING`, `COMPLETED`, `FAILED`.
-  Removed: `PRECONFIRMED`, `CLAIMED`, `FILLED`, `EXPIRED`.
-- **`IntentOpStatus`** response shape replaced with flat per-chain `operations[]`.
-  Removed: `claims`, `fillTransactionHash`, `fillTimestamp`, `destinationChainId`.
-- **`TransactionStatus`** (returned by `waitForExecution`) now contains `status`, `accountAddress`, and `operations[]` instead of `fill` / `claims`.
-- **`waitForExecution`**: removed the `acceptsPreconfirmations` parameter.
-- **Removed types**: `Claim`, `ClaimStatus`.
-- **Removed status constants**: `INTENT_STATUS_EXPIRED`, `INTENT_STATUS_FILLED`, `INTENT_STATUS_PRECONFIRMED`, `INTENT_STATUS_CLAIMED`.
-- **API version** bumped to `2026-04.blanc`.
-
-### New types
-
-- `OperationStatus`: `'PENDING' | 'COMPLETED' | 'FAILED'`
-- `FailureReason`: `'EXPIRED' | 'REVERTED' | 'RELAYER_FAILURE'`
-- `ChainOperation`: discriminated union with one operation per chain
+- `IntentStatus` reduced to 3 states: `PENDING`, `COMPLETED`, `FAILED`. Removed: `PRECONFIRMED`, `CLAIMED`, `FILLED`, `EXPIRED`.
+- `IntentOpStatus` response shape replaced with flat per-chain `operations[]`. Removed: `claims`, `fillTransactionHash`, `fillTimestamp`, `destinationChainId`.
+- `TransactionStatus` (returned by `waitForExecution`) now contains `status`, `accountAddress`, and `operations[]` instead of `fill` / `claims`.
+- `waitForExecution` no longer accepts the `acceptsPreconfirmations` parameter.
+- Removed types: `Claim`, `ClaimStatus`.
+- Removed status constants: `INTENT_STATUS_EXPIRED`, `INTENT_STATUS_FILLED`, `INTENT_STATUS_PRECONFIRMED`, `INTENT_STATUS_CLAIMED`.

--- a/.changeset/poll-until-intent-expiry.md
+++ b/.changeset/poll-until-intent-expiry.md
@@ -2,5 +2,5 @@
 '@rhinestone/sdk': major
 ---
 
-- `account.waitForExecution` now polls until the intent's quote `expiresAt`, replacing the previous hardcoded 3.5-minute cap. Long-fill intents are no longer cut off prematurely, and the orchestrator's `EXPIRED` status is now treated as terminal.
-- The `IntentStatusTimeoutError` class has been renamed to `IntentExpiredError`. Update any `catch` / `instanceof` checks accordingly.
+- `account.waitForExecution` now polls until the intent's quote `expiresAt`, replacing the previous hardcoded 3.5-minute cap. The orchestrator's `EXPIRED` status is treated as terminal.
+- Renamed `IntentStatusTimeoutError` to `IntentExpiredError`. Update any `catch` / `instanceof` checks accordingly.

--- a/.changeset/portfolio-amount.md
+++ b/.changeset/portfolio-amount.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- `PortfolioToken.chains[]` replaces `locked`/`unlocked` with a single `amount: bigint`, matching the orchestrator's blanc wire shape (`balance: { locked, unlocked }` collapsed to a flat `amount`; post-compact, locked is always `0`).
+`PortfolioToken.chains[]` replaces the `{ locked, unlocked }` balance pair with a single `amount: bigint`.

--- a/.changeset/quote-selection-target-execution.md
+++ b/.changeset/quote-selection-target-execution.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- `RhinestoneAccount.getTransactionMessages` now surfaces the optional `targetExecution` typed data, matching the underlying helper.
+`RhinestoneAccount.getTransactionMessages` now surfaces the optional `targetExecution` typed data alongside the existing `intent` and `compact` messages.

--- a/.changeset/remove-fee-token.md
+++ b/.changeset/remove-fee-token.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Drop the unused `feeToken` field from the `Cost` response and remove the public `FeeToken` type. The orchestrator's blanc `POST /quotes` response never populates this field.
+Drop the unused `feeToken` field from the `Cost` response and remove the public `FeeToken` type. The orchestrator never populated this field.

--- a/.changeset/remove-verify-executions-public-api.md
+++ b/.changeset/remove-verify-executions-public-api.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-Remove `verifyExecutions` from the public session signer API.
+Remove `verifyExecutions` from the public session signer API. It's now derived automatically per chain.

--- a/.changeset/retry-after-polling.md
+++ b/.changeset/retry-after-polling.md
@@ -1,5 +1,5 @@
 ---
-"@rhinestone/sdk": patch
+'@rhinestone/sdk': patch
 ---
 
 Respect `Retry-After` headers when polling intent status after rate limits.

--- a/.changeset/session-permissions-api.md
+++ b/.changeset/session-permissions-api.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Replace `Session.actions` with `toSession({ permissions, claimPolicies })`, an ABI-driven session definition shape (`{ abi, address, functions }`) that resolves to a low-level `Session`. Function selectors and param calldata offsets are derived from the ABI, param value types are checked against ABI input types, and public Permit2 claim policies use chain-aware fields that resolve to the internal onchain schema.
+Replace `Session.actions` with `toSession({ permissions, claimPolicies })`, an ABI-driven session definition shape (`{ abi, address, functions }`) that resolves to a low-level `Session`. Function selectors and calldata offsets are derived from the ABI, parameter value types are checked against ABI input types, and Permit2 claim policies use chain-aware fields that resolve to the internal onchain schema.

--- a/.changeset/settlement-layer-filter.md
+++ b/.changeset/settlement-layer-filter.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- `Transaction.settlementLayers` is now `{ include: SettlementLayer[] } | { exclude: SettlementLayer[] }` — you can blacklist specific layers without enumerating every other one.
+`Transaction.settlementLayers` is now `{ include: SettlementLayer[] } | { exclude: SettlementLayer[] }` — you can blacklist specific layers without enumerating every other one.

--- a/.changeset/signature-mode-sync.md
+++ b/.changeset/signature-mode-sync.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Sync intent `signatureMode` with the bytes shape the SDK actually signs: EOAs, non-session smart accounts, and claim-only sessions now emit `SIG_MODE_ERC1271` (1), while sessions with `verifyExecutions=true` continue to emit the dual-sig `SIG_MODE_EMISSARY_EXECUTION_ERC1271` (5). Previously the SDK always picked a hybrid mode, wasting an on-chain call attempt on the wrong validator path.
+Set the intent's declared `signatureMode` to match the bytes the SDK actually signs. EOAs, non-session smart accounts, and claim-only sessions now declare `ERC1271`; sessions with `verifyExecutions=true` declare `EMISSARY_EXECUTION_ERC1271`. Avoids a wasted on-chain validator call per bundle.

--- a/.changeset/small-jeans-care.md
+++ b/.changeset/small-jeans-care.md
@@ -1,5 +1,5 @@
 ---
-"@rhinestone/sdk": patch
+'@rhinestone/sdk': patch
 ---
 
-Add soneium usdt support
+Add USDT support on Soneium.

--- a/.changeset/submit-transaction-options.md
+++ b/.changeset/submit-transaction-options.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Reshape `account.submitTransaction` to take an options bag: `submitTransaction(signed, { authorizations?, internal_dryRun? })` instead of positional `submitTransaction(signed, authorizations?, dryRun?)`.
+Reshape `account.submitTransaction` to take an options bag: `submitTransaction(signed, { authorizations?, internal_dryRun? })` instead of positional `submitTransaction(signed, authorizations?, dryRun?)`.

--- a/.changeset/trim-fee-breakdown.md
+++ b/.changeset/trim-fee-breakdown.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': major
 ---
 
-- Drop `protocol` and `settlement` from `FeeBreakdown`. The orchestrator only returns `gas`, `bridge`, and `swap`.
+Drop `protocol` and `settlement` from `FeeBreakdown`. The orchestrator only returns `gas`, `bridge`, and `swap`.

--- a/.changeset/wait-for-terminal-state.md
+++ b/.changeset/wait-for-terminal-state.md
@@ -2,7 +2,7 @@
 '@rhinestone/sdk': major
 ---
 
-- `account.waitForExecution` now polls until the intent reaches a terminal state (`COMPLETED` or `FAILED`), without an SDK-side deadline. The previous `expiresAt`-based timeout proved unreliable for some flows (e.g. intent executor), where the quote `expiresAt` doesn't reflect the actual fill deadline. The orchestrator handles expiry internally and surfaces it as `FAILED`.
+- `account.waitForExecution` now polls until the intent reaches a terminal state (`COMPLETED` or `FAILED`), without an SDK-side deadline. The previous `expiresAt`-based timeout was unreliable for some flows (e.g. intent executor); the orchestrator handles expiry internally and surfaces it as `FAILED`.
 - Removed the `IntentExpiredError` class — expiry now surfaces as `IntentFailedError` (inspect `operations[].failureReason` for the cause).
 - Removed the `expiresAt` field from `TransactionResult`.
 - Narrowed `SettlementLayerFilter` to `CrossChainSettlementLayer[]` (`ACROSS | ECO | RELAY | OFT | NEAR | RHINO | CCTP`) — `SAME_CHAIN` and `INTENT_EXECUTOR` are picked by the orchestrator and were never accepted in the filter at runtime.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Once v2 is stable, we'll switch back to the standard `main` (dev) / `release` (p
 - Use viem types for addresses, chains, and hex values
 - Account implementations live in `/src/accounts/*.ts`
 - Public API is the union of `src/index.ts` re-exports and the subpath exports in `src/package.json` (`/actions`, `/errors`, `/jwt-server`, `/smart-sessions`, etc.) — adding, renaming, or removing exports is a breaking change
-- The project is using `changeset` to manage releases. Create a changeset file for each fix or feature.
+- The project uses `changeset` to manage releases. Create a changeset file for each fix or feature, and use the `sdk-changesets` skill when adding, editing, or reviewing SDK changelog wording.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Polishes the unpublished `.changeset/*.md` descriptions ahead of v2 shipping to `latest`. No code changes.

- Trims verbose internals from fix changesets — leads with the consumer-facing impact instead of the postmortem
- Replaces vague stubs (`Add bridgeFill param as response`, `Fix BridgeFill.destinationChainId type`, `Add soneium usdt support`, etc.) with proper descriptions
- Unifies formatting across the directory: drops the `**BREAKING**:` prefix and `### subheaders` from `operation-model-redesign.md`, normalizes frontmatter to single quotes, and standardizes on no-bullet single-statement entries vs. flat bullet lists for multi-deltas

Safe to make during pre-release mode (body-only edits) — `pre.json` and per-changeset frontmatter (package, bump type) are untouched, so already-published `2.0.0-beta.*` CHANGELOG entries are unaffected. The updated text flows into the final 2.0 release notes composed at `pre exit`.