### PR TITLE
feat: update smart session policies

### DIFF
--- a/.changeset/smart-session-policy-addresses.md
+++ b/.changeset/smart-session-policy-addresses.md
@@ -1,0 +1,17 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Update SmartSession policy singleton addresses to the canonical vanity deployments from `rhinestonewtf/yeet#172` and `#174` (Safe Singleton Factory, leading-zero prefixes): `SudoPolicy`, `TimeFramePolicy`, `UsageLimitPolicy`, `ValueLimitPolicy`, `UniversalActionPolicy`, `ERC20SpendingLimitPolicy`.
+
+Add `arg-policy` to the `Policy` union — the expression-tree successor to `universal-action`. Accepts an `ArgPolicyExpression` AST (`rule` / `not` / `and` / `or`); compiled internally to the bit-packed `uint256[]` node layout expected by `ArgPolicy` (`0x0000000000167edE64D8751daACDdC0312565a73`). Use when a session needs disjunction; plain AND-of-rules stays on `universal-action` (cheaper init).
+
+Extend `definePermissions` with `anyOf` constraint form: `{ anyOf: [v1, v2, ...] }` on a param compiles to an OR of EQUAL rules. When any param uses `anyOf`, the whole function emits `arg-policy`; otherwise it stays on `universal-action` for compatibility.
+
+Add per-function sugar fields to `definePermissions` that compose with `params` and raw `policies`:
+- `maxUses` → `usage-limit` policy (per-action counter, not session-wide)
+- `validUntil` / `validAfter` (`Date | number`) → `time-frame` policy; one-sided forms default the other end
+- `valueLimit` → `value-limit` policy; **type-gated to payable functions** + runtime throw
+- `spendingLimit` → `spending-limits` policy; **type-gated to ERC-20-transfer-shaped functions** (`(address,uint256)` / `(address,address,uint256)`) + runtime throw to prevent silently-wrong calldata decoding
+
+Add `arg-policy` to the `Policy` union — the expression-tree successor to `universal-action`. Accepts an `ArgPolicyExpression` AST with `rule` / `not` / `and` / `or` nodes; compiled internally to the bit-packed `uint256[]` node layout expected by `ArgPolicy` (`0x0000000000167edE64D8751daACDdC0312565a73`). Use when a session needs disjunction (e.g. allowlist of recipients); plain AND-of-rules is still simpler with `universal-action`.

--- a/src/actions/permissions.test.ts
+++ b/src/actions/permissions.test.ts
@@ -1,0 +1,926 @@
+import { type Address, erc20Abi, toFunctionSelector } from 'viem'
+import { base } from 'viem/chains'
+import { describe, expect, test } from 'vitest'
+import { accountA } from '../../test/consts'
+import { getSessionData } from '../modules/validators/smart-sessions'
+import type { Session } from '../types'
+import { definePermissions } from './permissions'
+
+const USDC: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const RECIPIENT: Address = '0x1111111111111111111111111111111111111111'
+
+// ---------------------------------------------------------------------------
+// A. Basic param rules
+// ---------------------------------------------------------------------------
+
+describe('definePermissions', () => {
+  test('ERC-20 transfer with param rules', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+            amount: { condition: 'lessThan', value: 1000n },
+          },
+        },
+      },
+    })
+
+    expect(actions).toHaveLength(1)
+    const action = actions[0]
+    expect(action.target).toBe(USDC)
+    expect(action.selector).toBe(
+      toFunctionSelector(
+        'function transfer(address recipient, uint256 amount)',
+      ),
+    )
+    expect(action.policies).toHaveLength(1)
+
+    const policy = action.policies![0]
+    expect(policy.type).toBe('universal-action')
+    if (policy.type !== 'universal-action') throw new Error('wrong type')
+
+    expect(policy.valueLimitPerUse).toBe(0n)
+    expect(policy.rules).toHaveLength(2)
+
+    const recipientRule = policy.rules.find((r) => r.calldataOffset === 0n)!
+    expect(recipientRule.condition).toBe('equal')
+    expect(recipientRule.referenceValue).toBe(RECIPIENT)
+
+    const amountRule = policy.rules.find((r) => r.calldataOffset === 32n)!
+    expect(amountRule.condition).toBe('lessThan')
+    expect(amountRule.referenceValue).toBe(1000n)
+  })
+
+  // ---------------------------------------------------------------------------
+  // B. Multiple functions
+  // ---------------------------------------------------------------------------
+
+  test('multiple functions on the same contract', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          policies: [{ type: 'usage-limit', limit: 10n }],
+        },
+        approve: {
+          policies: [{ type: 'usage-limit', limit: 5n }],
+        },
+      },
+    })
+
+    expect(actions).toHaveLength(2)
+    const names = actions.map((a) => a.selector).sort()
+    const expectedSelectors = [
+      toFunctionSelector('function transfer(address to, uint256 value)'),
+      toFunctionSelector('function approve(address spender, uint256 value)'),
+    ].sort()
+    expect(names).toEqual(expectedSelectors)
+  })
+
+  // ---------------------------------------------------------------------------
+  // C. Policies without params
+  // ---------------------------------------------------------------------------
+
+  test('policies only — no universal-action generated', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        approve: {
+          policies: [{ type: 'sudo' }],
+        },
+      },
+    })
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].policies).toEqual([{ type: 'sudo' }])
+  })
+
+  // ---------------------------------------------------------------------------
+  // D. Params + policies combined
+  // ---------------------------------------------------------------------------
+
+  test('user policies come before generated universal-action', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          policies: [{ type: 'usage-limit', limit: 3n }],
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+          },
+        },
+      },
+    })
+
+    const policies = actions[0].policies!
+    expect(policies).toHaveLength(2)
+    expect(policies[0].type).toBe('usage-limit')
+    expect(policies[1].type).toBe('universal-action')
+  })
+
+  // ---------------------------------------------------------------------------
+  // E. Third parameter offset
+  // ---------------------------------------------------------------------------
+
+  test('calldataOffset for third parameter is 64n', () => {
+    const customAbi = [
+      {
+        type: 'function',
+        name: 'foo',
+        inputs: [
+          { name: 'a', type: 'address' },
+          { name: 'b', type: 'uint256' },
+          { name: 'c', type: 'bool' },
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    const actions = definePermissions({
+      abi: customAbi,
+      address: USDC,
+      functions: {
+        foo: {
+          params: {
+            c: { condition: 'equal', value: true },
+          },
+        },
+      },
+    })
+
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong type')
+    expect(policy.rules[0].calldataOffset).toBe(64n)
+  })
+
+  // ---------------------------------------------------------------------------
+  // F. Boolean conversion
+  // ---------------------------------------------------------------------------
+
+  test('boolean true → 1n, false → 0n', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'setFlag',
+        inputs: [{ name: 'flag', type: 'bool' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    const actionsTrue = definePermissions({
+      abi,
+      address: USDC,
+      functions: {
+        setFlag: { params: { flag: { condition: 'equal', value: true } } },
+      },
+    })
+    const actionsFalse = definePermissions({
+      abi,
+      address: USDC,
+      functions: {
+        setFlag: { params: { flag: { condition: 'equal', value: false } } },
+      },
+    })
+
+    const ruleT = (actionsTrue[0].policies![0] as any).rules[0]
+    const ruleF = (actionsFalse[0].policies![0] as any).rules[0]
+    expect(ruleT.referenceValue).toBe(1n)
+    expect(ruleF.referenceValue).toBe(0n)
+  })
+
+  // ---------------------------------------------------------------------------
+  // G. Dynamic param type → throws
+  // ---------------------------------------------------------------------------
+
+  test('throws for dynamic parameter types', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'send',
+        inputs: [{ name: 'data', type: 'bytes' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    expect(() =>
+      definePermissions({
+        abi,
+        address: USDC,
+        functions: {
+          send: {
+            params: {
+              // @ts-expect-error — value is `never` for dynamic types
+              data: { condition: 'equal', value: '0x1234' },
+            },
+          },
+        },
+      }),
+    ).toThrow(/dynamic type/)
+  })
+
+  // ---------------------------------------------------------------------------
+  // H. Overloaded function → throws
+  // ---------------------------------------------------------------------------
+
+  test('throws for overloaded functions', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'transfer',
+        inputs: [
+          { name: 'to', type: 'address' },
+          { name: 'amount', type: 'uint256' },
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+      {
+        type: 'function',
+        name: 'transfer',
+        inputs: [
+          { name: 'from', type: 'address' },
+          { name: 'to', type: 'address' },
+          { name: 'amount', type: 'uint256' },
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    expect(() =>
+      definePermissions({
+        abi,
+        address: USDC,
+        functions: {
+          transfer: { policies: [{ type: 'sudo' }] },
+        },
+      }),
+    ).toThrow(/overloaded/)
+  })
+
+  // ---------------------------------------------------------------------------
+  // I. Unknown param name → throws
+  // ---------------------------------------------------------------------------
+
+  test('throws for unknown parameter name', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'foo',
+        inputs: [{ name: 'bar', type: 'uint256' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    expect(() =>
+      definePermissions({
+        abi,
+        address: USDC,
+        functions: {
+          foo: {
+            params: {
+              // @ts-expect-error — 'baz' doesn't exist
+              baz: { condition: 'equal', value: 1n },
+            },
+          },
+        },
+      }),
+    ).toThrow(/not found/)
+  })
+
+  // ---------------------------------------------------------------------------
+  // J. Empty functions → []
+  // ---------------------------------------------------------------------------
+
+  test('empty functions object returns empty array', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {},
+    })
+    expect(actions).toEqual([])
+  })
+
+  // ---------------------------------------------------------------------------
+  // K. valueLimitPerUse without params → value-limit policy
+  // ---------------------------------------------------------------------------
+
+  test('valueLimitPerUse without params becomes value-limit policy', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        approve: {
+          valueLimitPerUse: 100n,
+        },
+      },
+    })
+
+    expect(actions[0].policies).toEqual([{ type: 'value-limit', limit: 100n }])
+  })
+
+  // ---------------------------------------------------------------------------
+  // L. valueLimitPerUse with params → part of universal-action
+  // ---------------------------------------------------------------------------
+
+  test('valueLimitPerUse with params sets it on universal-action', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          valueLimitPerUse: 500n,
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+          },
+        },
+      },
+    })
+
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong type')
+    expect(policy.valueLimitPerUse).toBe(500n)
+  })
+
+  // ---------------------------------------------------------------------------
+  // M. usageLimit on param rule
+  // ---------------------------------------------------------------------------
+
+  test('usageLimit is forwarded to param rule', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: {
+              condition: 'equal',
+              value: RECIPIENT,
+              usageLimit: 5n,
+            },
+          },
+        },
+      },
+    })
+
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong type')
+    expect(policy.rules[0].usageLimit).toBe(5n)
+  })
+
+  // ---------------------------------------------------------------------------
+  // N. No policies and no params → action with no policies key
+  // ---------------------------------------------------------------------------
+
+  test('function with no config produces action without policies', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {},
+      },
+    })
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].policies).toBeUndefined()
+  })
+
+  // ---------------------------------------------------------------------------
+  // O. Composability — result works inside Session.actions
+  // ---------------------------------------------------------------------------
+
+  test('result can be spread into Session.actions', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          policies: [{ type: 'sudo' }],
+        },
+      },
+    })
+
+    const session: Session = {
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      actions: [...actions],
+    }
+
+    expect(session.actions).toHaveLength(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // P. End-to-end with getSessionData
+  // ---------------------------------------------------------------------------
+
+  test('result feeds into getSessionData without errors', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          policies: [{ type: 'usage-limit', limit: 10n }],
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+          },
+        },
+      },
+    })
+
+    const session: Session = {
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      actions: [...actions],
+    }
+
+    const data = getSessionData(session)
+    // User action + injected WETH deposit + injected intent-execution fallback
+    expect(data.actions.length).toBeGreaterThanOrEqual(2)
+    expect(data.actions[0].actionTarget).toBe(USDC)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Q. Function not found → throws
+  // ---------------------------------------------------------------------------
+
+  test('throws when function name not in ABI', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'foo',
+        inputs: [],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    expect(() =>
+      definePermissions({
+        abi,
+        address: USDC,
+        functions: {
+          // @ts-expect-error — 'bar' doesn't exist in abi
+          bar: { policies: [{ type: 'sudo' }] },
+        },
+      }),
+    ).toThrow(/not found/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F. anyOf → ArgPolicy
+// ---------------------------------------------------------------------------
+
+const ALICE: Address = '0xaaaa000000000000000000000000000000000001'
+const BOB: Address = '0xbbbb000000000000000000000000000000000002'
+const CAROL: Address = '0xcccc000000000000000000000000000000000003'
+
+describe('definePermissions — anyOf (arg-policy)', () => {
+  test('single param with anyOf emits arg-policy, no universal-action', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE, BOB] },
+          },
+        },
+      },
+    })
+
+    expect(actions).toHaveLength(1)
+    const policy = actions[0].policies![0]
+    expect(policy.type).toBe('arg-policy')
+    if (policy.type !== 'arg-policy') throw new Error('wrong policy type')
+
+    // Top-level: OR of two EQUAL leaves over the same offset
+    expect(policy.expression.type).toBe('or')
+    if (policy.expression.type !== 'or') throw new Error('wrong expr type')
+    expect(policy.expression.left.type).toBe('rule')
+    expect(policy.expression.right.type).toBe('rule')
+    if (
+      policy.expression.left.type !== 'rule' ||
+      policy.expression.right.type !== 'rule'
+    )
+      throw new Error('wrong leaves')
+    expect(policy.expression.left.rule.referenceValue).toBe(ALICE)
+    expect(policy.expression.right.rule.referenceValue).toBe(BOB)
+    expect(policy.expression.left.rule.condition).toBe('equal')
+    expect(policy.expression.right.rule.condition).toBe('equal')
+    // Both leaves point at the same calldata offset (param[0] → 0)
+    expect(policy.expression.left.rule.calldataOffset).toBe(0n)
+    expect(policy.expression.right.rule.calldataOffset).toBe(0n)
+  })
+
+  test('three-value anyOf right-folds: OR(a, OR(b, c))', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE, BOB, CAROL] },
+          },
+        },
+      },
+    })
+
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'arg-policy') throw new Error('wrong policy type')
+    if (policy.expression.type !== 'or') throw new Error('expected top OR')
+    if (policy.expression.left.type !== 'rule')
+      throw new Error('expected left rule')
+    expect(policy.expression.left.rule.referenceValue).toBe(ALICE)
+    if (policy.expression.right.type !== 'or')
+      throw new Error('expected nested OR')
+    if (
+      policy.expression.right.left.type !== 'rule' ||
+      policy.expression.right.right.type !== 'rule'
+    )
+      throw new Error('nested OR leaves')
+    expect(policy.expression.right.left.rule.referenceValue).toBe(BOB)
+    expect(policy.expression.right.right.rule.referenceValue).toBe(CAROL)
+  })
+
+  test('mixed: anyOf + single-condition param → AND(OR(...), rule)', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE, BOB] },
+            amount: { condition: 'lessThan', value: 1000n },
+          },
+        },
+      },
+    })
+
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'arg-policy') throw new Error('wrong policy type')
+    expect(policy.expression.type).toBe('and')
+    if (policy.expression.type !== 'and') throw new Error('expected AND')
+    // OR side (recipient)
+    expect(policy.expression.left.type).toBe('or')
+    // single-rule side (amount lessThan 1000)
+    if (policy.expression.right.type !== 'rule')
+      throw new Error('expected right leaf')
+    expect(policy.expression.right.rule.condition).toBe('lessThan')
+    expect(policy.expression.right.rule.referenceValue).toBe(1000n)
+    expect(policy.expression.right.rule.calldataOffset).toBe(32n)
+  })
+
+  test('all-single-condition params still emit universal-action (no arg-policy upgrade)', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { condition: 'equal', value: ALICE },
+            amount: { condition: 'lessThan', value: 1000n },
+          },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    expect(policy.type).toBe('universal-action')
+  })
+
+  test('empty anyOf array throws at runtime', () => {
+    expect(() =>
+      definePermissions({
+        abi: erc20Abi,
+        address: USDC,
+        functions: {
+          transfer: {
+            params: {
+              // @ts-expect-error — readonly tuple [T, ...T[]] requires ≥1 element
+              recipient: { anyOf: [] },
+            },
+          },
+        },
+      }),
+    ).toThrow(/empty anyOf/)
+  })
+
+  test('anyOf with one value still uses arg-policy (no premature collapse)', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE] },
+          },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    // One-leaf anyOf compiles to a single rule node — emitted as arg-policy
+    // for predictability (callers asked for the OR-capable variant).
+    expect(policy.type).toBe('arg-policy')
+    if (policy.type !== 'arg-policy') throw new Error('wrong policy type')
+    expect(policy.expression.type).toBe('rule')
+  })
+
+  test('anyOf passes through getSessionData encoding (smoke)', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE, BOB] },
+          },
+        },
+      },
+    })
+    const session: Session = {
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      actions,
+    }
+    const data = getSessionData(session)
+    expect(data.actions[0].actionPolicies[0].initData.length).toBeGreaterThan(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// G. Sugar fields → policy composition
+// ---------------------------------------------------------------------------
+
+// Minimal payable + non-ERC20-shape ABI for gating tests
+const customAbi = [
+  {
+    type: 'function',
+    name: 'deposit',
+    inputs: [{ name: 'amount', type: 'uint256' }],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'configure',
+    inputs: [{ name: 'flag', type: 'bool' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const
+
+const VAULT: Address = '0x2222222222222222222222222222222222222222'
+
+describe('definePermissions — sugar fields', () => {
+  test('maxUses emits a usage-limit policy alongside other policies', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          maxUses: 10n,
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+          },
+        },
+      },
+    })
+    const policies = actions[0].policies!
+    const usage = policies.find((p) => p.type === 'usage-limit')
+    expect(usage).toBeDefined()
+    if (usage?.type !== 'usage-limit') throw new Error('wrong')
+    expect(usage.limit).toBe(10n)
+    // universal-action still emitted from params
+    expect(policies.some((p) => p.type === 'universal-action')).toBe(true)
+  })
+
+  test('validUntil only → defaults validAfter=0', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: { validUntil: new Date('2027-01-01') },
+      },
+    })
+    const tf = actions[0].policies!.find((p) => p.type === 'time-frame')
+    if (tf?.type !== 'time-frame') throw new Error('expected time-frame')
+    expect(tf.validUntil).toBe(new Date('2027-01-01').getTime())
+    expect(tf.validAfter).toBe(0)
+  })
+
+  test('validAfter only → defaults validUntil to far-future', () => {
+    const after = new Date('2026-01-01').getTime()
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: { validAfter: after },
+      },
+    })
+    const tf = actions[0].policies!.find((p) => p.type === 'time-frame')
+    if (tf?.type !== 'time-frame') throw new Error('expected time-frame')
+    expect(tf.validAfter).toBe(after)
+    // Far-future = year 2100 in ms — well above any realistic validAfter
+    expect(tf.validUntil).toBeGreaterThan(after)
+    expect(tf.validUntil).toBeGreaterThan(new Date('2099-01-01').getTime())
+  })
+
+  test('validUntil < validAfter throws', () => {
+    expect(() =>
+      definePermissions({
+        abi: erc20Abi,
+        address: USDC,
+        functions: {
+          transfer: {
+            validUntil: new Date('2026-01-01'),
+            validAfter: new Date('2027-01-01'),
+          },
+        },
+      }),
+    ).toThrow(/before validAfter/)
+  })
+
+  test('Date and number inputs are accepted for validUntil/validAfter', () => {
+    const untilDate = new Date('2027-01-01')
+    const afterMs = new Date('2026-01-01').getTime()
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: { validUntil: untilDate, validAfter: afterMs },
+      },
+    })
+    const tf = actions[0].policies!.find((p) => p.type === 'time-frame')
+    if (tf?.type !== 'time-frame') throw new Error('expected time-frame')
+    expect(tf.validUntil).toBe(untilDate.getTime())
+    expect(tf.validAfter).toBe(afterMs)
+  })
+
+  test('spendingLimit on ERC-20 transfer → spending-limits policy', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: { spendingLimit: { token: USDC, amount: 5000n } },
+      },
+    })
+    const sp = actions[0].policies!.find((p) => p.type === 'spending-limits')
+    if (sp?.type !== 'spending-limits') throw new Error('expected sp')
+    expect(sp.limits).toEqual([{ token: USDC, amount: 5000n }])
+  })
+
+  test('spendingLimit on transferFrom (3-arg variant) also accepted', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transferFrom: { spendingLimit: { token: USDC, amount: 100n } },
+      },
+    })
+    expect(actions[0].policies!.some((p) => p.type === 'spending-limits')).toBe(
+      true,
+    )
+  })
+
+  test('valueLimit on payable function → value-limit policy', () => {
+    const actions = definePermissions({
+      abi: customAbi,
+      address: VAULT,
+      functions: {
+        deposit: { valueLimit: 1_000_000_000_000n },
+      },
+    })
+    const vl = actions[0].policies!.find((p) => p.type === 'value-limit')
+    if (vl?.type !== 'value-limit') throw new Error('expected vl')
+    expect(vl.limit).toBe(1_000_000_000_000n)
+  })
+
+  test('valueLimit on non-payable function → runtime throw (type gate bypassed)', () => {
+    expect(() =>
+      definePermissions({
+        abi: customAbi,
+        address: VAULT,
+        functions: {
+          // @ts-expect-error — valueLimit is `never` on non-payable functions
+          configure: { valueLimit: 1n },
+        },
+      }),
+    ).toThrow(/not payable/)
+  })
+
+  test('spendingLimit on non-ERC20-shape function → runtime throw', () => {
+    expect(() =>
+      definePermissions({
+        abi: customAbi,
+        address: VAULT,
+        functions: {
+          // @ts-expect-error — spendingLimit is `never` on non-ERC20-shape functions
+          deposit: { spendingLimit: { token: USDC, amount: 100n } },
+        },
+      }),
+    ).toThrow(/spendingLimit.*ERC-20/)
+  })
+
+  test('combined sugar fields all compose onto the same action', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE, BOB] },
+            amount: { condition: 'lessThan', value: 1000n },
+          },
+          maxUses: 10n,
+          validUntil: new Date('2027-01-01'),
+          spendingLimit: { token: USDC, amount: 5000n },
+        },
+      },
+    })
+    const policies = actions[0].policies!
+    const types = policies.map((p) => p.type).sort()
+    expect(types).toEqual(
+      ['arg-policy', 'spending-limits', 'time-frame', 'usage-limit'].sort(),
+    )
+  })
+
+  test('raw policies + sugar policies concat — duplicates not deduped', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          policies: [{ type: 'usage-limit', limit: 5n }],
+          maxUses: 10n, // sugar — separate from raw
+        },
+      },
+    })
+    const usageLimits = actions[0].policies!.filter(
+      (p) => p.type === 'usage-limit',
+    )
+    expect(usageLimits).toHaveLength(2)
+    if (
+      usageLimits[0].type !== 'usage-limit' ||
+      usageLimits[1].type !== 'usage-limit'
+    )
+      throw new Error('wrong')
+    const limits = [usageLimits[0].limit, usageLimits[1].limit].sort(
+      (a, b) => Number(a) - Number(b),
+    )
+    expect(limits).toEqual([5n, 10n])
+  })
+
+  test('sugar-only function with no params still produces a ScopedAction', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          maxUses: 3n,
+        },
+      },
+    })
+    expect(actions).toHaveLength(1)
+    expect(actions[0].selector).toBe(
+      toFunctionSelector(
+        'function transfer(address recipient, uint256 amount)',
+      ),
+    )
+    expect(actions[0].policies).toEqual([{ type: 'usage-limit', limit: 3n }])
+  })
+
+  test('sugar policies pass through getSessionData encoding', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          maxUses: 10n,
+          validUntil: new Date('2027-01-01'),
+          spendingLimit: { token: USDC, amount: 5000n },
+        },
+      },
+    })
+    const session: Session = {
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      actions,
+    }
+    const data = getSessionData(session)
+    // 3 sugar policies → 3 actionPolicies entries
+    expect(data.actions[0].actionPolicies).toHaveLength(3)
+    data.actions[0].actionPolicies.forEach((p) => {
+      expect(p.initData.length).toBeGreaterThan(2)
+    })
+  })
+})

--- a/src/actions/permissions.test.ts
+++ b/src/actions/permissions.test.ts
@@ -1,4 +1,4 @@
-import { type Address, erc20Abi, toFunctionSelector } from 'viem'
+import { type Address, erc20Abi, type Hex, toFunctionSelector } from 'viem'
 import { base } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
 import { accountA } from '../../test/consts'
@@ -654,6 +654,155 @@ describe('definePermissions — anyOf (arg-policy)', () => {
     }
     const data = getSessionData(session)
     expect(data.actions[0].actionPolicies[0].initData.length).toBeGreaterThan(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F2. bytesN reference value encoding — calldata is left-aligned + right-padded
+//     so the reference value the policy compares against must use the same
+//     layout, not the right-aligned form used for address/uint/bool.
+// ---------------------------------------------------------------------------
+
+describe('definePermissions — bytesN encoding', () => {
+  test('bytes4 reference value is left-aligned + right-padded to bytes32', () => {
+    const bytes4Abi = [
+      {
+        type: 'function',
+        name: 'check',
+        inputs: [{ name: 'sel', type: 'bytes4' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+    const actions = definePermissions({
+      abi: bytes4Abi,
+      address: USDC,
+      functions: {
+        check: {
+          params: {
+            sel: { condition: 'equal', value: '0x12345678' as Hex },
+          },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong policy')
+    expect(policy.rules[0].referenceValue).toBe(
+      // 4 value bytes + 28 zero bytes (left-aligned, right-padded)
+      `0x12345678${'00'.repeat(28)}` as Hex,
+    )
+  })
+
+  test('bytes1 ref value uses left-alignment, not right-alignment', () => {
+    const bytes1Abi = [
+      {
+        type: 'function',
+        name: 'check',
+        inputs: [{ name: 'b', type: 'bytes1' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+    const actions = definePermissions({
+      abi: bytes1Abi,
+      address: USDC,
+      functions: {
+        check: {
+          params: { b: { condition: 'equal', value: '0xff' as Hex } },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong policy')
+    // Left-aligned: high byte = 0xff, rest zero.
+    // Wrong (right-aligned) form would be `0x${'00'.repeat(31)}ff`.
+    expect(policy.rules[0].referenceValue).toBe(`0xff${'00'.repeat(31)}` as Hex)
+    expect(policy.rules[0].referenceValue).not.toBe(
+      `0x${'00'.repeat(31)}ff` as Hex,
+    )
+  })
+
+  test('bytes32 ref value pre-pads to itself (no-op, dir does not matter for full word)', () => {
+    const bytes32Abi = [
+      {
+        type: 'function',
+        name: 'check',
+        inputs: [{ name: 'h', type: 'bytes32' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+    const fullHash = `0x${'ab'.repeat(32)}` as Hex
+    const actions = definePermissions({
+      abi: bytes32Abi,
+      address: USDC,
+      functions: {
+        check: {
+          params: { h: { condition: 'equal', value: fullHash } },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong policy')
+    expect(policy.rules[0].referenceValue).toBe(fullHash)
+  })
+
+  test('address ref value still right-aligned (unchanged behavior)', () => {
+    const actions = definePermissions({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+          },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong policy')
+    // For address, the encoder downstream still left-pads the 20-byte value
+    // to 32 bytes; we return the raw address here so that pipeline is intact.
+    expect(policy.rules[0].referenceValue).toBe(RECIPIENT)
+  })
+
+  test('bytesN anyOf path also pre-pads each value (arg-policy)', () => {
+    const bytes4Abi = [
+      {
+        type: 'function',
+        name: 'check',
+        inputs: [{ name: 'sel', type: 'bytes4' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+    const actions = definePermissions({
+      abi: bytes4Abi,
+      address: USDC,
+      functions: {
+        check: {
+          params: {
+            sel: {
+              anyOf: ['0x11111111' as Hex, '0x22222222' as Hex] as const,
+            },
+          },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'arg-policy') throw new Error('expected arg-policy')
+    if (policy.expression.type !== 'or') throw new Error('expected OR')
+    if (
+      policy.expression.left.type !== 'rule' ||
+      policy.expression.right.type !== 'rule'
+    )
+      throw new Error('expected leaves')
+    expect(policy.expression.left.rule.referenceValue).toBe(
+      `0x11111111${'00'.repeat(28)}` as Hex,
+    )
+    expect(policy.expression.right.rule.referenceValue).toBe(
+      `0x22222222${'00'.repeat(28)}` as Hex,
+    )
   })
 })
 

--- a/src/actions/permissions.ts
+++ b/src/actions/permissions.ts
@@ -1,0 +1,468 @@
+import type { Abi, AbiFunction, AbiParameter } from 'abitype'
+import { type Address, type Hex, isAddress, toFunctionSelector } from 'viem'
+import type {
+  ArgPolicyExpression,
+  Policy,
+  UniversalActionPolicyParamCondition,
+} from '../types'
+
+// ---------------------------------------------------------------------------
+// Type-level utilities
+// ---------------------------------------------------------------------------
+
+type FunctionNames<TAbi extends Abi> = Extract<
+  TAbi[number],
+  { type: 'function' }
+>['name']
+
+type GetFunction<TAbi extends Abi, TName extends string> = Extract<
+  TAbi[number],
+  { type: 'function'; name: TName }
+>
+
+// Map a Solidity static type to the TS value type the developer supplies.
+// Dynamic types collapse to `never`: rules on dynamic-length args can't be
+// encoded into a fixed calldata offset.
+type AbiTypeToValue<T extends string> = T extends 'address'
+  ? Address
+  : T extends 'bool'
+    ? boolean
+    : T extends `uint${string}`
+      ? bigint
+      : T extends `int${string}`
+        ? bigint
+        : T extends `bytes${infer N}`
+          ? N extends ''
+            ? never
+            : Hex
+          : never
+
+type ParamValue<
+  TFn extends AbiFunction,
+  TParamName extends string,
+> = AbiTypeToValue<Extract<TFn['inputs'][number], { name: TParamName }>['type']>
+
+// A constraint on a single named parameter. Two shapes:
+//   - { condition, value, usageLimit? } : single comparison (AND-conjunctive)
+//   - { anyOf: [v1, v2, ...] }          : OR of EQUAL rules — forces arg-policy
+type ParamConstraint<TValue> =
+  | {
+      condition: UniversalActionPolicyParamCondition
+      value: TValue
+      usageLimit?: bigint
+      anyOf?: never
+    }
+  | {
+      anyOf: readonly [TValue, ...TValue[]]
+      condition?: never
+      value?: never
+      usageLimit?: never
+    }
+
+type NamedInputs<TFn extends AbiFunction> = Extract<
+  TFn['inputs'][number],
+  { name: string }
+>
+
+// Compile-time gates for sugar fields that only make sense on certain ABIs.
+// We use structural `extends` on `inputs` so any extra fields (`name`,
+// `internalType`) on the ABI entries don't prevent the match.
+type IsERC20TransferLike<TFn extends AbiFunction> = TFn['inputs'] extends
+  | readonly [{ type: 'address' }, { type: 'uint256' }]
+  | readonly [{ type: 'address' }, { type: 'address' }, { type: 'uint256' }]
+  ? true
+  : false
+
+type IsPayable<TFn extends AbiFunction> =
+  TFn['stateMutability'] extends 'payable' ? true : false
+
+// `never` on the sugar field rejects any user-supplied value at the call site,
+// turning a footgun (e.g. spendingLimit on vault.deposit) into a compile error.
+type SpendingLimitField<TFn extends AbiFunction> =
+  IsERC20TransferLike<TFn> extends true
+    ? { spendingLimit?: { token: Address; amount: bigint } }
+    : { spendingLimit?: never }
+
+type ValueLimitField<TFn extends AbiFunction> = IsPayable<TFn> extends true
+  ? { valueLimit?: bigint }
+  : { valueLimit?: never }
+
+type FunctionConfig<TFn extends AbiFunction> = {
+  /** Escape hatch — raw `Policy` objects merged with sugar-emitted policies. */
+  policies?: Policy[]
+  /** `valueLimitPerUse` embedded in universal/arg-policy `ActionConfig`. */
+  valueLimitPerUse?: bigint
+  params?: {
+    [K in NamedInputs<TFn>['name']]?: ParamConstraint<ParamValue<TFn, K>>
+  }
+  /**
+   * Per-action call cap. Emits a standalone `usage-limit` policy.
+   * Note: counters are scoped to this single action, not session-wide.
+   * `transfer.maxUses=10` and `approve.maxUses=10` are independent counters.
+   */
+  maxUses?: bigint
+  /**
+   * Upper bound on `block.timestamp` (Date or ms-epoch). Pairs with
+   * `validAfter` into one `time-frame` policy. If only one of the two is set,
+   * the other defaults to "always passes" (validAfter=0 / validUntil=year-2100).
+   */
+  validUntil?: Date | number
+  /** Lower bound on `block.timestamp` (Date or ms-epoch). See `validUntil`. */
+  validAfter?: Date | number
+} & SpendingLimitField<TFn> &
+  ValueLimitField<TFn>
+
+type ContractPermissions<TAbi extends Abi> = {
+  abi: TAbi
+  address: Address
+  functions: {
+    [K in FunctionNames<TAbi>]?: FunctionConfig<
+      GetFunction<TAbi, K> & AbiFunction
+    >
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime helpers
+// ---------------------------------------------------------------------------
+
+function isStaticAbiType(type: string): boolean {
+  if (type === 'address' || type === 'bool') return true
+  if (/^u?int\d*$/.test(type)) return true
+  if (/^bytes\d+$/.test(type)) {
+    const n = Number.parseInt(type.slice(5), 10)
+    return n >= 1 && n <= 32
+  }
+  return false
+}
+
+function toReferenceValue(value: unknown, abiType: string): Hex | bigint {
+  if (abiType === 'address') {
+    if (typeof value === 'string' && isAddress(value)) return value
+    throw new Error(`Expected address value, got: ${typeof value}`)
+  }
+  if (abiType === 'bool') {
+    if (typeof value === 'boolean') return value ? 1n : 0n
+    throw new Error(`Expected boolean value, got: ${typeof value}`)
+  }
+  if (abiType.startsWith('uint') || abiType.startsWith('int')) {
+    if (typeof value === 'bigint') return value
+    if (typeof value === 'number') return BigInt(value)
+    throw new Error(
+      `Expected bigint value for ${abiType}, got: ${typeof value}`,
+    )
+  }
+  if (/^bytes\d+$/.test(abiType)) {
+    if (typeof value === 'string') return value as Hex
+    throw new Error(`Expected hex string for ${abiType}, got: ${typeof value}`)
+  }
+  throw new Error(`Unsupported ABI type: ${abiType}`)
+}
+
+// Right-fold an array of leaves into a right-leaning OR chain:
+//   [a, b, c]  →  OR(a, OR(b, c))
+// Right-leaning is fine because ArgPolicy evaluates with short-circuit; any
+// shape that uses every leaf and respects post-order produces the same result.
+function orChain(leaves: readonly ArgPolicyExpression[]): ArgPolicyExpression {
+  if (leaves.length === 0) {
+    throw new Error('orChain requires at least one leaf')
+  }
+  let acc = leaves[leaves.length - 1]
+  for (let i = leaves.length - 2; i >= 0; i--) {
+    acc = { type: 'or', left: leaves[i], right: acc }
+  }
+  return acc
+}
+
+function andChain(leaves: readonly ArgPolicyExpression[]): ArgPolicyExpression {
+  if (leaves.length === 0) {
+    throw new Error('andChain requires at least one leaf')
+  }
+  let acc = leaves[leaves.length - 1]
+  for (let i = leaves.length - 2; i >= 0; i--) {
+    acc = { type: 'and', left: leaves[i], right: acc }
+  }
+  return acc
+}
+
+// ---------------------------------------------------------------------------
+// Main function
+// ---------------------------------------------------------------------------
+
+interface ScopedAction {
+  target: Address
+  selector: Hex
+  policies?: Policy[]
+}
+
+interface NormalizedConstraint {
+  paramName: string
+  calldataOffset: bigint
+  abiType: string
+  /** undefined → `anyOf` form, otherwise single-condition form */
+  condition?: UniversalActionPolicyParamCondition
+  value?: unknown
+  usageLimit?: bigint
+  anyOf?: readonly unknown[]
+}
+
+/**
+ * Build typed, ABI-aware `ScopedAction[]` for session-key permissions.
+ *
+ * Param constraint forms (under `params`):
+ *   - `{ condition, value, usageLimit? }` — single comparison rule
+ *   - `{ anyOf: [v1, v2, ...] }`          — OR of EQUAL rules (allowlist)
+ *
+ * Sugar fields (compose with `params` and any raw `policies`):
+ *   - `maxUses`         → `usage-limit` policy (per-action counter)
+ *   - `validUntil` / `validAfter` → `time-frame` policy
+ *   - `valueLimit`      → `value-limit` policy (payable functions only)
+ *   - `spendingLimit`   → `spending-limits` policy (ERC-20-transfer-shaped functions only)
+ *
+ * Action policy selection: every-param-single-condition → `universal-action`
+ * (cheaper init); any param uses `anyOf` → `arg-policy`. The sugar policies
+ * stack independently — smart-sessions AND-composes them on-chain.
+ *
+ * @example ERC-20 session: allowlist recipients, cap amount + total spend + uses
+ * ```ts
+ * definePermissions({
+ *   abi: erc20Abi,
+ *   address: USDC,
+ *   functions: {
+ *     transfer: {
+ *       params: {
+ *         recipient: { anyOf: [alice, bob] },
+ *         amount:    { condition: 'lessThan', value: 1000n },
+ *       },
+ *       maxUses: 10n,
+ *       validUntil: new Date('2027-01-01'),
+ *       spendingLimit: { token: USDC, amount: 5000n },
+ *     },
+ *   },
+ * })
+ * ```
+ */
+function definePermissions<const TAbi extends Abi>(
+  input: ContractPermissions<TAbi>,
+): ScopedAction[] {
+  const { abi, address, functions } = input
+  const actions: ScopedAction[] = []
+
+  for (const [fnName, fnConfig] of Object.entries(functions)) {
+    if (!fnConfig) continue
+    const config = fnConfig as FunctionConfig<AbiFunction>
+
+    const abiEntries = (abi as readonly AbiParameter[]).filter(
+      (entry): entry is AbiFunction =>
+        (entry as { type: string }).type === 'function' &&
+        (entry as { name: string }).name === fnName,
+    )
+    if (abiEntries.length === 0) {
+      throw new Error(`Function "${fnName}" not found in the provided ABI.`)
+    }
+    if (abiEntries.length > 1) {
+      throw new Error(
+        `Function "${fnName}" is overloaded (${abiEntries.length} variants). ` +
+          'definePermissions does not support overloaded functions. ' +
+          'Use the raw Action API with manual selector and calldataOffset instead.',
+      )
+    }
+
+    const abiEntry = abiEntries[0]
+    const selector = toFunctionSelector(abiEntry)
+
+    const policies: Policy[] = config.policies ? [...config.policies] : []
+
+    // --- Sugar field expansion -----------------------------------------------
+    // Each top-level field maps 1:1 to a known policy. Smart-sessions
+    // AND-composes every action policy on-chain, so duplicates (e.g. raw
+    // `policies: [{ type: 'usage-limit', ... }]` + sugar `maxUses`) are
+    // accepted but redundant; we don't dedupe.
+
+    if (config.maxUses !== undefined) {
+      policies.push({ type: 'usage-limit', limit: config.maxUses })
+    }
+
+    if (config.validUntil !== undefined || config.validAfter !== undefined) {
+      const toMs = (v: Date | number): number =>
+        v instanceof Date ? v.getTime() : v
+      // Defaults: validAfter=0 → "always after epoch"; validUntil far-future
+      // → "always before". Year 2100 in ms is well within uint128 after the
+      // ms→s conversion the encoder applies.
+      const FAR_FUTURE_MS = 4_102_444_800_000 // 2100-01-01
+      const validUntil =
+        config.validUntil !== undefined
+          ? toMs(config.validUntil)
+          : FAR_FUTURE_MS
+      const validAfter =
+        config.validAfter !== undefined ? toMs(config.validAfter) : 0
+      if (validUntil < validAfter) {
+        throw new Error(
+          `Function "${fnName}": validUntil (${validUntil}) is before validAfter (${validAfter}).`,
+        )
+      }
+      policies.push({ type: 'time-frame', validUntil, validAfter })
+    }
+
+    if (config.valueLimit !== undefined) {
+      // Runtime backstop: payable-gating is enforced at the type level, but
+      // users can bypass with `as` casts. ValueLimitPolicy on a non-payable
+      // function is harmless (msg.value is always 0, the cap always passes)
+      // but it leaks intent — we'd rather throw than encode dead weight.
+      if (abiEntry.stateMutability !== 'payable') {
+        throw new Error(
+          `Function "${fnName}" is not payable — \`valueLimit\` only constrains native ETH ` +
+            'attached to the call, which is always zero for non-payable functions. ' +
+            'Remove `valueLimit`, or use the raw `policies` field if this is intentional.',
+        )
+      }
+      policies.push({ type: 'value-limit', limit: config.valueLimit })
+    }
+
+    if (config.spendingLimit !== undefined) {
+      // Runtime backstop: ERC20SpendingLimitPolicy decodes the amount from a
+      // fixed offset that only makes sense for transfer(address,uint256),
+      // transferFrom(address,address,uint256), or approve(address,uint256).
+      // Attaching it to anything else reads garbage and is silently wrong.
+      const inputTypes = abiEntry.inputs.map((i) => i.type).join(',')
+      const ERC20_SHAPES = new Set([
+        'address,uint256',
+        'address,address,uint256',
+      ])
+      if (!ERC20_SHAPES.has(inputTypes)) {
+        throw new Error(
+          `Function "${fnName}" has signature (${inputTypes}); \`spendingLimit\` only ` +
+            'works on ERC-20 transfer-shaped functions: (address,uint256) or ' +
+            '(address,address,uint256). The policy decodes the amount from a fixed ' +
+            'calldata offset and would read garbage on other shapes.',
+        )
+      }
+      policies.push({
+        type: 'spending-limits',
+        limits: [config.spendingLimit],
+      })
+    }
+    // --- End sugar field expansion -------------------------------------------
+    const rawParams = (config.params ?? {}) as Record<
+      string,
+      ParamConstraint<unknown> | undefined
+    >
+    const paramEntries = Object.entries(rawParams).filter(
+      ([, v]) => v !== undefined,
+    ) as [string, ParamConstraint<unknown>][]
+
+    if (paramEntries.length > 0) {
+      const normalized = paramEntries.map<NormalizedConstraint>(
+        ([paramName, rule]) => {
+          const paramIndex = abiEntry.inputs.findIndex(
+            (p) => p.name === paramName,
+          )
+          if (paramIndex === -1) {
+            throw new Error(
+              `Parameter "${paramName}" not found in function "${fnName}". ` +
+                `Available: ${abiEntry.inputs.map((i) => i.name).join(', ')}`,
+            )
+          }
+          const param = abiEntry.inputs[paramIndex]
+          if (!isStaticAbiType(param.type)) {
+            throw new Error(
+              `Parameter "${paramName}" has dynamic type "${param.type}". ` +
+                'definePermissions only supports rules on static types ' +
+                '(address, bool, uint*, int*, bytes1–bytes32). ' +
+                'Use the raw Action API with manual calldataOffset for dynamic types.',
+            )
+          }
+          const calldataOffset = BigInt(paramIndex) * 32n
+
+          if ('anyOf' in rule && rule.anyOf !== undefined) {
+            if (rule.anyOf.length === 0) {
+              throw new Error(
+                `Parameter "${paramName}" has empty anyOf — provide at least one value.`,
+              )
+            }
+            return {
+              paramName,
+              calldataOffset,
+              abiType: param.type,
+              anyOf: rule.anyOf,
+            }
+          }
+
+          return {
+            paramName,
+            calldataOffset,
+            abiType: param.type,
+            condition: rule.condition,
+            value: rule.value,
+            usageLimit: rule.usageLimit,
+          }
+        },
+      )
+
+      const usesArgPolicy = normalized.some((n) => n.anyOf !== undefined)
+
+      if (usesArgPolicy) {
+        // Build one sub-expression per param, then AND them all together.
+        const perParam: ArgPolicyExpression[] = normalized.map((n) => {
+          if (n.anyOf !== undefined) {
+            const leaves: ArgPolicyExpression[] = n.anyOf.map((v) => ({
+              type: 'rule',
+              rule: {
+                condition: 'equal',
+                calldataOffset: n.calldataOffset,
+                referenceValue: toReferenceValue(v, n.abiType),
+              },
+            }))
+            return orChain(leaves)
+          }
+          return {
+            type: 'rule',
+            rule: {
+              condition: n.condition as UniversalActionPolicyParamCondition,
+              calldataOffset: n.calldataOffset,
+              referenceValue: toReferenceValue(n.value, n.abiType),
+              ...(n.usageLimit !== undefined
+                ? { usageLimit: n.usageLimit }
+                : {}),
+            },
+          }
+        })
+
+        policies.push({
+          type: 'arg-policy',
+          valueLimitPerUse: config.valueLimitPerUse ?? 0n,
+          expression: perParam.length === 1 ? perParam[0] : andChain(perParam),
+        })
+      } else {
+        // Flat AND-of-rules — cheaper to init via UniActionPolicy.
+        const rules = normalized.map((n) => ({
+          condition: n.condition as UniversalActionPolicyParamCondition,
+          calldataOffset: n.calldataOffset,
+          referenceValue: toReferenceValue(n.value, n.abiType),
+          ...(n.usageLimit !== undefined ? { usageLimit: n.usageLimit } : {}),
+        }))
+        policies.push({
+          type: 'universal-action',
+          valueLimitPerUse: config.valueLimitPerUse ?? 0n,
+          rules: rules as [(typeof rules)[number], ...(typeof rules)[number][]],
+        })
+      }
+    } else if (config.valueLimitPerUse !== undefined) {
+      policies.push({
+        type: 'value-limit',
+        limit: config.valueLimitPerUse,
+      })
+    }
+
+    actions.push({
+      target: address,
+      selector,
+      ...(policies.length > 0 ? { policies } : {}),
+    })
+  }
+
+  return actions
+}
+
+export { definePermissions }
+export type { ContractPermissions, ParamConstraint }

--- a/src/actions/permissions.ts
+++ b/src/actions/permissions.ts
@@ -1,5 +1,11 @@
 import type { Abi, AbiFunction, AbiParameter } from 'abitype'
-import { type Address, type Hex, isAddress, toFunctionSelector } from 'viem'
+import {
+  type Address,
+  type Hex,
+  isAddress,
+  padHex,
+  toFunctionSelector,
+} from 'viem'
 import type {
   ArgPolicyExpression,
   Policy,
@@ -153,7 +159,16 @@ function toReferenceValue(value: unknown, abiType: string): Hex | bigint {
     )
   }
   if (/^bytes\d+$/.test(abiType)) {
-    if (typeof value === 'string') return value as Hex
+    if (typeof value === 'string') {
+      // Solidity calldata encoding for `bytesN` (N<32) is left-aligned and
+      // right-padded inside its 32-byte word; for `address`/`uint*`/`bool`
+      // it's right-aligned and left-padded. Downstream `encodeActionParamRule`
+      // unconditionally left-pads with `padHex`, which is correct for the
+      // right-aligned types but wrong for `bytesN`. We pre-encode here to a
+      // full 32-byte hex with the correct alignment so the policy's bytes32
+      // == bytes32 comparison matches what's actually in calldata.
+      return padHex(value as Hex, { size: 32, dir: 'right' })
+    }
     throw new Error(`Expected hex string for ${abiType}, got: ${typeof value}`)
   }
   throw new Error(`Unsupported ABI type: ${abiType}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from './accounts'
 import { walletClientToAccount, wrapParaAccount } from './accounts/walletClient'
 import { deployAccountsForOwners } from './actions/deployment'
+import { definePermissions } from './actions/permissions'
 import { type AuthProvider, createAuthProvider } from './auth/provider'
 import {
   getIntentStatus as getIntentStatusInternal,
@@ -617,6 +618,7 @@ export {
   RhinestoneSDK,
   createRhinestoneAccount,
   deployAccountsForOwners,
+  definePermissions,
   walletClientToAccount,
   wrapParaAccount,
   // Validator addresses

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -14,6 +14,7 @@ import { accountA, accountB } from '../../../test/consts'
 import type { Session } from '../../types'
 import type { ResolvedSessionSignerSet } from './smart-sessions'
 import {
+  ARG_POLICY_ADDRESS,
   buildMockSignature,
   DUMMY_PRECLAIMOP_SELECTOR,
   DUMMY_PRECLAIMOP_TARGET,
@@ -133,6 +134,295 @@ describe('getPolicyData', () => {
     })
     expect(result.policy).toBe(UNIVERSAL_ACTION_POLICY_ADDRESS)
     expect(result.initData.length).toBeGreaterThan(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A2. ArgPolicy encoding — verifies the bit-packed node layout matches
+//     ArgPolicyTreeLib.sol exactly: [type:2 | ruleIdx:8 | leftChild:8 | rightChild:8]
+// ---------------------------------------------------------------------------
+
+const argPolicyActionConfigAbi = [
+  {
+    components: [
+      { name: 'valueLimitPerUse', type: 'uint256' },
+      {
+        components: [
+          { name: 'rootNodeIndex', type: 'uint8' },
+          {
+            components: [
+              { name: 'condition', type: 'uint8' },
+              { name: 'offset', type: 'uint64' },
+              { name: 'isLimited', type: 'bool' },
+              { name: 'ref', type: 'bytes32' },
+              {
+                components: [
+                  { name: 'limit', type: 'uint256' },
+                  { name: 'used', type: 'uint256' },
+                ],
+                name: 'usage',
+                type: 'tuple',
+              },
+            ],
+            name: 'rules',
+            type: 'tuple[]',
+          },
+          { name: 'packedNodes', type: 'uint256[]' },
+        ],
+        name: 'paramRules',
+        type: 'tuple',
+      },
+    ],
+    name: 'ActionConfig',
+    type: 'tuple',
+  },
+] as const
+
+function decodeArgPolicyInitData(initData: Hex) {
+  // Lazy import to avoid breaking module scope in this test file.
+  const { decodeAbiParameters } = require('viem') as typeof import('viem')
+  return decodeAbiParameters(argPolicyActionConfigAbi, initData)[0]
+}
+
+const NODE_TYPE_MASK = 0x3n
+const RULE_INDEX_MASK = 0xffn
+const CHILD_MASK = 0xffn
+
+function unpackNode(node: bigint) {
+  return {
+    nodeType: Number(node & NODE_TYPE_MASK),
+    ruleIndex: Number((node >> 2n) & RULE_INDEX_MASK),
+    leftChild: Number((node >> 10n) & CHILD_MASK),
+    rightChild: Number((node >> 18n) & CHILD_MASK),
+  }
+}
+
+describe('getPolicyData arg-policy', () => {
+  test('single rule → 1 rule, 1 RULE node, root index 0', () => {
+    const result = getPolicyData({
+      type: 'arg-policy',
+      valueLimitPerUse: 42n,
+      expression: {
+        type: 'rule',
+        rule: {
+          condition: 'equal',
+          calldataOffset: 4n,
+          referenceValue: 100n,
+        },
+      },
+    })
+    expect(result.policy).toBe(ARG_POLICY_ADDRESS)
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.valueLimitPerUse).toBe(42n)
+    expect(decoded.paramRules.rootNodeIndex).toBe(0)
+    expect(decoded.paramRules.rules.length).toBe(1)
+    expect(decoded.paramRules.packedNodes.length).toBe(1)
+    const root = unpackNode(decoded.paramRules.packedNodes[0])
+    expect(root.nodeType).toBe(0) // RULE
+    expect(root.ruleIndex).toBe(0)
+    // Reference value left-padded to 32 bytes
+    expect(decoded.paramRules.rules[0].ref).toBe(
+      `0x${'00'.repeat(31)}64` as Hex,
+    )
+    expect(decoded.paramRules.rules[0].offset).toBe(4n)
+    expect(decoded.paramRules.rules[0].isLimited).toBe(false)
+  })
+
+  test('OR of two rules — root is OR with two RULE children, children come before parent', () => {
+    const rule = (ref: bigint) =>
+      ({
+        type: 'rule',
+        rule: {
+          condition: 'equal' as const,
+          calldataOffset: 4n,
+          referenceValue: ref,
+        },
+      }) as const
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'or',
+        left: rule(1n),
+        right: rule(2n),
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.rules.length).toBe(2)
+    expect(decoded.paramRules.packedNodes.length).toBe(3)
+    // Post-order: left leaf → right leaf → OR root
+    const leftLeaf = unpackNode(decoded.paramRules.packedNodes[0])
+    const rightLeaf = unpackNode(decoded.paramRules.packedNodes[1])
+    const root = unpackNode(decoded.paramRules.packedNodes[2])
+    expect(leftLeaf.nodeType).toBe(0)
+    expect(leftLeaf.ruleIndex).toBe(0)
+    expect(rightLeaf.nodeType).toBe(0)
+    expect(rightLeaf.ruleIndex).toBe(1)
+    expect(root.nodeType).toBe(3) // OR
+    expect(root.leftChild).toBe(0)
+    expect(root.rightChild).toBe(1)
+    expect(decoded.paramRules.rootNodeIndex).toBe(2)
+  })
+
+  test('NOT wraps a single rule, unary child packed into left slot only', () => {
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'not',
+        child: {
+          type: 'rule',
+          rule: {
+            condition: 'equal',
+            calldataOffset: 4n,
+            referenceValue: 1n,
+          },
+        },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.packedNodes.length).toBe(2)
+    const notRoot = unpackNode(decoded.paramRules.packedNodes[1])
+    expect(notRoot.nodeType).toBe(1) // NOT
+    expect(notRoot.leftChild).toBe(0)
+    // Right child slot must be zero — not used by NOT
+    expect(notRoot.rightChild).toBe(0)
+  })
+
+  test('nested (A AND B) OR (NOT C) — node order is post-order, every parent points at earlier children', () => {
+    const ruleA = {
+      type: 'rule' as const,
+      rule: {
+        condition: 'equal' as const,
+        calldataOffset: 4n,
+        referenceValue: 1n,
+      },
+    }
+    const ruleB = {
+      type: 'rule' as const,
+      rule: {
+        condition: 'equal' as const,
+        calldataOffset: 4n,
+        referenceValue: 2n,
+      },
+    }
+    const ruleC = {
+      type: 'rule' as const,
+      rule: {
+        condition: 'equal' as const,
+        calldataOffset: 4n,
+        referenceValue: 3n,
+      },
+    }
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'or',
+        left: { type: 'and', left: ruleA, right: ruleB },
+        right: { type: 'not', child: ruleC },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    // 3 rules, 3 leaf nodes + AND + NOT + OR = 6 nodes
+    expect(decoded.paramRules.rules.length).toBe(3)
+    expect(decoded.paramRules.packedNodes.length).toBe(6)
+    // Every node's referenced child index must be strictly less than its own index
+    decoded.paramRules.packedNodes.forEach((rawNode: bigint, i: number) => {
+      const n = unpackNode(rawNode)
+      if (n.nodeType === 1) {
+        expect(n.leftChild).toBeLessThan(i)
+      } else if (n.nodeType === 2 || n.nodeType === 3) {
+        expect(n.leftChild).toBeLessThan(i)
+        expect(n.rightChild).toBeLessThan(i)
+      }
+    })
+    expect(decoded.paramRules.rootNodeIndex).toBe(5)
+    const root = unpackNode(decoded.paramRules.packedNodes[5])
+    expect(root.nodeType).toBe(3) // OR
+  })
+
+  test('usageLimit on a rule sets isLimited=true and copies the limit', () => {
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'rule',
+        rule: {
+          condition: 'lessThanOrEqual',
+          calldataOffset: 36n,
+          referenceValue: 1000n,
+          usageLimit: 5000n,
+        },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.rules[0].isLimited).toBe(true)
+    expect(decoded.paramRules.rules[0].usage.limit).toBe(5000n)
+    expect(decoded.paramRules.rules[0].usage.used).toBe(0n)
+  })
+
+  test('reference value as hex is left-padded to bytes32', () => {
+    const addr = '0xaabbccdd00000000000000000000000000000001' as Hex
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'rule',
+        rule: {
+          condition: 'equal',
+          calldataOffset: 4n,
+          referenceValue: addr,
+        },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.rules[0].ref).toBe(
+      `0x000000000000000000000000aabbccdd00000000000000000000000000000001` as Hex,
+    )
+  })
+
+  test('rule index packing uses bits 2..9 — supports indices > 0', () => {
+    // Build an expression with 3 distinct rule leaves so the third rule sits at index 2.
+    const r = (v: bigint) =>
+      ({
+        type: 'rule' as const,
+        rule: {
+          condition: 'equal' as const,
+          calldataOffset: 4n,
+          referenceValue: v,
+        },
+      }) as const
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'and',
+        left: r(1n),
+        right: { type: 'and', left: r(2n), right: r(3n) },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    // Find a leaf with ruleIndex 2 and confirm it round-trips
+    const leafIndices = decoded.paramRules.packedNodes
+      .map(unpackNode)
+      .filter((n: { nodeType: number }) => n.nodeType === 0)
+      .map((n: { ruleIndex: number }) => n.ruleIndex)
+    expect(leafIndices).toContain(2)
+  })
+
+  test('throws when expression compiles to >128 rules', () => {
+    // Build a right-leaning AND chain of 129 rule leaves.
+    const leaf = (v: bigint) =>
+      ({
+        type: 'rule' as const,
+        rule: {
+          condition: 'equal' as const,
+          calldataOffset: 4n,
+          referenceValue: v,
+        },
+      }) as const
+    let expr: import('../../types').ArgPolicyExpression = leaf(0n)
+    for (let i = 1; i < 129; i++) {
+      expr = { type: 'and', left: leaf(BigInt(i)), right: expr }
+    }
+    expect(() =>
+      getPolicyData({ type: 'arg-policy', expression: expr }),
+    ).toThrow(/max is 128/)
   })
 })
 

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -33,6 +33,7 @@ import {
 } from '../../orchestrator/registry'
 import type {
   Action,
+  ArgPolicyExpression,
   Policy,
   ProviderConfig,
   RhinestoneAccountConfig,
@@ -218,17 +219,18 @@ const DUMMY_PRECLAIMOP_TARGET: Address =
 const DUMMY_PRECLAIMOP_SELECTOR: Hex = '0x69123456'
 
 const SPENDING_LIMITS_POLICY_ADDRESS: Address =
-  '0x00000088d48cf102a8cdb0137a9b173f957c6343'
+  '0x000000000033212E272655D8a22402Db819477A6'
 const TIME_FRAME_POLICY_ADDRESS: Address =
-  '0x8177451511de0577b911c254e9551d981c26dc72'
+  '0x0000000000D30f611fA3bf652ac6879428586930'
 const SUDO_POLICY_ADDRESS: Address =
-  '0x0000003111cd8e92337c100f22b7a9dbf8dee301'
+  '0x0000000000FEEc8D74e3143fBaBbca515358d869'
 const UNIVERSAL_ACTION_POLICY_ADDRESS: Address =
-  '0x0000006dda6c463511c4e9b05cfc34c1247fcf1f'
+  '0x0000000000714Cf48FcF88A0bFBa70d313415032'
+const ARG_POLICY_ADDRESS: Address = '0x0000000000167edE64D8751daACDdC0312565a73'
 const USAGE_LIMIT_POLICY_ADDRESS: Address =
-  '0x1f34ef8311345a3a4a4566af321b313052f51493'
+  '0x00000000001d4479FA2A947026204d0283ceDe4B'
 const VALUE_LIMIT_POLICY_ADDRESS: Address =
-  '0x730da93267e7e513e932301b47f2ac7d062abc83'
+  '0x000000000021dC45451291BCDfc9f0B46d6f0278'
 const INTENT_EXECUTION_POLICY_ADDRESS: Address =
   '0xe9eA54d063975cDee9e06b7636d5563d95a7A23C'
 const INTENT_EXECUTION_POLICY_ADDRESS_DEV: Address =
@@ -241,6 +243,23 @@ const ACTION_CONDITION_GREATER_THAN_OR_EQUAL = 3
 const ACTION_CONDITION_LESS_THAN_OR_EQUAL = 4
 const ACTION_CONDITION_NOT_EQUAL = 5
 const ACTION_CONDITION_IN_RANGE = 6
+
+// ArgPolicy expression-tree node packing — must match ArgPolicyTreeLib.sol:
+//   bits  0..1  : node type (0=rule, 1=NOT, 2=AND, 3=OR)
+//   bits  2..9  : rule index (rule nodes only)
+//   bits 10..17 : left/only child index
+//   bits 18..25 : right child index (AND/OR only)
+const ARG_NODE_TYPE_RULE = 0n
+const ARG_NODE_TYPE_NOT = 1n
+const ARG_NODE_TYPE_AND = 2n
+const ARG_NODE_TYPE_OR = 3n
+const ARG_RULE_INDEX_SHIFT = 2n
+const ARG_LEFT_CHILD_SHIFT = 10n
+const ARG_RIGHT_CHILD_SHIFT = 18n
+// On-chain caps from ArgPolicyTreeLib.sol; we fail early instead of letting
+// the deployment revert with `TooManyRules` / `TooManyNodes`.
+const ARG_MAX_RULES = 128
+const ARG_MAX_NODES = 256
 
 interface ResolvedSessionSignerSet {
   type: 'experimental_session'
@@ -764,6 +783,110 @@ function getPermissionId(session: Session) {
   )
 }
 
+function getActionConditionId(
+  condition: UniversalActionPolicyParamCondition,
+): number {
+  switch (condition) {
+    case 'equal':
+      return ACTION_CONDITION_EQUAL
+    case 'greaterThan':
+      return ACTION_CONDITION_GREATER_THAN
+    case 'lessThan':
+      return ACTION_CONDITION_LESS_THAN
+    case 'greaterThanOrEqual':
+      return ACTION_CONDITION_GREATER_THAN_OR_EQUAL
+    case 'lessThanOrEqual':
+      return ACTION_CONDITION_LESS_THAN_OR_EQUAL
+    case 'notEqual':
+      return ACTION_CONDITION_NOT_EQUAL
+    case 'inRange':
+      return ACTION_CONDITION_IN_RANGE
+  }
+}
+
+function encodeActionParamRule(rule: {
+  condition: UniversalActionPolicyParamCondition
+  calldataOffset: bigint
+  usageLimit?: bigint
+  referenceValue: Hex | bigint
+}): ActionParamRule {
+  const ref = isHex(rule.referenceValue)
+    ? padHex(rule.referenceValue)
+    : toHex(rule.referenceValue, { size: 32 })
+  return {
+    condition: getActionConditionId(rule.condition),
+    offset: rule.calldataOffset,
+    isLimited: rule.usageLimit !== undefined,
+    ref,
+    usage: {
+      limit: rule.usageLimit ?? 0n,
+      used: 0n,
+    },
+  }
+}
+
+// Compile an ArgPolicyExpression AST into the on-chain wire format
+// (flat rules[] + bit-packed nodes[] + rootNodeIndex). Post-order walk:
+// children get appended before their parent so a parent's child indices
+// always reference earlier slots.
+function compileArgPolicyExpression(expr: ArgPolicyExpression): {
+  rules: ActionParamRule[]
+  packedNodes: bigint[]
+  rootNodeIndex: number
+} {
+  const rules: ActionParamRule[] = []
+  const nodes: bigint[] = []
+
+  function walk(e: ArgPolicyExpression): number {
+    switch (e.type) {
+      case 'rule': {
+        const ruleIdx = rules.length
+        rules.push(encodeActionParamRule(e.rule))
+        const nodeIdx = nodes.length
+        nodes.push(
+          ARG_NODE_TYPE_RULE | (BigInt(ruleIdx) << ARG_RULE_INDEX_SHIFT),
+        )
+        return nodeIdx
+      }
+      case 'not': {
+        const childIdx = walk(e.child)
+        const nodeIdx = nodes.length
+        nodes.push(
+          ARG_NODE_TYPE_NOT | (BigInt(childIdx) << ARG_LEFT_CHILD_SHIFT),
+        )
+        return nodeIdx
+      }
+      case 'and':
+      case 'or': {
+        const leftIdx = walk(e.left)
+        const rightIdx = walk(e.right)
+        const nodeIdx = nodes.length
+        const nodeType = e.type === 'and' ? ARG_NODE_TYPE_AND : ARG_NODE_TYPE_OR
+        nodes.push(
+          nodeType |
+            (BigInt(leftIdx) << ARG_LEFT_CHILD_SHIFT) |
+            (BigInt(rightIdx) << ARG_RIGHT_CHILD_SHIFT),
+        )
+        return nodeIdx
+      }
+    }
+  }
+
+  const rootNodeIndex = walk(expr)
+
+  if (rules.length > ARG_MAX_RULES) {
+    throw new Error(
+      `ArgPolicy expression has ${rules.length} rules, max is ${ARG_MAX_RULES}`,
+    )
+  }
+  if (nodes.length > ARG_MAX_NODES) {
+    throw new Error(
+      `ArgPolicy expression has ${nodes.length} nodes, max is ${ARG_MAX_NODES}`,
+    )
+  }
+  return { rules, packedNodes: nodes, rootNodeIndex }
+}
+
 function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
   switch (policy.type) {
     case 'sudo':
@@ -779,25 +902,6 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
         initData: '0x',
       }
     case 'universal-action': {
-      function getCondition(condition: UniversalActionPolicyParamCondition) {
-        switch (condition) {
-          case 'equal':
-            return ACTION_CONDITION_EQUAL
-          case 'greaterThan':
-            return ACTION_CONDITION_GREATER_THAN
-          case 'lessThan':
-            return ACTION_CONDITION_LESS_THAN
-          case 'greaterThanOrEqual':
-            return ACTION_CONDITION_GREATER_THAN_OR_EQUAL
-          case 'lessThanOrEqual':
-            return ACTION_CONDITION_LESS_THAN_OR_EQUAL
-          case 'notEqual':
-            return ACTION_CONDITION_NOT_EQUAL
-          case 'inRange':
-            return ACTION_CONDITION_IN_RANGE
-        }
-      }
-
       const MAX_RULES = 16
       const rules = createFixedArray<ActionParamRule, typeof MAX_RULES>(
         MAX_RULES,
@@ -810,20 +914,7 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
         }),
       )
       for (let i = 0; i < policy.rules.length; i++) {
-        const rule = policy.rules[i]
-        const ref = isHex(rule.referenceValue)
-          ? padHex(rule.referenceValue)
-          : toHex(rule.referenceValue, { size: 32 })
-        rules[i] = {
-          condition: getCondition(rule.condition),
-          offset: rule.calldataOffset,
-          isLimited: rule.usageLimit !== undefined,
-          ref,
-          usage: {
-            limit: rule.usageLimit ? rule.usageLimit : 0n,
-            used: 0n,
-          },
-        }
+        rules[i] = encodeActionParamRule(policy.rules[i])
       }
       return {
         policy: UNIVERSAL_ACTION_POLICY_ADDRESS,
@@ -892,6 +983,61 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
               paramRules: {
                 length: BigInt(policy.rules.length),
                 rules: rules,
+              },
+            },
+          ],
+        ),
+      }
+    }
+    case 'arg-policy': {
+      const { rules, packedNodes, rootNodeIndex } = compileArgPolicyExpression(
+        policy.expression,
+      )
+      return {
+        policy: ARG_POLICY_ADDRESS,
+        initData: encodeAbiParameters(
+          [
+            {
+              components: [
+                { name: 'valueLimitPerUse', type: 'uint256' },
+                {
+                  components: [
+                    { name: 'rootNodeIndex', type: 'uint8' },
+                    {
+                      components: [
+                        { name: 'condition', type: 'uint8' },
+                        { name: 'offset', type: 'uint64' },
+                        { name: 'isLimited', type: 'bool' },
+                        { name: 'ref', type: 'bytes32' },
+                        {
+                          components: [
+                            { name: 'limit', type: 'uint256' },
+                            { name: 'used', type: 'uint256' },
+                          ],
+                          name: 'usage',
+                          type: 'tuple',
+                        },
+                      ],
+                      name: 'rules',
+                      type: 'tuple[]',
+                    },
+                    { name: 'packedNodes', type: 'uint256[]' },
+                  ],
+                  name: 'paramRules',
+                  type: 'tuple',
+                },
+              ],
+              name: 'ActionConfig',
+              type: 'tuple',
+            },
+          ],
+          [
+            {
+              valueLimitPerUse: policy.valueLimitPerUse ?? 0n,
+              paramRules: {
+                rootNodeIndex,
+                rules,
+                packedNodes,
               },
             },
           ],
@@ -1026,6 +1172,7 @@ export {
   TIME_FRAME_POLICY_ADDRESS,
   SUDO_POLICY_ADDRESS,
   UNIVERSAL_ACTION_POLICY_ADDRESS,
+  ARG_POLICY_ADDRESS,
   USAGE_LIMIT_POLICY_ADDRESS,
   VALUE_LIMIT_POLICY_ADDRESS,
   INTENT_EXECUTION_POLICY_ADDRESS,

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,23 @@ type UniversalActionPolicyParamCondition =
   | 'notEqual'
   | 'inRange'
 
+// ArgPolicy is the expression-tree successor to UniActionPolicy. Same per-rule
+// leaf semantics, but rules are composed with AND/OR/NOT nodes and arbitrary
+// nesting instead of an implicit all-AND fixed array. Use when a session needs
+// disjunction (e.g. "recipient == alice OR recipient == bob") — for plain
+// AND-of-rules, UniversalActionPolicy is simpler.
+type ArgPolicyExpression =
+  | { type: 'rule'; rule: UniversalActionPolicyParamRule }
+  | { type: 'not'; child: ArgPolicyExpression }
+  | { type: 'and'; left: ArgPolicyExpression; right: ArgPolicyExpression }
+  | { type: 'or'; left: ArgPolicyExpression; right: ArgPolicyExpression }
+
+interface ArgPolicy {
+  type: 'arg-policy'
+  valueLimitPerUse?: bigint
+  expression: ArgPolicyExpression
+}
+
 interface SpendingLimitsPolicy {
   type: 'spending-limits'
   limits: {
@@ -189,6 +206,7 @@ interface Permit2ClaimPolicy {
 type Policy =
   | SudoPolicy
   | UniversalActionPolicy
+  | ArgPolicy
   | SpendingLimitsPolicy
   | TimeFramePolicy
   | UsageLimitPolicy
@@ -538,6 +556,7 @@ export type {
   Policy,
   Permit2ClaimPolicy,
   UniversalActionPolicyParamCondition,
+  ArgPolicyExpression,
   ApiKeyAuth,
   JwtAuth,
   AuthConfig,


### PR DESCRIPTION
## Summary

This PR updates SmartSession policy singleton addresses to the new canonical deployments, including Sudo, TimeFrame, UsageLimit, ValueLimit, UniversalAction, ERC20SpendingLimit, and ArgPolicy.

It adds `arg-policy` support with expression-tree encoding that matches SmartSessions `ArgPolicyTreeLib`, plus a typed `definePermissions` abstraction for building session-key permissions from a contract ABI.

Compatibility note: because the policy addresses are changing, existing sessions enabled against the old policy contracts may not be compatible with newly encoded session data and could require re-enabling or migration.

## Policy address updates

Source: [rhinestonewtf/yeet#172](https://github.com/rhinestonewtf/yeet/pull/172), [#174](https://github.com/rhinestonewtf/yeet/pull/174). All addresses are Safe Singleton Factory vanity deployments (leading-zero prefixes).

| Policy | New address |
|---|---|
| `UsageLimitPolicy` | `0x00000000001d4479FA2A947026204d0283ceDe4B` |
| `TimeFramePolicy` | `0x0000000000D30f611fA3bf652ac6879428586930` |
| `ValueLimitPolicy` | `0x000000000021dC45451291BCDfc9f0B46d6f0278` |
| `UniversalActionPolicy` | `0x0000000000714Cf48FcF88A0bFBa70d313415032` |
| `SudoPolicy` | `0x0000000000FEEc8D74e3143fBaBbca515358d869` |
| `ERC20SpendingLimitPolicy` | `0x000000000033212E272655D8a22402Db819477A6` |
| `ArgPolicy` (new) | `0x0000000000167edE64D8751daACDdC0312565a73` |

## `arg-policy` support

Added a new `arg-policy` variant to the `Policy` union. Accepts an `ArgPolicyExpression` AST (`rule` / `not` / `and` / `or`) and compiles it to ArgPolicy's wire format — flat `ParamRule[]` plus a bit-packed `uint256[]` node array matching `ArgPolicyTreeLib.sol` exactly: `type:2 | ruleIdx:8 | leftChild:8 | rightChild:8`. Post-order emission guarantees parent nodes always reference earlier child indices.

`universal-action` is left untouched — both policies are deployed in parallel and pick-your-own. `universal-action` stays cheaper to init (fixed `ParamRule[16]`, no expression tree); `arg-policy` is the right choice when you need disjunction (OR) or negation (NOT) between rules.

## `definePermissions` abstraction

A typed, ABI-aware builder for session-key permissions. Takes a contract ABI plus per-function config and returns a `ScopedAction[]` ready to spread into `Session.actions`. The whole point is to let the compiler do work that's otherwise easy to get wrong: function selectors, calldata offsets, reference-value type coercion, and policy-shape validation.

### Typed param constraints (drives `universal-action` / `arg-policy`)

```ts
import { erc20Abi } from 'viem'

definePermissions({
  abi: erc20Abi,
  address: USDC,
  functions: {
    transfer: {
      params: {
        recipient: { condition: 'equal', value: '0xabc...' },    // ✅ Address
        amount:    { condition: 'lessThan', value: 1000n },      // ✅ bigint
      },
    },
  },
})
```

- `abitype` resolves each param's TS value type from the ABI (`address` → `Address`, `uint*` → `bigint`, etc.). Dynamic types (`bytes`, `string`, arrays, tuples) collapse to `never`, so rules that the on-chain policy can't decode get rejected at the type level.
- Function selectors come from `toFunctionSelector(abiEntry)`. Param `calldataOffset` is `paramIndex * 32n`.
- Overloaded functions throw at runtime — they're ambiguous and the helper can't decide which selector to use.

### `anyOf` for OR-of-EQUAL allowlists

```ts
definePermissions({
  abi: erc20Abi,
  address: USDC,
  functions: {
    transfer: {
      params: {
        recipient: { anyOf: [alice, bob, carol] },     // → OR of 3 EQUAL rules
        amount:    { condition: 'lessThan', value: 1000n },
      },
    },
  },
})
```

- If every param uses the single-condition form, the function emits `universal-action` (cheaper init).
- If any param uses `anyOf`, the whole function switches to `arg-policy` and the helper compiles the expression tree: each `anyOf` becomes a right-leaning OR chain (`OR(a, OR(b, c))`); per-param sub-expressions are AND-composed.
- The selection is automatic — callers don't have to think about which policy variant to pick.

### Sugar fields with ABI-shape gating

Each top-level field maps to a stand-alone policy that smart-sessions AND-composes on-chain:

| Field | Emits | Gating |
|---|---|---|
| `maxUses: bigint` | `usage-limit` | None |
| `validUntil` / `validAfter: Date \| number` | `time-frame` | One-sided forms default the other end |
| `valueLimit: bigint` | `value-limit` | **Type-gated** to `stateMutability === 'payable'` |
| `spendingLimit: { token, amount }` | `spending-limits` | **Type-gated** to `(address,uint256)` / `(address,address,uint256)` ABIs |

The gates use conditional `extends` over the ABI's `inputs` / `stateMutability` to flip incompatible fields to `never`, so `vault.deposit.spendingLimit` and `erc20.approve.valueLimit` are compile errors. Runtime backstops throw if a user bypasses the type with `as`, because:

- `spendingLimit` on the wrong calldata shape silently reads garbage at offset 36 — worse than a no-op.
- `valueLimit` on a non-payable function would always trivially pass (msg.value is zero), signaling a misunderstanding rather than a constraint.

### Composed example

```ts
definePermissions({
  abi: erc20Abi,
  address: USDC,
  functions: {
    transfer: {
      params: {
        recipient: { anyOf: [alice, bob] },                     // OR allowlist
        amount:    { condition: 'lessThan', value: 1000n },
      },
      maxUses: 10n,                                              // usage-limit
      validUntil: new Date('2027-01-01'),                        // time-frame
      spendingLimit: { token: USDC, amount: 5000n },             // spending-limits (ABI-gated)
    },
  },
})
// → ScopedAction with: arg-policy + usage-limit + time-frame + spending-limits
```

Raw `policies?: Policy[]` stays as an escape hatch for anything the sugar doesn't cover (`intent-execution`, custom-addressed policies, future variants). Sugar policies and raw policies concatenate; the helper does not dedupe.

## Testing

- `bun run test` — 316 / 316 (38 in `permissions.test.ts`, 44 in `smart-sessions.test.ts`)
- `bun run typecheck` — clean
- `bun run check` — one pre-existing unrelated warning in `src/accounts/json-rpc/providers.ts`

Adversarial coverage on the new abstraction: type-gate bypass attempts (`@ts-expect-error` markers locked in), runtime throws on wrong calldata shape, one-sided time-frame defaults, `validUntil < validAfter` rejection, right-fold OR chain layout assertions, post-order node ordering, 129-rule overflow rejection, hex / bigint reference value coercion, and full end-to-end pass-through to `getSessionData` encoding.

## Changeset

`.changeset/smart-session-policy-addresses.md` — addresses + `arg-policy` + `definePermissions` extensions, released as a single `minor`.