### PR TITLE
feat: V2 smart session policies — arg-policy, sugar fields, address override

### DIFF
--- a/.changeset/smart-session-policy-addresses.md
+++ b/.changeset/smart-session-policy-addresses.md
@@ -1,10 +1,10 @@
 ---
-'@rhinestone/sdk': minor
+'@rhinestone/sdk': major
 ---
 
-Update SmartSession action policy singleton addresses to the new canonical V2 deployments (`SudoPolicy`, `UniversalActionPolicy`, `UsageLimitPolicy`, `ValueLimitPolicy`, `TimeFramePolicy`, `ERC20SpendingLimitPolicy`) and add `ArgPolicy` support for expression-tree rules.
+Update SmartSession action policy singleton addresses to the new canonical V2 deployments (`SudoPolicy`, `UniversalActionPolicy`, `UsageLimitPolicy`, `ValueLimitPolicy`, `TimeFramePolicy`, `ERC20SpendingLimitPolicy`) and add `ArgPolicy` support for expression-tree rules. Sessions enabled against the previous policy contracts are not compatible with newly encoded session data and need re-enabling, or per-session opt-in to the old addresses via `SessionDefinition.policyAddresses`.
 
 - Add the `arg-policy` policy variant (`ArgPolicyExpression` AST with `rule` / `not` / `and` / `or` nodes) for action rules that need disjunction or negation. `universal-action` stays available for plain AND-of-rules.
 - Extend the `permissions` builder used by `toSession`: `params` constraints accept `{ anyOf: [v1, v2, ...] }` to allowlist values (compiles to `arg-policy`); per-function sugar fields `maxUses`, `validUntil`, `validAfter`, `valueLimit`, and `spendingLimit` map 1:1 to their policy types, with `valueLimit` type-gated to `payable` functions and `spendingLimit` type-gated to ERC-20 transfer-shaped ABIs.
-- Add `SessionDefinition.policyAddresses` — a partial override map (`sudo`, `universalAction`, `argPolicy`, `spendingLimits`, `timeFrame`, `usageLimit`, `valueLimit`) for backwards compatibility with accounts that already enabled sessions against the previous policy deployments. Defaults to the new V2 addresses.
+- Add `SessionDefinition.policyAddresses` — a partial override map (`sudo`, `universalAction`, `argPolicy`, `spendingLimits`, `timeFrame`, `usageLimit`, `valueLimit`) for accounts already enabled against the previous deployments. Defaults to the new V2 addresses.
 - Fix `bytesN` (N<32) reference values in `permissions`: pre-pad right so the encoded `bytes32` matches Solidity calldata alignment instead of being read at the wrong end of the word.

--- a/.changeset/smart-session-policy-addresses.md
+++ b/.changeset/smart-session-policy-addresses.md
@@ -1,0 +1,10 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Update SmartSession action policy singleton addresses to the new canonical V2 deployments (`SudoPolicy`, `UniversalActionPolicy`, `UsageLimitPolicy`, `ValueLimitPolicy`, `TimeFramePolicy`, `ERC20SpendingLimitPolicy`) and add `ArgPolicy` support for expression-tree rules.
+
+- Add the `arg-policy` policy variant (`ArgPolicyExpression` AST with `rule` / `not` / `and` / `or` nodes) for action rules that need disjunction or negation. `universal-action` stays available for plain AND-of-rules.
+- Extend the `permissions` builder used by `toSession`: `params` constraints accept `{ anyOf: [v1, v2, ...] }` to allowlist values (compiles to `arg-policy`); per-function sugar fields `maxUses`, `validUntil`, `validAfter`, `valueLimit`, and `spendingLimit` map 1:1 to their policy types, with `valueLimit` type-gated to `payable` functions and `spendingLimit` type-gated to ERC-20 transfer-shaped ABIs.
+- Add `SessionDefinition.policyAddresses` — a partial override map (`sudo`, `universalAction`, `argPolicy`, `spendingLimits`, `timeFrame`, `usageLimit`, `valueLimit`) for backwards compatibility with accounts that already enabled sessions against the previous policy deployments. Defaults to the new V2 addresses.
+- Fix `bytesN` (N<32) reference values in `permissions`: pre-pad right so the encoded `bytes32` matches Solidity calldata alignment instead of being read at the wrong end of the word.

--- a/.changeset/smart-session-policy-addresses.md
+++ b/.changeset/smart-session-policy-addresses.md
@@ -6,5 +6,6 @@ Update SmartSession action policy singleton addresses to the new canonical V2 de
 
 - Add the `arg-policy` policy variant (`ArgPolicyExpression` AST with `rule` / `not` / `and` / `or` nodes) for action rules that need disjunction or negation. `universal-action` stays available for plain AND-of-rules.
 - Extend the `permissions` builder used by `toSession`: `params` constraints accept `{ anyOf: [v1, v2, ...] }` to allowlist values (compiles to `arg-policy`); per-function sugar fields `maxUses`, `validUntil`, `validAfter`, `valueLimit`, and `spendingLimit` map 1:1 to their policy types, with `valueLimit` type-gated to `payable` functions and `spendingLimit` type-gated to ERC-20 transfer-shaped ABIs.
+- Remove the `permissions.functions.*.policies` escape hatch. Use the typed permission fields instead; stale runtime callers that still provide `policies` now throw instead of silently dropping guards.
 - Add `SessionDefinition.policyAddresses` — a partial override map (`sudo`, `universalAction`, `argPolicy`, `spendingLimits`, `timeFrame`, `usageLimit`, `valueLimit`) for accounts already enabled against the previous deployments. Defaults to the new V2 addresses.
 - Fix `bytesN` (N<32) reference values in `permissions`: pre-pad right so the encoded `bytes32` matches Solidity calldata alignment instead of being read at the wrong end of the word.

--- a/src/execution/signing.test.ts
+++ b/src/execution/signing.test.ts
@@ -165,7 +165,7 @@ const sessionWithActions: Session = toSession({
       abi: erc20Abi,
       address: '0x1111111111111111111111111111111111111111',
       functions: {
-        transfer: { policies: [{ type: 'usage-limit', limit: 1n }] },
+        transfer: {},
       },
     },
   ],
@@ -411,7 +411,7 @@ const sessionWithPermit2ClaimPolicy: Session = toSession({
       abi: erc20Abi,
       address: '0x1111111111111111111111111111111111111111',
       functions: {
-        transfer: { policies: [{ type: 'usage-limit', limit: 1n }] },
+        transfer: {},
       },
     },
   ],

--- a/src/modules/validators/permissions.test.ts
+++ b/src/modules/validators/permissions.test.ts
@@ -72,41 +72,6 @@ describe('resolvePermission', () => {
     expect(names).toEqual(expectedSelectors)
   })
 
-  test('policies only — no universal-action generated', () => {
-    const actions = resolvePermission({
-      abi: erc20Abi,
-      address: USDC,
-      functions: {
-        approve: {
-          policies: [{ type: 'sudo' }],
-        },
-      },
-    })
-
-    expect(actions).toHaveLength(1)
-    expect(actions[0].policies).toEqual([{ type: 'sudo' }])
-  })
-
-  test('user policies come before generated universal-action', () => {
-    const actions = resolvePermission({
-      abi: erc20Abi,
-      address: USDC,
-      functions: {
-        transfer: {
-          policies: [{ type: 'usage-limit', limit: 3n }],
-          params: {
-            recipient: { condition: 'equal', value: RECIPIENT },
-          },
-        },
-      },
-    })
-
-    const policies = actions[0].policies!
-    expect(policies).toHaveLength(2)
-    expect(policies[0].type).toBe('usage-limit')
-    expect(policies[1].type).toBe('universal-action')
-  })
-
   test('calldataOffset for third parameter is 64n', () => {
     const customAbi = [
       {

--- a/src/modules/validators/permissions.test.ts
+++ b/src/modules/validators/permissions.test.ts
@@ -55,10 +55,10 @@ describe('resolvePermission', () => {
       address: USDC,
       functions: {
         transfer: {
-          policies: [{ type: 'usage-limit', limit: 10n }],
+          maxUses: 10n,
         },
         approve: {
-          policies: [{ type: 'usage-limit', limit: 5n }],
+          maxUses: 5n,
         },
       },
     })
@@ -301,10 +301,24 @@ describe('resolvePermission', () => {
         abi,
         address: USDC,
         functions: {
-          transfer: { policies: [{ type: 'sudo' }] },
+          transfer: {},
         },
       }),
     ).toThrow(/overloaded/)
+  })
+
+  test('throws when removed policies escape hatch is provided at runtime', () => {
+    expect(() =>
+      resolvePermission({
+        abi: erc20Abi,
+        address: USDC,
+        functions: {
+          transfer: {
+            policies: [{ type: 'usage-limit', limit: 1n }],
+          } as never,
+        },
+      }),
+    ).toThrow(/`policies` was removed/)
   })
 
   test('throws for unknown parameter name', () => {
@@ -428,7 +442,7 @@ describe('resolvePermission', () => {
         address: USDC,
         functions: {
           // @ts-expect-error — 'bar' doesn't exist in abi
-          bar: { policies: [{ type: 'sudo' }] },
+          bar: {},
         },
       }),
     ).toThrow(/not found/)
@@ -444,12 +458,12 @@ describe('resolvePermissions', () => {
       {
         abi: erc20Abi,
         address: usdc,
-        functions: { transfer: { policies: [{ type: 'sudo' }] } },
+        functions: { transfer: {} },
       },
       {
         abi: erc20Abi,
         address: dai,
-        functions: { approve: { policies: [{ type: 'sudo' }] } },
+        functions: { approve: {} },
       },
     ])
 
@@ -468,7 +482,7 @@ describe('resolvePermissions', () => {
           address: USDC,
           functions: {
             transfer: {
-              policies: [{ type: 'usage-limit', limit: 10n }],
+              maxUses: 10n,
               params: {
                 recipient: { condition: 'equal', value: RECIPIENT },
               },

--- a/src/modules/validators/permissions.test.ts
+++ b/src/modules/validators/permissions.test.ts
@@ -768,6 +768,102 @@ describe('resolvePermission sugar fields', () => {
     ).toThrow(/not payable/)
   })
 
+  test('valueLimit sugar propagates to universal-action valueLimitPerUse (single-condition params)', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'deposit',
+        inputs: [{ name: 'recipient', type: 'address' }],
+        outputs: [],
+        stateMutability: 'payable',
+      },
+    ] as const
+    const actions = resolvePermission({
+      abi,
+      address: USDC,
+      functions: {
+        deposit: {
+          valueLimit: 1_000_000n,
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+          },
+        },
+      },
+    })
+
+    const policies = actions[0].policies!
+    expect(policies.map((p) => p.type).sort()).toEqual(
+      ['universal-action', 'value-limit'].sort(),
+    )
+    const uni = policies.find((p) => p.type === 'universal-action')!
+    if (uni.type !== 'universal-action') throw new Error('wrong type')
+    // Without this propagation, msg.value > 0 would fail the action policy's
+    // `value <= valueLimitPerUse` check before the standalone value-limit
+    // policy could allow it.
+    expect(uni.valueLimitPerUse).toBe(1_000_000n)
+  })
+
+  test('valueLimit sugar propagates to arg-policy valueLimitPerUse (anyOf params)', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'deposit',
+        inputs: [{ name: 'recipient', type: 'address' }],
+        outputs: [],
+        stateMutability: 'payable',
+      },
+    ] as const
+    const actions = resolvePermission({
+      abi,
+      address: USDC,
+      functions: {
+        deposit: {
+          valueLimit: 1_000_000n,
+          params: {
+            recipient: { anyOf: [RECIPIENT] },
+          },
+        },
+      },
+    })
+
+    const policies = actions[0].policies!
+    expect(policies.map((p) => p.type).sort()).toEqual(
+      ['arg-policy', 'value-limit'].sort(),
+    )
+    const arg = policies.find((p) => p.type === 'arg-policy')!
+    if (arg.type !== 'arg-policy') throw new Error('wrong type')
+    expect(arg.valueLimitPerUse).toBe(1_000_000n)
+  })
+
+  test('explicit valueLimitPerUse wins over valueLimit sugar', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'deposit',
+        inputs: [{ name: 'recipient', type: 'address' }],
+        outputs: [],
+        stateMutability: 'payable',
+      },
+    ] as const
+    const actions = resolvePermission({
+      abi,
+      address: USDC,
+      functions: {
+        deposit: {
+          valueLimit: 1_000_000n,
+          valueLimitPerUse: 7n,
+          params: {
+            recipient: { condition: 'equal', value: RECIPIENT },
+          },
+        },
+      },
+    })
+
+    const uni = actions[0].policies!.find((p) => p.type === 'universal-action')!
+    if (uni.type !== 'universal-action') throw new Error('wrong type')
+    expect(uni.valueLimitPerUse).toBe(7n)
+  })
+
   test('all sugar fields stack with params (arg-policy + usage + time-frame + spending)', () => {
     const actions = resolvePermission({
       abi: erc20Abi,

--- a/src/modules/validators/permissions.test.ts
+++ b/src/modules/validators/permissions.test.ts
@@ -171,7 +171,11 @@ describe('resolvePermission', () => {
     expect(ruleF.referenceValue).toBe(0n)
   })
 
-  test('validates bytesN values are fixed-size hex strings', () => {
+  test('bytesN values are right-padded to 32 bytes (matches calldata alignment)', () => {
+    // Solidity calldata encodes bytesN (N<32) left-aligned + right-padded inside
+    // its 32-byte word, whereas downstream encodeActionParamRule left-pads with
+    // padHex. resolvePermission pre-pads with `dir: 'right'` so the downstream
+    // left-pad becomes idempotent and the policy comparison matches calldata.
     const abi = [
       {
         type: 'function',
@@ -196,7 +200,55 @@ describe('resolvePermission', () => {
 
     const policy = actions[0].policies![0]
     if (policy.type !== 'universal-action') throw new Error('wrong type')
-    expect(policy.rules[0].referenceValue).toBe('0x12345678')
+    expect(policy.rules[0].referenceValue).toBe(`0x12345678${'00'.repeat(28)}`)
+  })
+
+  test('bytes32 values are passed through unchanged (already 32 bytes)', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'setHash',
+        inputs: [{ name: 'h', type: 'bytes32' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    const full =
+      '0x1122334455667788112233445566778811223344556677881122334455667788' as const
+    const actions = resolvePermission({
+      abi,
+      address: USDC,
+      functions: {
+        setHash: { params: { h: { condition: 'equal', value: full } } },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong type')
+    expect(policy.rules[0].referenceValue).toBe(full)
+  })
+
+  test('bytes1 values are right-padded with 31 zero bytes', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'setOne',
+        inputs: [{ name: 'b', type: 'bytes1' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+
+    const actions = resolvePermission({
+      abi,
+      address: USDC,
+      functions: {
+        setOne: { params: { b: { condition: 'equal', value: '0xff' } } },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'universal-action') throw new Error('wrong type')
+    expect(policy.rules[0].referenceValue).toBe(`0xff${'00'.repeat(31)}`)
   })
 
   test('throws for invalid bytesN values', () => {
@@ -466,5 +518,274 @@ describe('resolvePermissions', () => {
     // + injected dummy preclaimop
     expect(data.actions.length).toBeGreaterThanOrEqual(2)
     expect(data.actions[0].actionTarget).toBe(USDC)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// anyOf: OR-of-EQUAL allowlists → emits arg-policy
+// ---------------------------------------------------------------------------
+
+describe('resolvePermission anyOf', () => {
+  const ALICE: Address = '0x4444444444444444444444444444444444444444'
+  const BOB: Address = '0x5555555555555555555555555555555555555555'
+  const CAROL: Address = '0x6666666666666666666666666666666666666666'
+
+  test('anyOf on a single param switches the emitted policy to arg-policy', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE, BOB] },
+          },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    expect(policy.type).toBe('arg-policy')
+    if (policy.type !== 'arg-policy') throw new Error('wrong type')
+    // Two-element anyOf becomes a single OR of two RULE leaves.
+    expect(policy.expression.type).toBe('or')
+  })
+
+  test('anyOf with a single value compiles to a bare rule (no OR wrapper)', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: { params: { recipient: { anyOf: [ALICE] } } },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'arg-policy') throw new Error('wrong type')
+    expect(policy.expression.type).toBe('rule')
+  })
+
+  test('mixing anyOf and single-condition AND-composes across params', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [ALICE, BOB] },
+            amount: { condition: 'lessThan', value: 1000n },
+          },
+        },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'arg-policy') throw new Error('wrong type')
+    // Top-level AND between recipient sub-expression and amount rule.
+    expect(policy.expression.type).toBe('and')
+  })
+
+  test('all-single-condition params keep emitting universal-action (cheaper init)', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { condition: 'equal', value: ALICE },
+            amount: { condition: 'lessThan', value: 1000n },
+          },
+        },
+      },
+    })
+    expect(actions[0].policies![0].type).toBe('universal-action')
+  })
+
+  test('three-element anyOf builds a right-leaning OR chain (OR(a, OR(b, c)))', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: { params: { recipient: { anyOf: [ALICE, BOB, CAROL] } } },
+      },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'arg-policy') throw new Error('wrong type')
+    expect(policy.expression.type).toBe('or')
+    if (policy.expression.type !== 'or') throw new Error()
+    expect(policy.expression.left.type).toBe('rule')
+    expect(policy.expression.right.type).toBe('or')
+  })
+
+  test('throws on empty anyOf', () => {
+    expect(() =>
+      resolvePermission({
+        abi: erc20Abi,
+        address: USDC,
+        functions: {
+          // @ts-expect-error — readonly [T, ...T[]] rejects an empty array at the type level too
+          transfer: { params: { recipient: { anyOf: [] } } },
+        },
+      }),
+    ).toThrow(/empty anyOf/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sugar fields: maxUses, validUntil/validAfter, valueLimit, spendingLimit
+// ---------------------------------------------------------------------------
+
+describe('resolvePermission sugar fields', () => {
+  test('maxUses emits a standalone usage-limit policy', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: { transfer: { maxUses: 10n } },
+    })
+    expect(actions[0].policies).toEqual([{ type: 'usage-limit', limit: 10n }])
+  })
+
+  test('validUntil + validAfter compose into a single time-frame policy', () => {
+    const until = new Date('2027-01-01').getTime()
+    const after = new Date('2026-01-01').getTime()
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          validUntil: new Date('2027-01-01'),
+          validAfter: new Date('2026-01-01'),
+        },
+      },
+    })
+    expect(actions[0].policies).toEqual([
+      { type: 'time-frame', validUntil: until, validAfter: after },
+    ])
+  })
+
+  test('one-sided validUntil defaults validAfter to 0', () => {
+    const until = new Date('2027-01-01').getTime()
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: { transfer: { validUntil: new Date('2027-01-01') } },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'time-frame') throw new Error('wrong type')
+    expect(policy.validUntil).toBe(until)
+    expect(policy.validAfter).toBe(0)
+  })
+
+  test('one-sided validAfter defaults validUntil to year-2100 sentinel', () => {
+    const after = new Date('2026-01-01').getTime()
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: { transfer: { validAfter: new Date('2026-01-01') } },
+    })
+    const policy = actions[0].policies![0]
+    if (policy.type !== 'time-frame') throw new Error('wrong type')
+    expect(policy.validUntil).toBe(4_102_444_800_000)
+    expect(policy.validAfter).toBe(after)
+  })
+
+  test('rejects validUntil < validAfter', () => {
+    expect(() =>
+      resolvePermission({
+        abi: erc20Abi,
+        address: USDC,
+        functions: {
+          transfer: {
+            validUntil: new Date('2026-01-01'),
+            validAfter: new Date('2027-01-01'),
+          },
+        },
+      }),
+    ).toThrow(/before validAfter/)
+  })
+
+  test('spendingLimit on an ERC-20-transfer-shaped ABI emits spending-limits', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: { spendingLimit: { token: USDC, amount: 5000n } },
+      },
+    })
+    expect(actions[0].policies).toEqual([
+      { type: 'spending-limits', limits: [{ token: USDC, amount: 5000n }] },
+    ])
+  })
+
+  test('spendingLimit on a non-ERC-20 shape throws (runtime backstop)', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'deposit',
+        inputs: [{ name: 'amount', type: 'uint256' }],
+        outputs: [],
+        stateMutability: 'payable',
+      },
+    ] as const
+    expect(() =>
+      resolvePermission({
+        abi,
+        address: USDC,
+        functions: {
+          // @ts-expect-error — spendingLimit is gated to ERC-20-transfer-shaped ABIs at the type level
+          deposit: { spendingLimit: { token: USDC, amount: 5000n } },
+        },
+      }),
+    ).toThrow(/spendingLimit.*only\s+works/)
+  })
+
+  test('valueLimit on a payable function emits value-limit', () => {
+    const abi = [
+      {
+        type: 'function',
+        name: 'deposit',
+        inputs: [],
+        outputs: [],
+        stateMutability: 'payable',
+      },
+    ] as const
+    const actions = resolvePermission({
+      abi,
+      address: USDC,
+      functions: { deposit: { valueLimit: 1_000_000n } },
+    })
+    expect(actions[0].policies).toEqual([
+      { type: 'value-limit', limit: 1_000_000n },
+    ])
+  })
+
+  test('valueLimit on a non-payable function throws (runtime backstop)', () => {
+    expect(() =>
+      resolvePermission({
+        abi: erc20Abi,
+        address: USDC,
+        functions: {
+          // @ts-expect-error — valueLimit is gated to payable functions at the type level
+          transfer: { valueLimit: 100n },
+        },
+      }),
+    ).toThrow(/not payable/)
+  })
+
+  test('all sugar fields stack with params (arg-policy + usage + time-frame + spending)', () => {
+    const actions = resolvePermission({
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          params: {
+            recipient: { anyOf: [RECIPIENT] },
+          },
+          maxUses: 10n,
+          validUntil: new Date('2027-01-01'),
+          spendingLimit: { token: USDC, amount: 5000n },
+        },
+      },
+    })
+    const types = actions[0].policies!.map((p) => p.type).sort()
+    expect(types).toEqual(
+      ['arg-policy', 'spending-limits', 'time-frame', 'usage-limit'].sort(),
+    )
   })
 })

--- a/src/modules/validators/permissions.test.ts
+++ b/src/modules/validators/permissions.test.ts
@@ -732,7 +732,35 @@ describe('resolvePermission sugar fields', () => {
           deposit: { spendingLimit: { token: USDC, amount: 5000n } },
         },
       }),
-    ).toThrow(/spendingLimit.*only\s+works/)
+    ).toThrow(/not an ERC-20 transfer\/approve selector/)
+  })
+
+  test('spendingLimit on an ERC-20-shaped non-ERC-20 selector throws (e.g. mint)', () => {
+    // mint(address,uint256) has the same calldata shape as transfer/approve
+    // but a different selector. On-chain ERC20SpendingLimitPolicy dispatches
+    // by selector, so it would fail every call — reject at SDK level.
+    const abi = [
+      {
+        type: 'function',
+        name: 'mint',
+        inputs: [
+          { name: 'to', type: 'address' },
+          { name: 'amount', type: 'uint256' },
+        ],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ] as const
+    expect(() =>
+      resolvePermission({
+        abi,
+        address: USDC,
+        functions: {
+          // @ts-expect-error — spendingLimit is gated to ERC-20 selectors at the type level
+          mint: { spendingLimit: { token: USDC, amount: 5000n } },
+        },
+      }),
+    ).toThrow(/not an ERC-20 transfer\/approve selector/)
   })
 
   test('valueLimit on a payable function emits value-limit', () => {

--- a/src/modules/validators/permissions.ts
+++ b/src/modules/validators/permissions.ts
@@ -112,9 +112,16 @@ type RawFunctionConfig = {
   spendingLimit?: { token: `0x${string}`; amount: bigint }
 }
 
-const ERC20_SPENDING_LIMIT_SHAPES = new Set([
-  'address,uint256',
-  'address,address,uint256',
+// On-chain ERC20SpendingLimitPolicy._isTokenTransferOrApprove matches by
+// 4-byte selector, accepting only these four. Selector-gating here keeps the
+// SDK's accepted set congruent with the contract's — a same-shaped function
+// like `mint(address,uint256)` would otherwise pass argument-type checks and
+// fail every call on-chain.
+const ERC20_SPENDING_LIMIT_SELECTORS = new Set<Hex>([
+  '0x095ea7b3', // approve(address,uint256)
+  '0x39509351', // increaseAllowance(address,uint256)
+  '0xa9059cbb', // transfer(address,uint256)
+  '0x23b872dd', // transferFrom(address,address,uint256)
 ])
 
 // Year 2100 in ms — well within uint128 after the encoder's ms→s conversion.
@@ -194,17 +201,15 @@ function resolvePermission(permission: Permission): ScopedAction[] {
     }
 
     if (config.spendingLimit !== undefined) {
-      // Runtime backstop: ERC20SpendingLimitPolicy decodes the amount from a
-      // fixed offset that only makes sense for transfer(address,uint256),
-      // transferFrom(address,address,uint256), or approve(address,uint256).
-      // Attaching it to anything else reads garbage and is silently wrong.
-      const inputTypes = abiEntry.inputs.map((i) => i.type).join(',')
-      if (!ERC20_SPENDING_LIMIT_SHAPES.has(inputTypes)) {
+      // Runtime backstop: type-level gate restricts shape, but ERC20SpendingLimitPolicy
+      // dispatches by selector on-chain — a same-shaped function like
+      // mint(address,uint256) would encode successfully and fail every call.
+      if (!ERC20_SPENDING_LIMIT_SELECTORS.has(selector)) {
         throw new Error(
-          `Function "${fnName}" has signature (${inputTypes}); \`spendingLimit\` only ` +
-            'works on ERC-20 transfer-shaped functions: (address,uint256) or ' +
-            '(address,address,uint256). The policy decodes the amount from a fixed ' +
-            'calldata offset and would read garbage on other shapes.',
+          `Function "${fnName}" (selector ${selector}) is not an ERC-20 transfer/approve ` +
+            'selector; `spendingLimit` only works on approve, increaseAllowance, ' +
+            'transfer, or transferFrom. The on-chain policy dispatches by selector ' +
+            'and would fail every call for other functions.',
         )
       }
       policies.push({

--- a/src/modules/validators/permissions.ts
+++ b/src/modules/validators/permissions.ts
@@ -102,7 +102,6 @@ type RawParamConstraint = {
 }
 
 type RawFunctionConfig = {
-  policies?: Policy[]
   valueLimitPerUse?: bigint
   params?: Record<string, RawParamConstraint | undefined>
   maxUses?: bigint
@@ -156,7 +155,7 @@ function resolvePermission(permission: Permission): ScopedAction[] {
     const abiEntry = abiEntries[0]
     const selector = toFunctionSelector(abiEntry)
 
-    const policies: Policy[] = config.policies ? [...config.policies] : []
+    const policies: Policy[] = []
 
     // --- Sugar field expansion -----------------------------------------------
     // Each top-level field maps 1:1 to a known policy. Smart-sessions

--- a/src/modules/validators/permissions.ts
+++ b/src/modules/validators/permissions.ts
@@ -4,10 +4,12 @@ import {
   type Hex,
   isAddress,
   isHex,
+  padHex,
   size,
   toFunctionSelector,
 } from 'viem'
 import type {
+  ArgPolicyExpression,
   Permission,
   Policy,
   ScopedAction,
@@ -47,12 +49,77 @@ function toReferenceValue(value: unknown, abiType: string): Hex | bigint {
       isHex(value) &&
       size(value) === expectedSize
     ) {
-      return value as Hex
+      // Solidity calldata encodes bytesN (N<32) left-aligned + right-padded
+      // inside its 32-byte word, whereas address/uint*/bool are right-aligned
+      // + left-padded. Downstream `encodeActionParamRule` unconditionally
+      // left-pads with `padHex`, which is correct for the right-aligned types
+      // but wrong for bytesN. Pre-encode here to the full 32-byte hex with
+      // the correct alignment so the policy's bytes32 == bytes32 comparison
+      // matches what's actually in calldata.
+      return padHex(value as Hex, { size: 32, dir: 'right' })
     }
     throw new Error(`Expected ${expectedSize}-byte hex string for ${abiType}`)
   }
   throw new Error(`Unsupported ABI type: ${abiType}`)
 }
+
+// Right-fold an array of leaves into a right-leaning OR chain:
+//   [a, b, c]  →  OR(a, OR(b, c))
+// Right-leaning is fine because ArgPolicy evaluates with short-circuit; any
+// shape that uses every leaf and respects post-order produces the same result.
+function orChain(leaves: readonly ArgPolicyExpression[]): ArgPolicyExpression {
+  let acc = leaves[leaves.length - 1]
+  for (let i = leaves.length - 2; i >= 0; i--) {
+    acc = { type: 'or', left: leaves[i], right: acc }
+  }
+  return acc
+}
+
+function andChain(leaves: readonly ArgPolicyExpression[]): ArgPolicyExpression {
+  let acc = leaves[leaves.length - 1]
+  for (let i = leaves.length - 2; i >= 0; i--) {
+    acc = { type: 'and', left: leaves[i], right: acc }
+  }
+  return acc
+}
+
+interface NormalizedConstraint {
+  paramName: string
+  calldataOffset: bigint
+  abiType: string
+  /** undefined → `anyOf` form, otherwise single-condition form */
+  condition?: UniversalActionPolicyParamCondition
+  value?: unknown
+  usageLimit?: bigint
+  anyOf?: readonly unknown[]
+}
+
+type RawParamConstraint = {
+  condition?: UniversalActionPolicyParamCondition
+  value?: unknown
+  usageLimit?: bigint
+  anyOf?: readonly unknown[]
+}
+
+type RawFunctionConfig = {
+  policies?: Policy[]
+  valueLimitPerUse?: bigint
+  params?: Record<string, RawParamConstraint | undefined>
+  maxUses?: bigint
+  validUntil?: Date | number
+  validAfter?: Date | number
+  valueLimit?: bigint
+  spendingLimit?: { token: `0x${string}`; amount: bigint }
+}
+
+const ERC20_SPENDING_LIMIT_SHAPES = new Set([
+  'address,uint256',
+  'address,address,uint256',
+])
+
+// Year 2100 in ms — well within uint128 after the encoder's ms→s conversion.
+// Used as the one-sided default for `validUntil` when only `validAfter` is set.
+const FAR_FUTURE_MS = 4_102_444_800_000
 
 function resolvePermission(permission: Permission): ScopedAction[] {
   const { abi, address, functions } = permission
@@ -60,14 +127,7 @@ function resolvePermission(permission: Permission): ScopedAction[] {
 
   for (const [fnName, fnConfig] of Object.entries(functions)) {
     if (!fnConfig) continue
-    const config = fnConfig as {
-      policies?: Policy[]
-      valueLimitPerUse?: bigint
-      params?: Record<
-        string,
-        { condition: string; value: unknown; usageLimit?: bigint }
-      >
-    }
+    const config = fnConfig as RawFunctionConfig
 
     const abiEntries = (abi as readonly AbiParameter[]).filter(
       (entry): entry is AbiFunction =>
@@ -90,50 +150,173 @@ function resolvePermission(permission: Permission): ScopedAction[] {
     const selector = toFunctionSelector(abiEntry)
 
     const policies: Policy[] = config.policies ? [...config.policies] : []
-    const params = config.params ?? {}
-    const paramEntries = Object.entries(params).filter(
+
+    // --- Sugar field expansion -----------------------------------------------
+    // Each top-level field maps 1:1 to a known policy. Smart-sessions
+    // AND-composes every action policy on-chain, so duplicates (e.g. raw
+    // `policies: [{ type: 'usage-limit', ... }]` + sugar `maxUses`) are
+    // accepted but redundant; not deduped.
+
+    if (config.maxUses !== undefined) {
+      policies.push({ type: 'usage-limit', limit: config.maxUses })
+    }
+
+    if (config.validUntil !== undefined || config.validAfter !== undefined) {
+      const toMs = (v: Date | number): number =>
+        v instanceof Date ? v.getTime() : v
+      const validUntil =
+        config.validUntil !== undefined
+          ? toMs(config.validUntil)
+          : FAR_FUTURE_MS
+      const validAfter =
+        config.validAfter !== undefined ? toMs(config.validAfter) : 0
+      if (validUntil < validAfter) {
+        throw new Error(
+          `Function "${fnName}": validUntil (${validUntil}) is before validAfter (${validAfter}).`,
+        )
+      }
+      policies.push({ type: 'time-frame', validUntil, validAfter })
+    }
+
+    if (config.valueLimit !== undefined) {
+      // Runtime backstop: payable-gating is enforced at the type level, but
+      // users can bypass with `as` casts. valueLimit on a non-payable function
+      // is harmless on-chain (msg.value is always 0, the cap always passes)
+      // but it leaks intent — throw rather than encode dead weight.
+      if (abiEntry.stateMutability !== 'payable') {
+        throw new Error(
+          `Function "${fnName}" is not payable — \`valueLimit\` only constrains native ETH ` +
+            'attached to the call, which is always zero for non-payable functions. ' +
+            'Remove `valueLimit`, or use the raw `policies` field if this is intentional.',
+        )
+      }
+      policies.push({ type: 'value-limit', limit: config.valueLimit })
+    }
+
+    if (config.spendingLimit !== undefined) {
+      // Runtime backstop: ERC20SpendingLimitPolicy decodes the amount from a
+      // fixed offset that only makes sense for transfer(address,uint256),
+      // transferFrom(address,address,uint256), or approve(address,uint256).
+      // Attaching it to anything else reads garbage and is silently wrong.
+      const inputTypes = abiEntry.inputs.map((i) => i.type).join(',')
+      if (!ERC20_SPENDING_LIMIT_SHAPES.has(inputTypes)) {
+        throw new Error(
+          `Function "${fnName}" has signature (${inputTypes}); \`spendingLimit\` only ` +
+            'works on ERC-20 transfer-shaped functions: (address,uint256) or ' +
+            '(address,address,uint256). The policy decodes the amount from a fixed ' +
+            'calldata offset and would read garbage on other shapes.',
+        )
+      }
+      policies.push({
+        type: 'spending-limits',
+        limits: [config.spendingLimit],
+      })
+    }
+    // --- End sugar field expansion -------------------------------------------
+
+    const rawParams = config.params ?? {}
+    const paramEntries = Object.entries(rawParams).filter(
       ([, v]) => v !== undefined,
-    )
+    ) as [string, RawParamConstraint][]
 
     if (paramEntries.length > 0) {
-      const rules = paramEntries.map(([paramName, rule]) => {
-        const paramIndex = abiEntry.inputs.findIndex(
-          (p) => p.name === paramName,
-        )
-        if (paramIndex === -1) {
-          throw new Error(
-            `Parameter "${paramName}" not found in function "${fnName}". ` +
-              `Available: ${abiEntry.inputs.map((i) => i.name).join(', ')}`,
+      const normalized = paramEntries.map<NormalizedConstraint>(
+        ([paramName, rule]) => {
+          const paramIndex = abiEntry.inputs.findIndex(
+            (p) => p.name === paramName,
           )
-        }
+          if (paramIndex === -1) {
+            throw new Error(
+              `Parameter "${paramName}" not found in function "${fnName}". ` +
+                `Available: ${abiEntry.inputs.map((i) => i.name).join(', ')}`,
+            )
+          }
 
-        const param = abiEntry.inputs[paramIndex]
-        if (!isStaticAbiType(param.type)) {
-          throw new Error(
-            `Parameter "${paramName}" has dynamic type "${param.type}". ` +
-              'Permission rules only support static types ' +
-              '(address, bool, uint*, int*, bytes1–bytes32).',
-          )
-        }
+          const param = abiEntry.inputs[paramIndex]
+          if (!isStaticAbiType(param.type)) {
+            throw new Error(
+              `Parameter "${paramName}" has dynamic type "${param.type}". ` +
+                'Permission rules only support static types ' +
+                '(address, bool, uint*, int*, bytes1–bytes32).',
+            )
+          }
 
-        const calldataOffset = BigInt(paramIndex) * 32n
-        const referenceValue = toReferenceValue(rule.value, param.type)
+          const calldataOffset = BigInt(paramIndex) * 32n
 
-        return {
-          condition: rule.condition as UniversalActionPolicyParamCondition,
-          calldataOffset,
-          referenceValue,
-          ...(rule.usageLimit !== undefined
-            ? { usageLimit: rule.usageLimit }
-            : {}),
-        }
-      })
+          if (rule.anyOf !== undefined) {
+            if (rule.anyOf.length === 0) {
+              throw new Error(
+                `Parameter "${paramName}" has empty anyOf — provide at least one value.`,
+              )
+            }
+            return {
+              paramName,
+              calldataOffset,
+              abiType: param.type,
+              anyOf: rule.anyOf,
+            }
+          }
 
-      policies.push({
-        type: 'universal-action' as const,
-        valueLimitPerUse: config.valueLimitPerUse ?? 0n,
-        rules: rules as [(typeof rules)[number], ...(typeof rules)[number][]],
-      })
+          return {
+            paramName,
+            calldataOffset,
+            abiType: param.type,
+            condition: rule.condition,
+            value: rule.value,
+            usageLimit: rule.usageLimit,
+          }
+        },
+      )
+
+      const usesArgPolicy = normalized.some((n) => n.anyOf !== undefined)
+
+      if (usesArgPolicy) {
+        // One sub-expression per param, then AND across params.
+        const perParam: ArgPolicyExpression[] = normalized.map((n) => {
+          if (n.anyOf !== undefined) {
+            const leaves: ArgPolicyExpression[] = n.anyOf.map((v) => ({
+              type: 'rule',
+              rule: {
+                condition: 'equal',
+                calldataOffset: n.calldataOffset,
+                referenceValue: toReferenceValue(v, n.abiType),
+              },
+            }))
+            return leaves.length === 1 ? leaves[0] : orChain(leaves)
+          }
+          return {
+            type: 'rule',
+            rule: {
+              condition: n.condition as UniversalActionPolicyParamCondition,
+              calldataOffset: n.calldataOffset,
+              referenceValue: toReferenceValue(n.value, n.abiType),
+              ...(n.usageLimit !== undefined
+                ? { usageLimit: n.usageLimit }
+                : {}),
+            },
+          }
+        })
+
+        policies.push({
+          type: 'arg-policy',
+          valueLimitPerUse: config.valueLimitPerUse ?? 0n,
+          expression: perParam.length === 1 ? perParam[0] : andChain(perParam),
+        })
+      } else {
+        // Flat AND-of-rules — cheaper to init via UniActionPolicy.
+        const rules = normalized.map((n) => ({
+          condition: n.condition as UniversalActionPolicyParamCondition,
+          calldataOffset: n.calldataOffset,
+          referenceValue: toReferenceValue(n.value, n.abiType),
+          ...(n.usageLimit !== undefined ? { usageLimit: n.usageLimit } : {}),
+        }))
+
+        policies.push({
+          type: 'universal-action' as const,
+          valueLimitPerUse: config.valueLimitPerUse ?? 0n,
+          rules: rules as [(typeof rules)[number], ...(typeof rules)[number][]],
+        })
+      }
     } else if (config.valueLimitPerUse !== undefined) {
       policies.push({
         type: 'value-limit' as const,

--- a/src/modules/validators/permissions.ts
+++ b/src/modules/validators/permissions.ts
@@ -155,13 +155,16 @@ function resolvePermission(permission: Permission): ScopedAction[] {
     const abiEntry = abiEntries[0]
     const selector = toFunctionSelector(abiEntry)
 
+    if (Object.hasOwn(config, 'policies')) {
+      throw new Error(
+        `Function "${fnName}": \`policies\` was removed from permission configs. ` +
+          'Use params, maxUses, validUntil/validAfter, valueLimit, or spendingLimit instead.',
+      )
+    }
+
     const policies: Policy[] = []
 
     // --- Sugar field expansion -----------------------------------------------
-    // Each top-level field maps 1:1 to a known policy. Smart-sessions
-    // AND-composes every action policy on-chain, so duplicates (e.g. raw
-    // `policies: [{ type: 'usage-limit', ... }]` + sugar `maxUses`) are
-    // accepted but redundant; not deduped.
 
     if (config.maxUses !== undefined) {
       policies.push({ type: 'usage-limit', limit: config.maxUses })
@@ -193,7 +196,7 @@ function resolvePermission(permission: Permission): ScopedAction[] {
         throw new Error(
           `Function "${fnName}" is not payable — \`valueLimit\` only constrains native ETH ` +
             'attached to the call, which is always zero for non-payable functions. ' +
-            'Remove `valueLimit`, or use the raw `policies` field if this is intentional.',
+            'Remove `valueLimit`.',
         )
       }
       policies.push({ type: 'value-limit', limit: config.valueLimit })

--- a/src/modules/validators/permissions.ts
+++ b/src/modules/validators/permissions.ts
@@ -270,6 +270,14 @@ function resolvePermission(permission: Permission): ScopedAction[] {
 
       const usesArgPolicy = normalized.some((n) => n.anyOf !== undefined)
 
+      // UniActionPolicy/ArgPolicy reject `msg.value > valueLimitPerUse`, so a
+      // default of 0 would block any non-zero msg.value before the standalone
+      // value-limit policy (sugar) could allow it. Inherit the sugar's cap so
+      // the per-use gate matches user intent; value-limit still enforces the
+      // cumulative cap on top.
+      const embeddedValueLimit =
+        config.valueLimitPerUse ?? config.valueLimit ?? 0n
+
       if (usesArgPolicy) {
         // One sub-expression per param, then AND across params.
         const perParam: ArgPolicyExpression[] = normalized.map((n) => {
@@ -299,7 +307,7 @@ function resolvePermission(permission: Permission): ScopedAction[] {
 
         policies.push({
           type: 'arg-policy',
-          valueLimitPerUse: config.valueLimitPerUse ?? 0n,
+          valueLimitPerUse: embeddedValueLimit,
           expression: perParam.length === 1 ? perParam[0] : andChain(perParam),
         })
       } else {
@@ -313,7 +321,7 @@ function resolvePermission(permission: Permission): ScopedAction[] {
 
         policies.push({
           type: 'universal-action' as const,
-          valueLimitPerUse: config.valueLimitPerUse ?? 0n,
+          valueLimitPerUse: embeddedValueLimit,
           rules: rules as [(typeof rules)[number], ...(typeof rules)[number][]],
         })
       }

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -55,7 +55,7 @@ const sessionWithAction: Session = toSession({
       abi: erc20Abi,
       address: '0x1111111111111111111111111111111111111111' as Address,
       functions: {
-        transfer: { policies: [{ type: 'sudo' }] },
+        transfer: {},
       },
     },
   ],
@@ -461,7 +461,7 @@ describe('policyAddresses override', () => {
           abi: erc20Abi,
           address: USDC,
           functions: {
-            transfer: { policies: [{ type: 'sudo' }] },
+            transfer: {},
           },
         },
       ],

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -1,5 +1,6 @@
 import {
   type Address,
+  decodeAbiParameters,
   encodeAbiParameters,
   encodePacked,
   erc20Abi,
@@ -12,10 +13,11 @@ import {
 import { base } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
 import { accountA, accountB } from '../../../test/consts'
-import type { Session } from '../../types'
+import type { ArgPolicyExpression, Session } from '../../types'
 import { PERMIT2_CLAIM_POLICY_ADDRESS } from './policies/claim/permit2'
 import type { ResolvedSessionSignerSet } from './smart-sessions'
 import {
+  ARG_POLICY_ADDRESS,
   buildMockSignature,
   DUMMY_PRECLAIMOP_SELECTOR,
   DUMMY_PRECLAIMOP_TARGET,
@@ -140,6 +142,362 @@ describe('getPolicyData', () => {
     })
     expect(result.policy).toBe(UNIVERSAL_ACTION_POLICY_ADDRESS)
     expect(result.initData.length).toBeGreaterThan(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A2. ArgPolicy encoding — verifies the bit-packed node layout matches
+//     ArgPolicyTreeLib.sol exactly: [type:2 | ruleIdx:8 | leftChild:8 | rightChild:8]
+// ---------------------------------------------------------------------------
+
+const argPolicyActionConfigAbi = [
+  {
+    components: [
+      { name: 'valueLimitPerUse', type: 'uint256' },
+      {
+        components: [
+          { name: 'rootNodeIndex', type: 'uint8' },
+          {
+            components: [
+              { name: 'condition', type: 'uint8' },
+              { name: 'offset', type: 'uint64' },
+              { name: 'isLimited', type: 'bool' },
+              { name: 'ref', type: 'bytes32' },
+              {
+                components: [
+                  { name: 'limit', type: 'uint256' },
+                  { name: 'used', type: 'uint256' },
+                ],
+                name: 'usage',
+                type: 'tuple',
+              },
+            ],
+            name: 'rules',
+            type: 'tuple[]',
+          },
+          { name: 'packedNodes', type: 'uint256[]' },
+        ],
+        name: 'paramRules',
+        type: 'tuple',
+      },
+    ],
+    name: 'ActionConfig',
+    type: 'tuple',
+  },
+] as const
+
+function decodeArgPolicyInitData(initData: Hex) {
+  return decodeAbiParameters(argPolicyActionConfigAbi, initData)[0]
+}
+
+const NODE_TYPE_MASK = 0x3n
+const RULE_INDEX_MASK = 0xffn
+const CHILD_MASK = 0xffn
+
+function unpackNode(node: bigint) {
+  return {
+    nodeType: Number(node & NODE_TYPE_MASK),
+    ruleIndex: Number((node >> 2n) & RULE_INDEX_MASK),
+    leftChild: Number((node >> 10n) & CHILD_MASK),
+    rightChild: Number((node >> 18n) & CHILD_MASK),
+  }
+}
+
+describe('getPolicyData arg-policy', () => {
+  test('single rule → 1 rule, 1 RULE node, root index 0', () => {
+    const result = getPolicyData({
+      type: 'arg-policy',
+      valueLimitPerUse: 42n,
+      expression: {
+        type: 'rule',
+        rule: {
+          condition: 'equal',
+          calldataOffset: 4n,
+          referenceValue: 100n,
+        },
+      },
+    })
+    expect(result.policy).toBe(ARG_POLICY_ADDRESS)
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.valueLimitPerUse).toBe(42n)
+    expect(decoded.paramRules.rootNodeIndex).toBe(0)
+    expect(decoded.paramRules.rules.length).toBe(1)
+    expect(decoded.paramRules.packedNodes.length).toBe(1)
+    const root = unpackNode(decoded.paramRules.packedNodes[0])
+    expect(root.nodeType).toBe(0) // RULE
+    expect(root.ruleIndex).toBe(0)
+    expect(decoded.paramRules.rules[0].ref).toBe(
+      `0x${'00'.repeat(31)}64` as Hex,
+    )
+    expect(decoded.paramRules.rules[0].offset).toBe(4n)
+    expect(decoded.paramRules.rules[0].isLimited).toBe(false)
+  })
+
+  test('OR of two rules — root is OR with two RULE children, children come before parent', () => {
+    const rule = (ref: bigint) =>
+      ({
+        type: 'rule',
+        rule: {
+          condition: 'equal' as const,
+          calldataOffset: 4n,
+          referenceValue: ref,
+        },
+      }) as const
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'or',
+        left: rule(1n),
+        right: rule(2n),
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.rules.length).toBe(2)
+    expect(decoded.paramRules.packedNodes.length).toBe(3)
+    const leftLeaf = unpackNode(decoded.paramRules.packedNodes[0])
+    const rightLeaf = unpackNode(decoded.paramRules.packedNodes[1])
+    const root = unpackNode(decoded.paramRules.packedNodes[2])
+    expect(leftLeaf.nodeType).toBe(0)
+    expect(leftLeaf.ruleIndex).toBe(0)
+    expect(rightLeaf.nodeType).toBe(0)
+    expect(rightLeaf.ruleIndex).toBe(1)
+    expect(root.nodeType).toBe(3) // OR
+    expect(root.leftChild).toBe(0)
+    expect(root.rightChild).toBe(1)
+    expect(decoded.paramRules.rootNodeIndex).toBe(2)
+  })
+
+  test('NOT wraps a single rule, unary child packed into left slot only', () => {
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'not',
+        child: {
+          type: 'rule',
+          rule: {
+            condition: 'equal',
+            calldataOffset: 4n,
+            referenceValue: 1n,
+          },
+        },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.packedNodes.length).toBe(2)
+    const notRoot = unpackNode(decoded.paramRules.packedNodes[1])
+    expect(notRoot.nodeType).toBe(1) // NOT
+    expect(notRoot.leftChild).toBe(0)
+    expect(notRoot.rightChild).toBe(0)
+  })
+
+  test('nested (A AND B) OR (NOT C) — post-order, every parent points at earlier children', () => {
+    const ruleA: ArgPolicyExpression = {
+      type: 'rule',
+      rule: { condition: 'equal', calldataOffset: 4n, referenceValue: 1n },
+    }
+    const ruleB: ArgPolicyExpression = {
+      type: 'rule',
+      rule: { condition: 'equal', calldataOffset: 4n, referenceValue: 2n },
+    }
+    const ruleC: ArgPolicyExpression = {
+      type: 'rule',
+      rule: { condition: 'equal', calldataOffset: 4n, referenceValue: 3n },
+    }
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'or',
+        left: { type: 'and', left: ruleA, right: ruleB },
+        right: { type: 'not', child: ruleC },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    // 3 rules, 3 leaf nodes + AND + NOT + OR = 6 nodes
+    expect(decoded.paramRules.rules.length).toBe(3)
+    expect(decoded.paramRules.packedNodes.length).toBe(6)
+    decoded.paramRules.packedNodes.forEach((rawNode: bigint, i: number) => {
+      const n = unpackNode(rawNode)
+      if (n.nodeType === 1) {
+        expect(n.leftChild).toBeLessThan(i)
+      } else if (n.nodeType === 2 || n.nodeType === 3) {
+        expect(n.leftChild).toBeLessThan(i)
+        expect(n.rightChild).toBeLessThan(i)
+      }
+    })
+    expect(decoded.paramRules.rootNodeIndex).toBe(5)
+    const root = unpackNode(decoded.paramRules.packedNodes[5])
+    expect(root.nodeType).toBe(3) // OR
+  })
+
+  test('usageLimit on a rule sets isLimited=true and copies the limit', () => {
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'rule',
+        rule: {
+          condition: 'lessThanOrEqual',
+          calldataOffset: 36n,
+          referenceValue: 1000n,
+          usageLimit: 5000n,
+        },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.rules[0].isLimited).toBe(true)
+    expect(decoded.paramRules.rules[0].usage.limit).toBe(5000n)
+    expect(decoded.paramRules.rules[0].usage.used).toBe(0n)
+  })
+
+  test('reference value as hex is left-padded to bytes32', () => {
+    const addr = '0xaabbccdd00000000000000000000000000000001' as Hex
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'rule',
+        rule: {
+          condition: 'equal',
+          calldataOffset: 4n,
+          referenceValue: addr,
+        },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    expect(decoded.paramRules.rules[0].ref).toBe(
+      `0x000000000000000000000000aabbccdd00000000000000000000000000000001` as Hex,
+    )
+  })
+
+  test('rule index packing uses bits 2..9 — supports indices > 0', () => {
+    const r = (v: bigint): ArgPolicyExpression => ({
+      type: 'rule',
+      rule: { condition: 'equal', calldataOffset: 4n, referenceValue: v },
+    })
+    const result = getPolicyData({
+      type: 'arg-policy',
+      expression: {
+        type: 'and',
+        left: r(1n),
+        right: { type: 'and', left: r(2n), right: r(3n) },
+      },
+    })
+    const decoded = decodeArgPolicyInitData(result.initData)
+    const leafIndices = decoded.paramRules.packedNodes
+      .map(unpackNode)
+      .filter((n) => n.nodeType === 0)
+      .map((n) => n.ruleIndex)
+    expect(leafIndices).toContain(2)
+  })
+
+  test('throws when expression compiles to >128 rules', () => {
+    const leaf = (v: bigint): ArgPolicyExpression => ({
+      type: 'rule',
+      rule: { condition: 'equal', calldataOffset: 4n, referenceValue: v },
+    })
+    let expr: ArgPolicyExpression = leaf(0n)
+    for (let i = 1; i < 129; i++) {
+      expr = { type: 'and', left: leaf(BigInt(i)), right: expr }
+    }
+    expect(() =>
+      getPolicyData({ type: 'arg-policy', expression: expr }),
+    ).toThrow(/max is 128/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// A3. Per-session policyAddresses override
+// ---------------------------------------------------------------------------
+
+describe('policyAddresses override', () => {
+  const SUDO_OVERRIDE: Address = '0xdeadbeef00000000000000000000000000000001'
+  const UA_OVERRIDE: Address = '0xdeadbeef00000000000000000000000000000002'
+
+  test('partial override pins only the named policies, defaults stay for the rest', () => {
+    const session = toSession({
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      permissions: [
+        {
+          abi: erc20Abi,
+          address: USDC,
+          functions: {
+            transfer: {
+              policies: [{ type: 'sudo' }, { type: 'usage-limit', limit: 3n }],
+            },
+          },
+        },
+      ],
+      policyAddresses: { sudo: SUDO_OVERRIDE },
+    })
+    const data = getSessionData(session)
+    const userAction = data.actions[0]
+    expect(userAction.actionPolicies[0].policy).toBe(SUDO_OVERRIDE)
+    // Non-overridden policies keep their default address.
+    expect(userAction.actionPolicies[1].policy).toBe(USAGE_LIMIT_POLICY_ADDRESS)
+  })
+
+  test('override propagates to the erc1271 sudo policy too', () => {
+    const session = toSession({
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      policyAddresses: { sudo: SUDO_OVERRIDE },
+    })
+    const data = getSessionData(session)
+    expect(data.erc7739Policies.erc1271Policies[0].policy).toBe(SUDO_OVERRIDE)
+  })
+
+  test('default fallback sudo action picks up the override', () => {
+    // No explicit permissions → resolveSessionData emits the [sudoAction] fallback.
+    const session = toSession({
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      policyAddresses: { sudo: SUDO_OVERRIDE },
+    })
+    const data = getSessionData(session)
+    expect(data.actions[0].actionPolicies[0].policy).toBe(SUDO_OVERRIDE)
+  })
+
+  test('universal-action address override is reflected in encoded action policy', () => {
+    const session = toSession({
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      permissions: [
+        {
+          abi: erc20Abi,
+          address: USDC,
+          functions: {
+            transfer: {
+              params: {
+                recipient: { condition: 'equal', value: RECIPIENT },
+              },
+            },
+          },
+        },
+      ],
+      policyAddresses: { universalAction: UA_OVERRIDE },
+    })
+    const data = getSessionData(session)
+    expect(data.actions[0].actionPolicies[0].policy).toBe(UA_OVERRIDE)
+  })
+
+  test('no override → all default V2 addresses are used', () => {
+    const session = toSession({
+      chain: base,
+      owners: { type: 'ecdsa', accounts: [accountA] },
+      permissions: [
+        {
+          abi: erc20Abi,
+          address: USDC,
+          functions: {
+            transfer: { policies: [{ type: 'sudo' }] },
+          },
+        },
+      ],
+    })
+    const data = getSessionData(session)
+    expect(data.actions[0].actionPolicies[0].policy).toBe(SUDO_POLICY_ADDRESS)
+    expect(data.erc7739Policies.erc1271Policies[0].policy).toBe(
+      SUDO_POLICY_ADDRESS,
+    )
   })
 })
 

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -96,21 +96,18 @@ describe('getPolicyData', () => {
     expect(result.initData).toBe(expected)
   })
 
-  test('time-frame packs (validUntil, validAfter) as bytes16 || bytes16 in seconds (ms → s)', () => {
+  test('time-frame packs (validUntil, validAfter) as uint48 || uint48 in seconds (ms → s)', () => {
     const validUntil = 1_800_000_000_000
     const validAfter = 1_700_000_000_000
     const result = getPolicyData({ type: 'time-frame', validUntil, validAfter })
     expect(result.policy).toBe(TIME_FRAME_POLICY_ADDRESS)
     const expected = encodePacked(
-      ['uint128', 'uint128'],
-      [
-        BigInt(Math.floor(validUntil / 1000)),
-        BigInt(Math.floor(validAfter / 1000)),
-      ],
+      ['uint48', 'uint48'],
+      [Math.floor(validUntil / 1000), Math.floor(validAfter / 1000)],
     )
     expect(result.initData).toBe(expected)
-    // 32 bytes total (matches deployed TimeFramePolicy's `bytes16 || bytes16` layout)
-    expect((expected.length - 2) / 2).toBe(32)
+    // 12 bytes total (matches deployed TimeFramePolicy's bytes12 / uint96 layout)
+    expect((expected.length - 2) / 2).toBe(12)
   })
 
   test('usage-limit encodes limit as uint128', () => {

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -408,30 +408,6 @@ describe('policyAddresses override', () => {
   const SUDO_OVERRIDE: Address = '0xdeadbeef00000000000000000000000000000001'
   const UA_OVERRIDE: Address = '0xdeadbeef00000000000000000000000000000002'
 
-  test('partial override pins only the named policies, defaults stay for the rest', () => {
-    const session = toSession({
-      chain: base,
-      owners: { type: 'ecdsa', accounts: [accountA] },
-      permissions: [
-        {
-          abi: erc20Abi,
-          address: USDC,
-          functions: {
-            transfer: {
-              policies: [{ type: 'sudo' }, { type: 'usage-limit', limit: 3n }],
-            },
-          },
-        },
-      ],
-      policyAddresses: { sudo: SUDO_OVERRIDE },
-    })
-    const data = getSessionData(session)
-    const userAction = data.actions[0]
-    expect(userAction.actionPolicies[0].policy).toBe(SUDO_OVERRIDE)
-    // Non-overridden policies keep their default address.
-    expect(userAction.actionPolicies[1].policy).toBe(USAGE_LIMIT_POLICY_ADDRESS)
-  })
-
   test('override propagates to the erc1271 sudo policy too', () => {
     const session = toSession({
       chain: base,
@@ -566,30 +542,6 @@ describe('getSessionData', () => {
     expect(data.actions).toHaveLength(1)
     expect(data.actions[0].actionTarget).toBe(
       SMART_SESSIONS_FALLBACK_TARGET_FLAG,
-    )
-  })
-
-  test('multiple policies on one action', () => {
-    const session = toSession({
-      chain: base,
-      owners: { type: 'ecdsa', accounts: [accountA] },
-      permissions: [
-        {
-          abi: erc20Abi,
-          address: '0x2222222222222222222222222222222222222222' as Address,
-          functions: {
-            transfer: {
-              policies: [{ type: 'sudo' }, { type: 'usage-limit', limit: 3n }],
-            },
-          },
-        },
-      ],
-    })
-    const data = getSessionData(session)
-    expect(data.actions[0].actionPolicies).toHaveLength(2)
-    expect(data.actions[0].actionPolicies[0].policy).toBe(SUDO_POLICY_ADDRESS)
-    expect(data.actions[0].actionPolicies[1].policy).toBe(
-      USAGE_LIMIT_POLICY_ADDRESS,
     )
   })
 

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -1155,14 +1155,15 @@ function getPolicyData(
       }
     }
     case 'time-frame': {
-      // Deployed TimeFramePolicy reads `bytes16 validUntil || bytes16 validAfter` (32 bytes).
+      // Deployed TimeFramePolicy slices initData[0:12] and unpacks as
+      // uint48 validUntil || uint48 validAfter (high 48 bits || low 48 bits).
       return {
         policy: addresses.timeFrame,
         initData: encodePacked(
-          ['uint128', 'uint128'],
+          ['uint48', 'uint48'],
           [
-            BigInt(Math.floor(policy.validUntil / 1000)),
-            BigInt(Math.floor(policy.validAfter / 1000)),
+            Math.floor(policy.validUntil / 1000),
+            Math.floor(policy.validAfter / 1000),
           ],
         ),
       }

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -35,6 +35,7 @@ import {
 } from '../../orchestrator/registry'
 import type {
   Action,
+  ArgPolicyExpression,
   Permit2ClaimPolicy,
   Policy,
   ProviderConfig,
@@ -46,6 +47,7 @@ import type {
   Session,
   SessionDefinition,
   SessionEnableData,
+  SessionPolicyAddresses,
   UniversalActionPolicyParamCondition,
 } from '../../types'
 import smartSessionEmissaryAbi from '../abi/smart-session-emissary'
@@ -206,17 +208,18 @@ const DUMMY_PRECLAIMOP_TARGET: Address =
 const DUMMY_PRECLAIMOP_SELECTOR: Hex = '0x69123456'
 
 const SPENDING_LIMITS_POLICY_ADDRESS: Address =
-  '0x00000088d48cf102a8cdb0137a9b173f957c6343'
+  '0x000000000033212E272655D8a22402Db819477A6'
 const TIME_FRAME_POLICY_ADDRESS: Address =
-  '0x8177451511de0577b911c254e9551d981c26dc72'
+  '0x0000000000D30f611fA3bf652ac6879428586930'
 const SUDO_POLICY_ADDRESS: Address =
-  '0x0000003111cd8e92337c100f22b7a9dbf8dee301'
+  '0x0000000000FEEc8D74e3143fBaBbca515358d869'
 const UNIVERSAL_ACTION_POLICY_ADDRESS: Address =
-  '0x0000006dda6c463511c4e9b05cfc34c1247fcf1f'
+  '0x0000000000714Cf48FcF88A0bFBa70d313415032'
+const ARG_POLICY_ADDRESS: Address = '0x0000000000167edE64D8751daACDdC0312565a73'
 const USAGE_LIMIT_POLICY_ADDRESS: Address =
-  '0x1f34ef8311345a3a4a4566af321b313052f51493'
+  '0x00000000001d4479FA2A947026204d0283ceDe4B'
 const VALUE_LIMIT_POLICY_ADDRESS: Address =
-  '0x730da93267e7e513e932301b47f2ac7d062abc83'
+  '0x000000000021dC45451291BCDfc9f0B46d6f0278'
 const INTENT_EXECUTION_POLICY_ADDRESS: Address =
   '0xe9eA54d063975cDee9e06b7636d5563d95a7A23C'
 const INTENT_EXECUTION_POLICY_ADDRESS_DEV: Address =
@@ -229,6 +232,62 @@ const ACTION_CONDITION_GREATER_THAN_OR_EQUAL = 3
 const ACTION_CONDITION_LESS_THAN_OR_EQUAL = 4
 const ACTION_CONDITION_NOT_EQUAL = 5
 const ACTION_CONDITION_IN_RANGE = 6
+
+// ArgPolicy expression-tree node packing — must match ArgPolicyTreeLib.sol:
+//   bits  0..1  : node type (0=rule, 1=NOT, 2=AND, 3=OR)
+//   bits  2..9  : rule index (rule nodes only)
+//   bits 10..17 : left/only child index
+//   bits 18..25 : right child index (AND/OR only)
+const ARG_NODE_TYPE_RULE = 0n
+const ARG_NODE_TYPE_NOT = 1n
+const ARG_NODE_TYPE_AND = 2n
+const ARG_NODE_TYPE_OR = 3n
+const ARG_RULE_INDEX_SHIFT = 2n
+const ARG_LEFT_CHILD_SHIFT = 10n
+const ARG_RIGHT_CHILD_SHIFT = 18n
+// On-chain caps from ArgPolicyTreeLib.sol; fail early instead of letting
+// the deployment revert with `TooManyRules` / `TooManyNodes`.
+const ARG_MAX_RULES = 128
+const ARG_MAX_NODES = 256
+
+// Defaults resolved at construction time; users override via
+// `SessionDefinition.policyAddresses`.
+interface ResolvedPolicyAddresses {
+  sudo: Address
+  universalAction: Address
+  argPolicy: Address
+  spendingLimits: Address
+  timeFrame: Address
+  usageLimit: Address
+  valueLimit: Address
+}
+
+const DEFAULT_POLICY_ADDRESSES: ResolvedPolicyAddresses = {
+  sudo: SUDO_POLICY_ADDRESS,
+  universalAction: UNIVERSAL_ACTION_POLICY_ADDRESS,
+  argPolicy: ARG_POLICY_ADDRESS,
+  spendingLimits: SPENDING_LIMITS_POLICY_ADDRESS,
+  timeFrame: TIME_FRAME_POLICY_ADDRESS,
+  usageLimit: USAGE_LIMIT_POLICY_ADDRESS,
+  valueLimit: VALUE_LIMIT_POLICY_ADDRESS,
+}
+
+function resolvePolicyAddresses(
+  overrides?: SessionPolicyAddresses,
+): ResolvedPolicyAddresses {
+  if (!overrides) return DEFAULT_POLICY_ADDRESSES
+  return {
+    sudo: overrides.sudo ?? DEFAULT_POLICY_ADDRESSES.sudo,
+    universalAction:
+      overrides.universalAction ?? DEFAULT_POLICY_ADDRESSES.universalAction,
+    argPolicy: overrides.argPolicy ?? DEFAULT_POLICY_ADDRESSES.argPolicy,
+    spendingLimits:
+      overrides.spendingLimits ?? DEFAULT_POLICY_ADDRESSES.spendingLimits,
+    timeFrame: overrides.timeFrame ?? DEFAULT_POLICY_ADDRESSES.timeFrame,
+    usageLimit: overrides.usageLimit ?? DEFAULT_POLICY_ADDRESSES.usageLimit,
+    valueLimit: overrides.valueLimit ?? DEFAULT_POLICY_ADDRESSES.valueLimit,
+  }
+}
 
 interface ResolvedSessionSignerSet {
   type: 'experimental_session'
@@ -628,7 +687,12 @@ function toSession<const TAbis extends readonly Abi[]>(
   definition: SessionDefinition<TAbis>,
   options: { useDevContracts?: boolean } = {},
 ): Session {
-  const sessionData = resolveSessionData(definition, options.useDevContracts)
+  const addresses = resolvePolicyAddresses(definition.policyAddresses)
+  const sessionData = resolveSessionData(
+    definition,
+    options.useDevContracts,
+    addresses,
+  )
   return {
     chain: definition.chain,
     owners: definition.owners,
@@ -674,6 +738,7 @@ function resolvePermit2ClaimPolicy(
 function resolveSessionData(
   session: SessionDefinition,
   useDevContracts?: boolean,
+  addresses: ResolvedPolicyAddresses = DEFAULT_POLICY_ADDRESSES,
 ): SessionData {
   const validator = getValidator(session.owners)
   const allowedContent = [
@@ -686,7 +751,7 @@ function resolveSessionData(
     allowedERC7739Content: allowedContent,
     erc1271Policies: [
       {
-        policy: SUDO_POLICY_ADDRESS,
+        policy: addresses.sudo,
         initData: '0x' as Hex,
       },
     ],
@@ -696,7 +761,7 @@ function resolveSessionData(
     actionTarget: SMART_SESSIONS_FALLBACK_TARGET_FLAG,
     actionPolicies: [
       {
-        policy: SUDO_POLICY_ADDRESS,
+        policy: addresses.sudo,
         initData: '0x' as Hex,
       },
     ],
@@ -742,10 +807,10 @@ function resolveSessionData(
             ? action.target
             : SMART_SESSIONS_FALLBACK_TARGET_FLAG,
         actionPolicies: action.policies?.map((policy) =>
-          getPolicyData(policy, useDevContracts),
+          getPolicyData(policy, useDevContracts, addresses),
         ) ?? [
           {
-            policy: SUDO_POLICY_ADDRESS,
+            policy: addresses.sudo,
             initData: '0x' as Hex,
           },
         ],
@@ -813,11 +878,119 @@ function getPermissionIdFromData(sessionData: SessionData) {
   )
 }
 
-function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
+function getActionConditionId(
+  condition: UniversalActionPolicyParamCondition,
+): number {
+  switch (condition) {
+    case 'equal':
+      return ACTION_CONDITION_EQUAL
+    case 'greaterThan':
+      return ACTION_CONDITION_GREATER_THAN
+    case 'lessThan':
+      return ACTION_CONDITION_LESS_THAN
+    case 'greaterThanOrEqual':
+      return ACTION_CONDITION_GREATER_THAN_OR_EQUAL
+    case 'lessThanOrEqual':
+      return ACTION_CONDITION_LESS_THAN_OR_EQUAL
+    case 'notEqual':
+      return ACTION_CONDITION_NOT_EQUAL
+    case 'inRange':
+      return ACTION_CONDITION_IN_RANGE
+  }
+}
+
+function encodeActionParamRule(rule: {
+  condition: UniversalActionPolicyParamCondition
+  calldataOffset: bigint
+  usageLimit?: bigint
+  referenceValue: Hex | bigint
+}): ActionParamRule {
+  const ref = isHex(rule.referenceValue)
+    ? padHex(rule.referenceValue)
+    : toHex(rule.referenceValue, { size: 32 })
+  return {
+    condition: getActionConditionId(rule.condition),
+    offset: rule.calldataOffset,
+    isLimited: rule.usageLimit !== undefined,
+    ref,
+    usage: {
+      limit: rule.usageLimit ?? 0n,
+      used: 0n,
+    },
+  }
+}
+
+// Compile an ArgPolicyExpression AST into the on-chain wire format
+// (flat rules[] + bit-packed nodes[] + rootNodeIndex). Post-order walk:
+// children get appended before their parent so a parent's child indices
+// always reference earlier slots.
+function compileArgPolicyExpression(expr: ArgPolicyExpression): {
+  rules: ActionParamRule[]
+  packedNodes: bigint[]
+  rootNodeIndex: number
+} {
+  const rules: ActionParamRule[] = []
+  const nodes: bigint[] = []
+
+  function walk(e: ArgPolicyExpression): number {
+    switch (e.type) {
+      case 'rule': {
+        const ruleIdx = rules.length
+        rules.push(encodeActionParamRule(e.rule))
+        const nodeIdx = nodes.length
+        nodes.push(
+          ARG_NODE_TYPE_RULE | (BigInt(ruleIdx) << ARG_RULE_INDEX_SHIFT),
+        )
+        return nodeIdx
+      }
+      case 'not': {
+        const childIdx = walk(e.child)
+        const nodeIdx = nodes.length
+        nodes.push(
+          ARG_NODE_TYPE_NOT | (BigInt(childIdx) << ARG_LEFT_CHILD_SHIFT),
+        )
+        return nodeIdx
+      }
+      case 'and':
+      case 'or': {
+        const leftIdx = walk(e.left)
+        const rightIdx = walk(e.right)
+        const nodeIdx = nodes.length
+        const nodeType = e.type === 'and' ? ARG_NODE_TYPE_AND : ARG_NODE_TYPE_OR
+        nodes.push(
+          nodeType |
+            (BigInt(leftIdx) << ARG_LEFT_CHILD_SHIFT) |
+            (BigInt(rightIdx) << ARG_RIGHT_CHILD_SHIFT),
+        )
+        return nodeIdx
+      }
+    }
+  }
+
+  const rootNodeIndex = walk(expr)
+
+  if (rules.length > ARG_MAX_RULES) {
+    throw new Error(
+      `ArgPolicy expression has ${rules.length} rules, max is ${ARG_MAX_RULES}`,
+    )
+  }
+  if (nodes.length > ARG_MAX_NODES) {
+    throw new Error(
+      `ArgPolicy expression has ${nodes.length} nodes, max is ${ARG_MAX_NODES}`,
+    )
+  }
+  return { rules, packedNodes: nodes, rootNodeIndex }
+}
+
+function getPolicyData(
+  policy: Policy,
+  useDevContracts?: boolean,
+  addresses: ResolvedPolicyAddresses = DEFAULT_POLICY_ADDRESSES,
+): PolicyData {
   switch (policy.type) {
     case 'sudo':
       return {
-        policy: SUDO_POLICY_ADDRESS,
+        policy: addresses.sudo,
         initData: '0x',
       }
     case 'intent-execution':
@@ -828,25 +1001,6 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
         initData: '0x',
       }
     case 'universal-action': {
-      function getCondition(condition: UniversalActionPolicyParamCondition) {
-        switch (condition) {
-          case 'equal':
-            return ACTION_CONDITION_EQUAL
-          case 'greaterThan':
-            return ACTION_CONDITION_GREATER_THAN
-          case 'lessThan':
-            return ACTION_CONDITION_LESS_THAN
-          case 'greaterThanOrEqual':
-            return ACTION_CONDITION_GREATER_THAN_OR_EQUAL
-          case 'lessThanOrEqual':
-            return ACTION_CONDITION_LESS_THAN_OR_EQUAL
-          case 'notEqual':
-            return ACTION_CONDITION_NOT_EQUAL
-          case 'inRange':
-            return ACTION_CONDITION_IN_RANGE
-        }
-      }
-
       const MAX_RULES = 16
       const rules = createFixedArray<ActionParamRule, typeof MAX_RULES>(
         MAX_RULES,
@@ -859,23 +1013,10 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
         }),
       )
       for (let i = 0; i < policy.rules.length; i++) {
-        const rule = policy.rules[i]
-        const ref = isHex(rule.referenceValue)
-          ? padHex(rule.referenceValue)
-          : toHex(rule.referenceValue, { size: 32 })
-        rules[i] = {
-          condition: getCondition(rule.condition),
-          offset: rule.calldataOffset,
-          isLimited: rule.usageLimit !== undefined,
-          ref,
-          usage: {
-            limit: rule.usageLimit ? rule.usageLimit : 0n,
-            used: 0n,
-          },
-        }
+        rules[i] = encodeActionParamRule(policy.rules[i])
       }
       return {
-        policy: UNIVERSAL_ACTION_POLICY_ADDRESS,
+        policy: addresses.universalAction,
         initData: encodeAbiParameters(
           [
             {
@@ -947,11 +1088,66 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
         ),
       }
     }
+    case 'arg-policy': {
+      const { rules, packedNodes, rootNodeIndex } = compileArgPolicyExpression(
+        policy.expression,
+      )
+      return {
+        policy: addresses.argPolicy,
+        initData: encodeAbiParameters(
+          [
+            {
+              components: [
+                { name: 'valueLimitPerUse', type: 'uint256' },
+                {
+                  components: [
+                    { name: 'rootNodeIndex', type: 'uint8' },
+                    {
+                      components: [
+                        { name: 'condition', type: 'uint8' },
+                        { name: 'offset', type: 'uint64' },
+                        { name: 'isLimited', type: 'bool' },
+                        { name: 'ref', type: 'bytes32' },
+                        {
+                          components: [
+                            { name: 'limit', type: 'uint256' },
+                            { name: 'used', type: 'uint256' },
+                          ],
+                          name: 'usage',
+                          type: 'tuple',
+                        },
+                      ],
+                      name: 'rules',
+                      type: 'tuple[]',
+                    },
+                    { name: 'packedNodes', type: 'uint256[]' },
+                  ],
+                  name: 'paramRules',
+                  type: 'tuple',
+                },
+              ],
+              name: 'ActionConfig',
+              type: 'tuple',
+            },
+          ],
+          [
+            {
+              valueLimitPerUse: policy.valueLimitPerUse ?? 0n,
+              paramRules: {
+                rootNodeIndex,
+                rules,
+                packedNodes,
+              },
+            },
+          ],
+        ),
+      }
+    }
     case 'spending-limits': {
       const tokens = policy.limits.map(({ token }) => token)
       const limits = policy.limits.map(({ amount }) => amount)
       return {
-        policy: SPENDING_LIMITS_POLICY_ADDRESS,
+        policy: addresses.spendingLimits,
         initData: encodeAbiParameters(
           [{ type: 'address[]' }, { type: 'uint256[]' }],
           [tokens, limits],
@@ -961,7 +1157,7 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
     case 'time-frame': {
       // Deployed TimeFramePolicy reads `bytes16 validUntil || bytes16 validAfter` (32 bytes).
       return {
-        policy: TIME_FRAME_POLICY_ADDRESS,
+        policy: addresses.timeFrame,
         initData: encodePacked(
           ['uint128', 'uint128'],
           [
@@ -973,13 +1169,13 @@ function getPolicyData(policy: Policy, useDevContracts?: boolean): PolicyData {
     }
     case 'usage-limit': {
       return {
-        policy: USAGE_LIMIT_POLICY_ADDRESS,
+        policy: addresses.usageLimit,
         initData: encodePacked(['uint128'], [policy.limit]),
       }
     }
     case 'value-limit': {
       return {
-        policy: VALUE_LIMIT_POLICY_ADDRESS,
+        policy: addresses.valueLimit,
         initData: encodeAbiParameters([{ type: 'uint256' }], [policy.limit]),
       }
     }
@@ -1110,6 +1306,7 @@ export {
   TIME_FRAME_POLICY_ADDRESS,
   SUDO_POLICY_ADDRESS,
   UNIVERSAL_ACTION_POLICY_ADDRESS,
+  ARG_POLICY_ADDRESS,
   USAGE_LIMIT_POLICY_ADDRESS,
   VALUE_LIMIT_POLICY_ADDRESS,
   INTENT_EXECUTION_POLICY_ADDRESS,

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,13 +288,24 @@ type ParamConstraint<TValue> =
     }
 
 // Compile-time gates for sugar fields that only make sense on certain ABIs.
-// Structural `extends` on `inputs` so extra ABI entry fields (`name`,
-// `internalType`) don't prevent the match.
-type IsERC20TransferLike<TFn extends AbiFunction> = TFn['inputs'] extends
-  | readonly [{ type: 'address' }, { type: 'uint256' }]
-  | readonly [{ type: 'address' }, { type: 'address' }, { type: 'uint256' }]
-  ? true
-  : false
+// Match the on-chain selector dispatch in ERC20SpendingLimitPolicy: name must
+// be one of the four ERC-20 transfer/approve selectors AND shape must match.
+type IsERC20TransferLike<TFn extends AbiFunction> = TFn['name'] extends
+  | 'approve'
+  | 'increaseAllowance'
+  | 'transfer'
+  ? TFn['inputs'] extends readonly [{ type: 'address' }, { type: 'uint256' }]
+    ? true
+    : false
+  : TFn['name'] extends 'transferFrom'
+    ? TFn['inputs'] extends readonly [
+        { type: 'address' },
+        { type: 'address' },
+        { type: 'uint256' },
+      ]
+      ? true
+      : false
+    : false
 
 type IsPayable<TFn extends AbiFunction> =
   TFn['stateMutability'] extends 'payable' ? true : false

--- a/src/types.ts
+++ b/src/types.ts
@@ -322,8 +322,6 @@ type ValueLimitField<TFn extends AbiFunction> = IsPayable<TFn> extends true
   : { valueLimit?: never }
 
 type PermissionFunctionConfig<TFn extends AbiFunction> = {
-  /** Escape hatch — raw `Policy` objects merged with sugar-emitted policies. */
-  policies?: Policy[]
   /** `valueLimitPerUse` embedded in universal/arg-policy `ActionConfig`. */
   valueLimitPerUse?: bigint
   params?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,23 @@ type UniversalActionPolicyParamCondition =
   | 'notEqual'
   | 'inRange'
 
+// ArgPolicy is the expression-tree successor to UniversalActionPolicy. Same
+// per-rule leaf semantics, but rules are composed with AND/OR/NOT nodes and
+// arbitrary nesting instead of an implicit all-AND fixed array. Use when a
+// session needs disjunction (e.g. "recipient == alice OR recipient == bob") —
+// for plain AND-of-rules, UniversalActionPolicy is simpler and cheaper to init.
+type ArgPolicyExpression =
+  | { type: 'rule'; rule: UniversalActionPolicyParamRule }
+  | { type: 'not'; child: ArgPolicyExpression }
+  | { type: 'and'; left: ArgPolicyExpression; right: ArgPolicyExpression }
+  | { type: 'or'; left: ArgPolicyExpression; right: ArgPolicyExpression }
+
+interface ArgPolicy {
+  type: 'arg-policy'
+  valueLimitPerUse?: bigint
+  expression: ArgPolicyExpression
+}
+
 interface SpendingLimitsPolicy {
   type: 'spending-limits'
   limits: {
@@ -188,6 +205,7 @@ interface Permit2ClaimPolicy {
 type Policy =
   | SudoPolicy
   | UniversalActionPolicy
+  | ArgPolicy
   | SpendingLimitsPolicy
   | TimeFramePolicy
   | UsageLimitPolicy
@@ -250,19 +268,72 @@ type NamedInputs<TFn extends AbiFunction> = Extract<
   { name: string }
 >
 
-interface ParamConstraint<TValue> {
-  condition: UniversalActionPolicyParamCondition
-  value: TValue
-  usageLimit?: bigint
-}
+// A constraint on a single named parameter. Two shapes:
+//   - { condition, value, usageLimit? } : single comparison (AND-conjunctive,
+//     emits universal-action when every param uses this form)
+//   - { anyOf: [v1, v2, ...] }           : OR of EQUAL rules (allowlist) —
+//     forces the function to emit arg-policy
+type ParamConstraint<TValue> =
+  | {
+      condition: UniversalActionPolicyParamCondition
+      value: TValue
+      usageLimit?: bigint
+      anyOf?: never
+    }
+  | {
+      anyOf: readonly [TValue, ...TValue[]]
+      condition?: never
+      value?: never
+      usageLimit?: never
+    }
 
-interface PermissionFunctionConfig<TFn extends AbiFunction> {
+// Compile-time gates for sugar fields that only make sense on certain ABIs.
+// Structural `extends` on `inputs` so extra ABI entry fields (`name`,
+// `internalType`) don't prevent the match.
+type IsERC20TransferLike<TFn extends AbiFunction> = TFn['inputs'] extends
+  | readonly [{ type: 'address' }, { type: 'uint256' }]
+  | readonly [{ type: 'address' }, { type: 'address' }, { type: 'uint256' }]
+  ? true
+  : false
+
+type IsPayable<TFn extends AbiFunction> =
+  TFn['stateMutability'] extends 'payable' ? true : false
+
+// `never` on the sugar field rejects any user-supplied value at the call site,
+// turning a footgun (e.g. spendingLimit on vault.deposit) into a compile error.
+type SpendingLimitField<TFn extends AbiFunction> =
+  IsERC20TransferLike<TFn> extends true
+    ? { spendingLimit?: { token: Address; amount: bigint } }
+    : { spendingLimit?: never }
+
+type ValueLimitField<TFn extends AbiFunction> = IsPayable<TFn> extends true
+  ? { valueLimit?: bigint }
+  : { valueLimit?: never }
+
+type PermissionFunctionConfig<TFn extends AbiFunction> = {
+  /** Escape hatch — raw `Policy` objects merged with sugar-emitted policies. */
   policies?: Policy[]
+  /** `valueLimitPerUse` embedded in universal/arg-policy `ActionConfig`. */
   valueLimitPerUse?: bigint
   params?: {
     [K in NamedInputs<TFn>['name']]?: ParamConstraint<ParamValue<TFn, K>>
   }
-}
+  /**
+   * Per-action call cap. Emits a standalone `usage-limit` policy.
+   * Counter is scoped to this single action — `transfer.maxUses=10` and
+   * `approve.maxUses=10` are independent counters.
+   */
+  maxUses?: bigint
+  /**
+   * Upper bound on `block.timestamp` (Date or ms-epoch). Pairs with
+   * `validAfter` into one `time-frame` policy. If only one of the two is set,
+   * the other defaults to "always passes" (validAfter=0 / validUntil=year-2100).
+   */
+  validUntil?: Date | number
+  /** Lower bound on `block.timestamp` (Date or ms-epoch). See `validUntil`. */
+  validAfter?: Date | number
+} & SpendingLimitField<TFn> &
+  ValueLimitField<TFn>
 
 interface Permission<TAbi extends Abi = Abi> {
   abi: TAbi
@@ -278,11 +349,39 @@ type PermissionsForAbis<TAbis extends readonly Abi[]> = {
   [K in keyof TAbis]: TAbis[K] extends Abi ? Permission<TAbis[K]> : never
 }
 
+/**
+ * Per-session override for SmartSession policy singleton addresses.
+ *
+ * Defaults are the latest canonical V2 deployments. Provide a partial map to
+ * pin one or more policies to non-default addresses — primarily for backwards
+ * compatibility with accounts that already enabled sessions against the
+ * previous V1 deployments.
+ *
+ * Resolved addresses are baked into `Session.actions[i].actionPolicies[j].policy`
+ * at construction time, so this only needs to be set on `SessionDefinition` —
+ * downstream consumers read the already-resolved values off the `Session`.
+ */
+interface SessionPolicyAddresses {
+  sudo?: Address
+  universalAction?: Address
+  argPolicy?: Address
+  spendingLimits?: Address
+  timeFrame?: Address
+  usageLimit?: Address
+  valueLimit?: Address
+}
+
 interface SessionDefinition<TAbis extends readonly Abi[] = readonly Abi[]> {
   chain: Chain
   owners: OwnerSet
   permissions?: readonly [...PermissionsForAbis<TAbis>]
   claimPolicies?: readonly Permit2ClaimPolicy[]
+  /**
+   * Override one or more SmartSession policy addresses. Defaults to the latest
+   * V2 deployments. Use to pin to V1 deployments for an account that already
+   * has sessions enabled against them.
+   */
+  policyAddresses?: SessionPolicyAddresses
 }
 
 type SessionInput<TAbis extends readonly Abi[] = readonly Abi[]> = Omit<
@@ -697,6 +796,8 @@ export type {
   Policy,
   Permit2ClaimPolicy,
   UniversalActionPolicyParamCondition,
+  ArgPolicyExpression,
+  SessionPolicyAddresses,
   ApiKeyAuth,
   JwtAuth,
   AuthConfig,

--- a/test/types/session-permissions.ts
+++ b/test/types/session-permissions.ts
@@ -127,6 +127,23 @@ toSession({
   ],
 })
 
+toSession({
+  chain: base,
+  owners: { type: 'ecdsa', accounts: [accountA] },
+  permissions: [
+    {
+      abi: erc20Abi,
+      address: USDC,
+      functions: {
+        transfer: {
+          // @ts-expect-error raw policies were removed from permission configs.
+          policies: [{ type: 'usage-limit', limit: 1n }],
+        },
+      },
+    },
+  ],
+})
+
 const permission = {
   abi: erc20Abi,
   address: USDC,


### PR DESCRIPTION
## Summary

Ports PR #541 to the `release` branch (V2) and adapts it to the `toSession` API.

- Bumps the 6 SmartSession action-policy singleton addresses to the new canonical V2 deployments and adds `ARG_POLICY_ADDRESS`.
- Adds the `arg-policy` policy variant (`ArgPolicyExpression` AST: `rule` / `not` / `and` / `or`) with expression-tree encoding matching `ArgPolicyTreeLib.sol` (bit-packed nodes, post-order layout).
- Extends the `permissions` builder consumed by `toSession`:
  - `params` constraints accept `{ anyOf: [v1, v2, ...] }` to allowlist values — compiles to a right-folded OR chain and switches the function to `arg-policy`. Single-condition params keep emitting `universal-action` (cheaper init).
  - Per-function sugar fields: `maxUses`, `validUntil`, `validAfter`, `valueLimit` (compile- and runtime-gated to `payable`), `spendingLimit` (compile- and runtime-gated to ERC-20-transfer-shaped ABIs).
- Adds `SessionDefinition.policyAddresses?: SessionPolicyAddresses` — a partial map (`sudo`, `universalAction`, `argPolicy`, `spendingLimits`, `timeFrame`, `usageLimit`, `valueLimit`) so accounts already enabled against the previous V2 policy deployments can pin one or more addresses per session. Defaults stay V2.
- Right-pads `bytesN` reference values to 32 bytes so the encoded `bytes32` matches Solidity calldata alignment (port of `81695d7`).

Tests cover arg-policy bit packing, post-order ordering, 129-rule rejection, `anyOf` (single/double/triple), AND-composition across params, all sugar fields, type-gate runtime backstops, `bytesN` padding for `bytes1`/`bytes4`/`bytes32`, and the `policyAddresses` override (partial pin + fallback + erc1271 propagation).

Companion PR (against `main`/v1): rhinestonewtf/sdk#541