### PR TITLE
feat: add HyperCore as a destination chain

### DIFF
--- a/.changeset/hypercore-destination.md
+++ b/.changeset/hypercore-destination.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add HyperCore as a destination chain. `hyperCoreMainnet` (Hyperliquid's virtual trading L1, chain id 1337, settling on HyperEVM 999) can now be passed as `targetChain`, exactly like `solanaMainnet` / `tronMainnet`. HyperCore deposits are solver-mediated — the orchestrator builds the core-deposit executions and the user signs no destination session — so they prepare and sign without a destination-side smart session. Previously, expressing a HyperCore destination as a viem chain with id 1337 threw `UnsupportedChainError` at signing because 1337 is not a registered EVM chain.

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ import type {
   TokenRequirements,
   WrapRequired,
 } from './orchestrator'
-import { solanaMainnet, tronMainnet } from './orchestrator'
+import { hyperCoreMainnet, solanaMainnet, tronMainnet } from './orchestrator'
 import type {
   AccountProviderConfig,
   AccountType,
@@ -602,7 +602,8 @@ class RhinestoneSDK {
 export {
   RhinestoneSDK,
   createRhinestoneAccount,
-  // Non-EVM destination chain descriptors
+  // Non-viem destination chain descriptors (Solana, Tron, HyperCore)
+  hyperCoreMainnet,
   solanaMainnet,
   tronMainnet,
   // Validator addresses

--- a/src/orchestrator/destinations.test.ts
+++ b/src/orchestrator/destinations.test.ts
@@ -1,0 +1,45 @@
+import { base } from 'viem/chains'
+import { describe, expect, test } from 'vitest'
+import {
+  getChainId,
+  hyperCoreMainnet,
+  isNonEvmChain,
+  solanaMainnet,
+  tronMainnet,
+} from './destinations'
+
+describe('isNonEvmChain', () => {
+  test('true for any descriptor-addressed destination (svm/tvm/hypercore)', () => {
+    expect(isNonEvmChain(solanaMainnet)).toBe(true)
+    expect(isNonEvmChain(tronMainnet)).toBe(true)
+    expect(isNonEvmChain(hyperCoreMainnet)).toBe(true)
+  })
+
+  test('false for a plain viem Chain', () => {
+    expect(isNonEvmChain(base)).toBe(false)
+  })
+})
+
+describe('getChainId', () => {
+  test('viem Chain uses its numeric id', () => {
+    expect(getChainId(base)).toBe(base.id)
+  })
+
+  test('Solana / Tron resolve to their synthetic ids', () => {
+    expect(getChainId(solanaMainnet)).toBe(792703809)
+    expect(getChainId(tronMainnet)).toBe(728126428)
+  })
+
+  // HyperCore is addressed by its virtual id 1337 on the wire; the orchestrator
+  // maps 1337 -> 999 (HyperEVM) for settlement.
+  test('HyperCore resolves to the virtual id 1337', () => {
+    expect(getChainId(hyperCoreMainnet)).toBe(1337)
+  })
+})
+
+describe('hyperCoreMainnet descriptor', () => {
+  test('is an EVM-settled virtual destination addressed by eip155:1337', () => {
+    expect(hyperCoreMainnet.kind).toBe('hypercore')
+    expect(hyperCoreMainnet.caip2).toBe('eip155:1337')
+  })
+})

--- a/src/orchestrator/destinations.ts
+++ b/src/orchestrator/destinations.ts
@@ -1,7 +1,9 @@
-// Public non-EVM destination chain descriptors. Mirrors the minimal shape
-// of viem's `Chain` (name, nativeCurrency) so callers can pass them
-// anywhere a destination chain is expected — `targetChain: solanaMainnet`
-// reads the same as `targetChain: optimism`.
+// Public destination chain descriptors for destinations that aren't a plain
+// viem `Chain`: the non-EVM chains (Solana, Tron) plus HyperCore (an EVM-settled
+// virtual L1). Mirrors the minimal shape of viem's `Chain` (name,
+// nativeCurrency) so callers can pass them anywhere a destination chain is
+// expected — `targetChain: solanaMainnet` reads the same as `targetChain:
+// optimism`.
 //
 // The `kind` field discriminates these from viem `Chain` objects; viem
 // chains don't carry a `kind` field, so the `isNonEvmChain` helper
@@ -31,7 +33,10 @@ type NonEvmAddress = string
 interface NonEvmChain {
   readonly name: string
   readonly caip2: Caip2ChainId
-  readonly kind: 'svm' | 'tvm'
+  // 'svm' (Solana) / 'tvm' (Tron) are non-EVM VMs; 'hypercore' is an EVM-settled
+  // virtual L1. All three are solver-mediated destinations with no user-signed
+  // destination session — see `isNonEvmChain`.
+  readonly kind: 'svm' | 'tvm' | 'hypercore'
   readonly nativeCurrency: NativeCurrency
   readonly testnet?: boolean
 }
@@ -52,8 +57,26 @@ const tronMainnet: NonEvmChain = {
   nativeCurrency: { name: 'Tron', symbol: 'TRX', decimals: 6 },
 }
 
+// HyperCore is Hyperliquid's virtual trading L1 (chain id 1337). Unlike Solana
+// and Tron it settles on an EVM chain (HyperEVM, 999), but the deposit is
+// solver-mediated: the orchestrator builds the core-deposit executions and the
+// user signs no destination session, so it belongs with the descriptor-addressed
+// destinations rather than the standard EVM signing path. The CAIP-2 reference
+// is the virtual id; the orchestrator maps 1337 → 999 for settlement.
+const hyperCoreMainnet: NonEvmChain = {
+  name: 'HyperCore',
+  caip2: 'eip155:1337',
+  kind: 'hypercore',
+  nativeCurrency: { name: 'Hyperliquid', symbol: 'HYPE', decimals: 18 },
+}
+
+// True for any descriptor-addressed destination (Solana, Tron, HyperCore) as
+// opposed to a plain viem `Chain`. viem chains carry no `kind` field, so the
+// presence of `kind` is the structural discriminator — and every such
+// destination is solver-mediated (no user-signed destination session, no
+// destination-side validator), which is what every caller keys off.
 function isNonEvmChain(chain: DestinationChain): chain is NonEvmChain {
-  return 'kind' in chain && (chain.kind === 'svm' || chain.kind === 'tvm')
+  return 'kind' in chain
 }
 
 // Numeric chain id for either chain kind. EVM uses viem's `id`; non-EVM
@@ -64,4 +87,10 @@ function getChainId(chain: DestinationChain): number {
 }
 
 export type { DestinationChain, NativeCurrency, NonEvmAddress, NonEvmChain }
-export { getChainId, isNonEvmChain, solanaMainnet, tronMainnet }
+export {
+  getChainId,
+  hyperCoreMainnet,
+  isNonEvmChain,
+  solanaMainnet,
+  tronMainnet,
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3,6 +3,7 @@ import { Orchestrator } from './client'
 import { PROD_ORCHESTRATOR_URL, RHINESTONE_SPOKE_POOL_ADDRESS } from './consts'
 import {
   type DestinationChain,
+  hyperCoreMainnet,
   isNonEvmChain,
   type NonEvmAddress,
   type NonEvmChain,
@@ -136,6 +137,7 @@ export type {
   WrapRequired,
 }
 export {
+  hyperCoreMainnet,
   isNonEvmChain,
   solanaMainnet,
   tronMainnet,

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -125,7 +125,10 @@ function resolveTokenAddress(
   // Non-EVM destinations carry SPL mints (base58) / Tron T-prefixed
   // addresses that don't satisfy viem's `isAddress`. The orchestrator's
   // wire schema accepts the raw string for non-EVM chains, so pass it
-  // through unchanged.
+  // through unchanged. HyperCore is descriptor-addressed too but its tokens
+  // are EVM hex addresses (returned above), so it is intentionally absent
+  // from `isNonEvmChainId` — a token *symbol* for HyperCore is not a valid
+  // request and falls through to the throw below.
   if (isNonEvmChainId(chainId)) {
     return token
   }


### PR DESCRIPTION
## What

Adds **HyperCore** (Hyperliquid's virtual trading L1 — chain id `1337`, settling on HyperEVM `999`) as a destination chain via a new `hyperCoreMainnet` descriptor, alongside `solanaMainnet` / `tronMainnet`.

## Why

The orchestrator already supports HyperCore destinations, but the SDK had no way to express one that *signs*:
- Passing a viem `Chain` with id `1337` takes the EVM destination path → at signing, `getDestinationSignature` → `signDestinationSeparately` → `getChainById(1337)` throws `UnsupportedChainError` (1337 isn't a registered EVM chain). So user-owned / session HyperCore deposits prepare a quote but fail before submission.
- `NonEvmChain` required `kind: 'svm' | 'tvm'`, which doesn't fit HyperCore.

HyperCore deposits are **solver-mediated** (like Solana/Tron): the orchestrator builds the core-deposit `approve`+`depositFor` executions and the user signs **no destination session**. So HyperCore belongs on the same no-destination-signature path as the non-EVM descriptors.

## How

- New `hyperCoreMainnet`: `{ kind: 'hypercore', caip2: 'eip155:1337', nativeCurrency: HYPE }`. `getChainId` → `1337` via `fromCaip2` (the orchestrator maps 1337 → 999 for settlement; the SDK never signs anything keyed to 1337).
- `isNonEvmChain` now keys off the **presence of the `kind` discriminator** (`'kind' in chain`) instead of an `svm | tvm` allowlist. viem chains carry no `kind`, so this is behaviorally identical for every existing input — it just means "any descriptor-addressed destination is solver-mediated," so HyperCore (and any future descriptor) routes through the no-destination-signature path automatically.
- Re-exported `hyperCoreMainnet` through `orchestrator/index.ts` → `src/index.ts`.

I audited all `isNonEvmChain` call sites in `execution/utils.ts`: each is correct for HyperCore (no destination calls, no target-execution signature, recipient emitted as bare `{ address }` — orchestrator treats undefined accountType as EOA, target chain id excluded from `mockSignatures`, destination signature reused from origin). No `getChainById(1337)` is reachable for a descriptor-addressed destination.

## Naming note (reviewer input welcome)

The type stays `NonEvmChain` and the predicate `isNonEvmChain`, though HyperCore is EVM-settled. The property every caller keys off is "solver-mediated, no user destination session" — not the VM. I kept the names (and updated comments to redefine the bucket) to avoid a breaking public-API rename; happy to rename to e.g. `isSolverMediatedDestination` if preferred.

## Known/intended contract

`isNonEvmChain` (now true for 1337) and `isNonEvmChainId` in `caip2.ts` (still false for 1337) diverge. This only surfaces in `resolveTokenAddress`: a HyperCore token expressed as a **symbol** (`'USDC'`) would throw `UnsupportedChainError(1337)`. HyperCore tokens are EVM hex addresses (handled by the `isAddress` passthrough), so the happy path works; symbol-tokens for HyperCore aren't a valid request. Documented inline at `registry.ts`. Flagging in case you'd prefer symbol resolution via the settlement chain (999).

## Testing

`src/orchestrator/destinations.test.ts` (new) covers `isNonEvmChain`/`getChainId` for svm/tvm/hypercore + a viem chain, and the descriptor shape. 113 tests pass across the touched files (`destinations`, `caip2`, `smart-sessions`, `execution/utils`); `tsc --noEmit` clean. Changeset added (`minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
