### PR TITLE
fix(hypercore): send HyperCore recipients as EOA-typed accounts

### DIFF
--- a/.changeset/hypercore-eoa-recipient.md
+++ b/.changeset/hypercore-eoa-recipient.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Send HyperCore recipients as EOA-typed orchestrator accounts. HyperCore recipients are EVM EOAs, but `getRecipient` emitted them as a bare `{ address }` (the Solana/Tron shape, with no `accountType`). The orchestrator's HyperCore planning gate strictly requires `accountType === 'EOA'`, so deposits were rejected at `/quotes` with "HyperCore destinations require an EOA recipient". HyperCore now takes the EVM passthrough (`accountType: 'EOA'`) while remaining solver-mediated for signing.

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -87,7 +87,7 @@ import {
   type Quote,
   type SignData,
 } from '../orchestrator'
-import { toCaip2 } from '../orchestrator/caip2'
+import { isNonEvmChainId, toCaip2 } from '../orchestrator/caip2'
 import {
   type DestinationChain,
   getChainId,
@@ -1014,13 +1014,16 @@ async function prepareTransactionAsIntent(
     recipient: RhinestoneAccountConfig | Address | NonEvmAddress | undefined,
   ): OrchestratorAccount | undefined {
     if (typeof recipient === 'string') {
-      // Non-EVM recipients (Solana base58 / Tron T-prefix) carry no
-      // EVM smart-account semantics; orchestrator schema requires
-      // accountType / setupOps to be unset. Emit just the address.
-      if (isNonEvmChain(targetChain)) {
+      // Non-EVM-addressed recipients (Solana base58 / Tron T-prefix) carry no
+      // EVM smart-account semantics; the orchestrator schema requires
+      // accountType / setupOps to be unset. Emit just the address. HyperCore
+      // is EVM-addressed (eip155:1337) so it falls through to the EOA
+      // passthrough below — the orchestrator's HyperCore gate requires
+      // accountType: 'EOA'.
+      if (isNonEvmChainId(targetChainId)) {
         return { address: recipient }
       }
-      // EVM passthrough — assume EOA.
+      // EVM (and HyperCore) passthrough — assume EOA.
       return {
         address: recipient,
         accountType: 'EOA',


### PR DESCRIPTION
## What

`getRecipient` now emits HyperCore recipients as EOA-typed orchestrator accounts (`{ address, accountType: 'EOA', setupOps: [], delegations }`) instead of the bare `{ address }` shape used for Solana/Tron.

## Why

HyperCore recipients are EVM EOAs, but the recipient was emitted as a bare `{ address }` with no `accountType` (the Solana/Tron path). The orchestrator's HyperCore planning gate **strictly** requires `recipient.accountType === 'EOA'`, so HyperCore deposits were rejected at `POST /quotes`:

> HyperCore destinations require an EOA recipient (or EOA originator on self-send); smart-account recipients are not supported.

This was confirmed from the orchestrator's own request logs: the SDK sent `recipient: { address: 0x… }` with **no** `accountType`, `destinationChainId: 1337`, USDC token — and the planning gate rejected the undefined `accountType`. (The intent schema tolerates `undefined`; the planning gate does not.)

## How

The bare-address branch now keys on **`isNonEvmChainId(targetChainId)`** (the address-namespace predicate — true for Solana/Tron, **false** for `eip155:1337`) instead of `isNonEvmChain(targetChain)` (which #545 made true for HyperCore too).

This is the semantically correct distinction: the recipient shape depends on the *address namespace*, not on whether the destination is solver-mediated. svm/tvm recipients are base58/T-prefix addresses with no EVM semantics → bare `{ address }`. HyperCore recipients are EVM `0x` EOAs → EOA passthrough.

Every other `isNonEvmChain(targetChain)` call site in `execution/utils.ts` is **unchanged** — HyperCore stays solver-mediated for signing (no destination signature, no session resolution). Only the recipient shape changes.

## Testing

End-to-end against the **prod** orchestrator (Base USDC → HyperCore destination) via the deposit-processor local e2e: previously failed at `/quotes` with the EOA-recipient error; with this change it completes `deposit-received → bridge-started → bridge-complete` and persists a `completed` row with `destinationTxHash`. `tsc --noEmit` clean. Changeset added (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)