### PR TITLE
Fix Para signature validation

### DIFF
--- a/src/accounts/walletClient.test.ts
+++ b/src/accounts/walletClient.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { wrapParaAccount } from './walletClient'
+
+const createSignature = (v: string) =>
+  `0x${'11'.repeat(32)}${'22'.repeat(32)}${v}` as const
+
+describe('wrapParaAccount', () => {
+  it('adjusts Para message signatures with 0/1 v-byte', async () => {
+    const account = wrapParaAccount({
+      address: '0x0000000000000000000000000000000000000001',
+      signMessage: async () => createSignature('01'),
+      type: 'local',
+    } as any)
+
+    await expect(account.signMessage({ message: 'hello' })).resolves.toBe(
+      createSignature('1c'),
+    )
+  })
+
+  it('rejects malformed Para message signatures', async () => {
+    const account = wrapParaAccount({
+      address: '0x0000000000000000000000000000000000000001',
+      signMessage: async () => `${'11'.repeat(32)}${'22'.repeat(32)}zz`,
+      type: 'local',
+    } as any)
+
+    await expect(account.signMessage({ message: 'hello' })).rejects.toThrow(
+      'Invalid signature',
+    )
+  })
+})

--- a/src/accounts/walletClient.ts
+++ b/src/accounts/walletClient.ts
@@ -141,6 +141,10 @@ export function wrapParaAccount(
 function adjustVByte(signature: string): Hex {
   const V_OFFSET_FOR_ETHEREUM = 27
   const cleanSig = signature.startsWith('0x') ? signature.slice(2) : signature
+  if (!/^[\da-f]{130}$/iu.test(cleanSig)) {
+    throw new Error('Invalid signature')
+  }
+
   const r = cleanSig.slice(0, 64)
   const s = cleanSig.slice(64, 128)
   let v = parseInt(cleanSig.slice(128, 130), 16)


### PR DESCRIPTION
Fixes Para signature v-byte adjustment so malformed signatures are rejected instead of producing an invalid adjusted signature. Adds regression coverage for malformed Para message signatures.