### PR TITLE
feat: add ENS-HCA smart account support

### DIFF
--- a/.changeset/add-hca-account.md
+++ b/.changeset/add-hca-account.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Add ENS-HCA (Hierarchical Contract Account) support

--- a/src/accounts/error.ts
+++ b/src/accounts/error.ts
@@ -230,6 +230,8 @@ function getAccountName(account: AccountType) {
       return 'Nexus'
     case 'startale':
       return 'Startale'
+    case 'hca':
+      return 'HCA'
     case 'eoa':
       return 'EOA'
   }

--- a/src/accounts/hca.test.ts
+++ b/src/accounts/hca.test.ts
@@ -1,0 +1,350 @@
+import type { Address } from 'viem'
+import { decodeFunctionData, maxUint48, parseAbi } from 'viem'
+import { describe, expect, test } from 'vitest'
+
+import { accountA, accountB, passkeyAccount } from '../../test/consts'
+import { MODULE_TYPE_ID_VALIDATOR } from '../modules/common'
+import { AccountConfigurationNotSupportedError } from './error'
+import {
+  ENS_HCA_MODULE,
+  getAddress,
+  getDeployArgs,
+  getInstallData,
+  packSignature,
+} from './hca'
+
+const MOCK_MODULE_ADDRESS = '0x28de6501fa86f2e6cd0b33c3aabdaeb4a1b93f3f'
+
+describe('Accounts: HCA', () => {
+  describe('Deploy Args', () => {
+    test('ENS owner with expirations', () => {
+      const result = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(result).not.toBeNull()
+      const { factory, factoryData, implementation } = result!
+      expect(factory).toBeDefined()
+      expect(factoryData).toBeDefined()
+      expect(implementation).toBeDefined()
+
+      // Verify factoryData encodes createAccount(bytes)
+      const decoded = decodeFunctionData({
+        abi: parseAbi(['function createAccount(bytes)']),
+        data: factoryData,
+      })
+      expect(decoded.functionName).toEqual('createAccount')
+      expect(decoded.args[0]).toBeDefined()
+    })
+
+    test('ENS owner with multiple owners and threshold', () => {
+      const result = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA, accountB],
+          threshold: 2,
+          ownerExpirations: [Number(maxUint48), 1000000],
+        },
+      })
+      expect(result).not.toBeNull()
+      const { factoryData } = result!
+      expect(factoryData).toBeDefined()
+    })
+
+    test('ECDSA owner throws', () => {
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          owners: {
+            type: 'ecdsa',
+            accounts: [accountA],
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('Passkey owner throws', () => {
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          owners: {
+            type: 'passkey',
+            accounts: [passkeyAccount],
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('recovery throws', () => {
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          owners: {
+            type: 'ens',
+            accounts: [accountA],
+            ownerExpirations: [Number(maxUint48)],
+          },
+          recovery: { guardians: [accountB] },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('extra modules throw', () => {
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          owners: {
+            type: 'ens',
+            accounts: [accountA],
+            ownerExpirations: [Number(maxUint48)],
+          },
+          modules: [
+            {
+              address: MOCK_MODULE_ADDRESS,
+              initData: '0x',
+              type: 'validator',
+            },
+          ],
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('sessions throw', () => {
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          owners: {
+            type: 'ens',
+            accounts: [accountA],
+            ownerExpirations: [Number(maxUint48)],
+          },
+          experimental_sessions: { enabled: true },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('initData with factory round-trips correctly', () => {
+      const deployArgs = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(deployArgs).not.toBeNull()
+      const { factory, factoryData } = deployArgs!
+
+      const roundTripped = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+        initData: {
+          address: '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7',
+          factory,
+          factoryData,
+          intentExecutorInstalled: true,
+        },
+      })
+      expect(roundTripped).not.toBeNull()
+      expect(roundTripped!.factory).toEqual(factory)
+      expect(roundTripped!.initializationCallData).toBeDefined()
+    })
+
+    test('initData path rejects unsupported config', () => {
+      const { factory, factoryData } = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })!
+      expect(() =>
+        getDeployArgs({
+          account: { type: 'hca' },
+          recovery: { guardians: [accountB] },
+          initData: {
+            address: '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7',
+            factory,
+            factoryData,
+            intentExecutorInstalled: true,
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('initData without factory returns null', () => {
+      const result = getDeployArgs({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+        initData: {
+          address: '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7',
+        },
+      })
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('Get Address', () => {
+    test('CREATE3 derivation is deterministic', () => {
+      const address = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(address).toBeDefined()
+      expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/)
+
+      // Same config produces same address
+      const address2 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(address).toEqual(address2)
+    })
+
+    test('Different primary owners produce different addresses', () => {
+      const address1 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      const address2 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountB],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(address1).not.toEqual(address2)
+    })
+
+    test('Owner ordering does not affect the derived address', () => {
+      const address1 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA, accountB],
+          threshold: 2,
+          ownerExpirations: [Number(maxUint48), Number(maxUint48)],
+        },
+      })
+      const address2 = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountB, accountA],
+          threshold: 2,
+          ownerExpirations: [Number(maxUint48), Number(maxUint48)],
+        },
+      })
+      expect(address1).toEqual(address2)
+    })
+
+    test('initData with address fallback', () => {
+      const expectedAddress = '0x229ca553b9863b0c8f2f03d4287cb8c73e2bede7'
+      const address = getAddress({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+        initData: {
+          address: expectedAddress,
+        },
+      })
+      expect(address).toEqual(expectedAddress)
+    })
+
+    test('factory-backed initData derives the address from factoryData', () => {
+      const config = {
+        account: { type: 'hca' as const },
+        owners: {
+          type: 'ens' as const,
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      }
+      const derived = getAddress(config)
+      const { factory, factoryData } = getDeployArgs(config)!
+
+      // A mismatched initData.address must not be trusted.
+      const address = getAddress({
+        ...config,
+        initData: {
+          address: '0x000000000000000000000000000000000000dead',
+          factory,
+          factoryData,
+          intentExecutorInstalled: true,
+        },
+      })
+      expect(address).toEqual(derived)
+    })
+  })
+
+  describe('Get Install Data', () => {
+    test('Module', () => {
+      const installData = getInstallData({
+        address: MOCK_MODULE_ADDRESS,
+        initData: '0xabcd',
+        type: MODULE_TYPE_ID_VALIDATOR,
+        deInitData: '0x0000',
+        additionalContext: '0x0000',
+      })
+      expect(installData).toEqual(
+        '0x9517e29f000000000000000000000000000000000000000000000000000000000000000100000000000000000000000028de6501fa86f2e6cd0b33c3aabdaeb4a1b93f3f00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000002abcd000000000000000000000000000000000000000000000000000000000000',
+      )
+    })
+  })
+
+  describe('Get Packed Signature', () => {
+    test('Non-default validator includes address', async () => {
+      const mockSignature = '0x1234'
+      const validator = {
+        address: '0xe35b75e5ec3c04e9cefa8e581fbee859f56edeb4' as Address,
+        isRoot: true,
+      }
+      const signature = await packSignature(mockSignature, validator)
+      expect(signature).toEqual(
+        '0xe35b75e5ec3c04e9cefa8e581fbee859f56edeb41234',
+      )
+    })
+
+    test('Default ENS validator packs as zero address', async () => {
+      const mockSignature = '0x1234'
+      const validator = {
+        address: ENS_HCA_MODULE,
+        isRoot: true,
+      }
+      const signature = await packSignature(mockSignature, validator)
+      expect(signature).toEqual(
+        '0x00000000000000000000000000000000000000001234',
+      )
+    })
+  })
+})

--- a/src/accounts/hca.ts
+++ b/src/accounts/hca.ts
@@ -1,0 +1,264 @@
+import type { Address, Chain, Hex, PublicClient } from 'viem'
+import {
+  concat,
+  decodeAbiParameters,
+  decodeFunctionData,
+  encodeFunctionData,
+  encodePacked,
+  keccak256,
+  pad,
+  parseAbi,
+  slice,
+  zeroHash,
+} from 'viem'
+import type { Module } from '../modules/common'
+import { ENS_HCA_MODULE, getOwnerValidator } from '../modules/validators/core'
+import type { OwnerSet, RhinestoneAccountConfig } from '../types'
+import {
+  AccountConfigurationNotSupportedError,
+  Eip712DomainNotAvailableError,
+} from './error'
+import {
+  getGuardianSmartAccount as getNexusGuardianSmartAccount,
+  getInstallData as getNexusInstallData,
+  getSmartAccount as getNexusSmartAccount,
+  packSignature as packNexusSignature,
+} from './nexus'
+import type { ValidatorConfig } from './utils'
+
+const HCA_IMPLEMENTATION_ADDRESS: Address =
+  '0x7c2cC1e499a87ab480Df154e05164cD56D05d570'
+const HCA_FACTORY_ADDRESS: Address =
+  '0x358680728dedb552adaa9f5eb5d4395b291cf943'
+
+// HCA inherits Nexus's EIP-712 domain (verified on-chain via eip712Domain()).
+const HCA_VERSION = '1.2.0'
+
+// Solady CREATE3 proxy bytecode hash
+const CREATE3_PROXY_HASH: Hex =
+  '0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f'
+
+function getDeployArgs(config: RhinestoneAccountConfig) {
+  // HCA accounts are locked to their initial configuration and block module
+  // installation, so recovery, sessions, and extra modules can never be
+  // installed. Reject them on every path (including externally-provided
+  // initData) rather than silently dropping them.
+  if (
+    config.recovery ||
+    config.experimental_sessions?.enabled ||
+    (config.modules && config.modules.length > 0)
+  ) {
+    throw new AccountConfigurationNotSupportedError(
+      'HCA accounts cannot install recovery, sessions, or additional modules',
+      'hca',
+    )
+  }
+  if (config.owners && config.owners.type !== 'ens') {
+    throw new AccountConfigurationNotSupportedError(
+      'HCA accounts require ENS owners with ownerExpirations',
+      'hca',
+    )
+  }
+
+  if (config.initData) {
+    if (!('factory' in config.initData)) {
+      return null
+    }
+    const { factory, factoryData } = config.initData
+    try {
+      const decoded = decodeFunctionData({
+        abi: parseAbi(['function createAccount(bytes)']),
+        data: factoryData,
+      })
+      const moduleInitData = decoded.args[0]
+      const initializationCallData = encodeFunctionData({
+        abi: parseAbi(['function initializeAccount(bytes)']),
+        functionName: 'initializeAccount',
+        args: [moduleInitData],
+      })
+      return {
+        factory,
+        factoryData,
+        salt: zeroHash,
+        implementation: HCA_IMPLEMENTATION_ADDRESS,
+        initializationCallData,
+      }
+    } catch {
+      return null
+    }
+  }
+
+  if (!config.owners) {
+    throw new AccountConfigurationNotSupportedError(
+      'HCA accounts require ENS owners with ownerExpirations',
+      'hca',
+    )
+  }
+
+  const ownerValidator = getOwnerValidator(config)
+  const moduleInitData = ownerValidator.initData
+
+  // Factory takes module initData directly: abi.encode(threshold, owners[])
+  // It internally calls module.getOwnerFromInitData(initData) to derive the CREATE3 salt,
+  // then deploys the proxy with the stored implementation
+  const factoryData = encodeFunctionData({
+    abi: parseAbi(['function createAccount(bytes)']),
+    functionName: 'createAccount',
+    args: [moduleInitData],
+  })
+
+  const initializationCallData = encodeFunctionData({
+    abi: parseAbi(['function initializeAccount(bytes)']),
+    functionName: 'initializeAccount',
+    args: [moduleInitData],
+  })
+
+  return {
+    factory: HCA_FACTORY_ADDRESS,
+    factoryData,
+    salt: zeroHash,
+    implementation: HCA_IMPLEMENTATION_ADDRESS,
+    initializationCallData,
+  }
+}
+
+function getAddress(config: RhinestoneAccountConfig) {
+  const deployArgs = getDeployArgs(config)
+  if (!deployArgs) {
+    if (config.initData?.address) {
+      return config.initData.address
+    }
+    throw new Error('Cannot derive address: deploy args not available')
+  }
+
+  // Always derive deterministically from the factory data so a mismatched
+  // initData.address is caught by checkAddress instead of being trusted.
+  const primaryOwner = getPrimaryOwnerFromFactoryData(deployArgs.factoryData)
+  return predictCreate3Address(deployArgs.factory, primaryOwner)
+}
+
+// The factory derives the CREATE3 salt from getOwnerFromInitData(initData),
+// which returns owners[0] of the validator init data. getOwnerValidator sorts
+// owners by lowercased address, so owners[0] is the salt owner the factory uses.
+function getPrimaryOwnerFromFactoryData(factoryData: Hex): Address {
+  const { args } = decodeFunctionData({
+    abi: parseAbi(['function createAccount(bytes)']),
+    data: factoryData,
+  })
+  const [, owners] = decodeAbiParameters(
+    [
+      { type: 'uint256' },
+      {
+        type: 'tuple[]',
+        components: [
+          { name: 'addr', type: 'address' },
+          { name: 'expiration', type: 'uint48' },
+        ],
+      },
+    ],
+    args[0],
+  )
+  return owners[0].addr
+}
+
+// Solady CREATE3 address derivation:
+// 1. salt = bytes32(bytes20(primaryOwner)) — right-padded
+// 2. proxy = CREATE2(factory, salt, CREATE3_PROXY_HASH)
+// 3. account = CREATE(proxy, nonce=1) = keccak256(0xd694 ++ proxy ++ 0x01)
+function predictCreate3Address(
+  factory: Address,
+  primaryOwner: Address,
+): Address {
+  // salt = bytes32(bytes20(owner)) — address right-padded to 32 bytes
+  const salt = pad(primaryOwner as Hex, { size: 32, dir: 'right' })
+
+  // CREATE2: proxy address
+  const proxyHash = keccak256(
+    encodePacked(
+      ['bytes1', 'address', 'bytes32', 'bytes32'],
+      ['0xff', factory, salt, CREATE3_PROXY_HASH],
+    ),
+  )
+  const proxyAddress = slice(proxyHash, 12, 32)
+
+  // CREATE with nonce 1: RLP([proxy, 1]) = 0xd694 ++ proxy ++ 0x01
+  const accountHash = keccak256(concat(['0xd694', proxyAddress, '0x01']))
+  return slice(accountHash, 12, 32)
+}
+
+function getEip712Domain(config: RhinestoneAccountConfig, chain: Chain) {
+  if (config.initData) {
+    throw new Eip712DomainNotAvailableError(
+      'Existing HCA accounts are not yet supported',
+    )
+  }
+  return {
+    name: 'Nexus',
+    version: HCA_VERSION,
+    chainId: chain.id,
+    verifyingContract: getAddress(config),
+    salt: zeroHash,
+  }
+}
+
+function getInstallData(module: Module) {
+  return getNexusInstallData(module)
+}
+
+async function packSignature(
+  signature: Hex,
+  validator: ValidatorConfig,
+  transformSignature: (signature: Hex) => Hex = (signature) => signature,
+) {
+  return packNexusSignature(
+    signature,
+    validator,
+    transformSignature,
+    ENS_HCA_MODULE,
+  )
+}
+
+async function getSmartAccount(
+  client: PublicClient,
+  address: Address,
+  owners: OwnerSet,
+  validatorAddress: Address,
+  sign: (hash: Hex) => Promise<Hex>,
+) {
+  return getNexusSmartAccount(
+    client,
+    address,
+    owners,
+    validatorAddress,
+    sign,
+    ENS_HCA_MODULE,
+  )
+}
+
+async function getGuardianSmartAccount(
+  client: PublicClient,
+  address: Address,
+  guardians: OwnerSet,
+  validatorAddress: Address,
+  sign: (hash: Hex) => Promise<Hex>,
+) {
+  return getNexusGuardianSmartAccount(
+    client,
+    address,
+    guardians,
+    validatorAddress,
+    sign,
+    ENS_HCA_MODULE,
+  )
+}
+
+export {
+  ENS_HCA_MODULE,
+  getEip712Domain,
+  getInstallData,
+  getAddress,
+  packSignature,
+  getDeployArgs,
+  getSmartAccount,
+  getGuardianSmartAccount,
+}

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -52,6 +52,14 @@ import {
   WalletClientNoConnectedAccountError,
 } from './error'
 import {
+  getAddress as getHcaAddress,
+  getDeployArgs as getHcaDeployArgs,
+  getEip712Domain as getHcaEip712Domain,
+  getGuardianSmartAccount as getHcaGuardianSmartAccount,
+  getSmartAccount as getHcaSmartAccount,
+  packSignature as packHcaSignature,
+} from './hca'
+import {
   getAddress as getKernelAddress,
   getDeployArgs as getKernelDeployArgs,
   getEip712Domain as getKernelEip712Domain,
@@ -117,6 +125,9 @@ function getDeployArgs(config: RhinestoneConfig) {
     }
     case 'startale': {
       return getStartaleDeployArgs(config)
+    }
+    case 'hca': {
+      return getHcaDeployArgs(config)
     }
     case 'eoa': {
       throw new Error('EOA accounts do not have deploy args')
@@ -191,7 +202,8 @@ async function signEip7702InitData(config: RhinestoneConfig) {
     }
     case 'safe':
     case 'kernel':
-    case 'startale': {
+    case 'startale':
+    case 'hca': {
       throw new Eip7702NotSupportedForAccountError(account.type)
     }
     default: {
@@ -208,7 +220,8 @@ function getEip7702InitCall(config: RhinestoneConfig, signature: Hex) {
     }
     case 'safe':
     case 'kernel':
-    case 'startale': {
+    case 'startale':
+    case 'hca': {
       throw new Eip7702NotSupportedForAccountError(account.type)
     }
     default: {
@@ -231,6 +244,9 @@ function getEip712Domain(config: RhinestoneConfig, chain: Chain) {
     }
     case 'startale': {
       return getStartaleEip712Domain(config, chain)
+    }
+    case 'hca': {
+      return getHcaEip712Domain(config, chain)
     }
     case 'eoa': {
       throw new Eip712DomainNotAvailableError(
@@ -265,6 +281,9 @@ function getModuleInstallationCalls(
       }
       case 'startale': {
         return [getStartaleInstallData(module)]
+      }
+      case 'hca': {
+        throw new ModuleInstallationNotSupportedError(account.type)
       }
       case 'eoa': {
         throw new ModuleInstallationNotSupportedError(account.type)
@@ -401,6 +420,9 @@ function getAddress(config: RhinestoneConfig) {
     case 'startale': {
       return getStartaleAddress(config)
     }
+    case 'hca': {
+      return getHcaAddress(config)
+    }
     case 'eoa': {
       if (!config.eoa) {
         throw new AccountError({
@@ -465,6 +487,10 @@ async function getEip1271Signature(
     case 'startale': {
       const signature = await signFn(hash)
       return packStartaleSignature(signature, validator, transformSignature)
+    }
+    case 'hca': {
+      const signature = await signFn(hash)
+      return packHcaSignature(signature, validator, transformSignature)
     }
     default: {
       throw new Error(`Unsupported account type: ${(account as any).type}`)
@@ -544,6 +570,10 @@ async function getTypedDataPackedSignature<
       const signature = await signFn(parameters)
       return packStartaleSignature(signature, validator, transformSignature)
     }
+    case 'hca': {
+      const signature = await signFn(parameters)
+      return packHcaSignature(signature, validator, transformSignature)
+    }
     default: {
       throw new Error(`Unsupported account type: ${(account as any).type}`)
     }
@@ -585,7 +615,7 @@ async function deploy(
   }
 
   const account = getAccountProvider(config)
-  if (account.type === 'eoa') {
+  if (account.type === 'eoa' || account.type === 'hca') {
     return false
   }
 
@@ -840,6 +870,15 @@ async function getSmartAccount(
         signFn,
       )
     }
+    case 'hca': {
+      return getHcaSmartAccount(
+        client,
+        address,
+        config.owners,
+        ownerValidator.address,
+        signFn,
+      )
+    }
   }
 }
 
@@ -896,6 +935,15 @@ async function getGuardianSmartAccount(
     }
     case 'startale': {
       return getStartaleGuardianSmartAccount(
+        client,
+        address,
+        guardians,
+        socialRecoveryValidator.address,
+        signFn,
+      )
+    }
+    case 'hca': {
+      return getHcaGuardianSmartAccount(
         client,
         address,
         guardians,

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -652,7 +652,8 @@ async function deploy(
 async function setup(config: RhinestoneConfig, chain: Chain): Promise<boolean> {
   const account = getAccountProvider(config)
 
-  if (account.type === 'eoa') {
+  // HCA accounts are locked and cannot install modules, so there is nothing to set up.
+  if (account.type === 'eoa' || account.type === 'hca') {
     return false
   }
 

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -615,7 +615,7 @@ async function deploy(
   }
 
   const account = getAccountProvider(config)
-  if (account.type === 'eoa' || account.type === 'hca') {
+  if (account.type === 'eoa') {
     return false
   }
 

--- a/src/accounts/signing/common.ts
+++ b/src/accounts/signing/common.ts
@@ -16,7 +16,7 @@ import {
 import type { WebAuthnAccount } from 'viem/account-abstraction'
 import { isRip7212SupportedNetwork } from '../../modules'
 import {
-  ENS_VALIDATOR_ADDRESS,
+  ENS_HCA_MODULE,
   getValidator,
   OWNABLE_VALIDATOR_ADDRESS,
   WEBAUTHN_V0_VALIDATOR_ADDRESS,
@@ -49,7 +49,7 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
         type: 'owner',
         kind: 'ecdsa',
         accounts: owners.accounts,
-        module: owners.module ?? ENS_VALIDATOR_ADDRESS,
+        module: owners.module ?? ENS_HCA_MODULE,
       }
     }
     case 'passkey': {
@@ -79,7 +79,7 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
                 type: 'ecdsa',
                 id: index,
                 accounts: validator.accounts,
-                module: validator.module ?? ENS_VALIDATOR_ADDRESS,
+                module: validator.module ?? ENS_HCA_MODULE,
               }
             }
             case 'passkey': {
@@ -268,7 +268,7 @@ async function signWithOwners<T>(
       const isOwnableOrENS =
         !signers.module ||
         signers.module?.toLowerCase() === OWNABLE_VALIDATOR_ADDRESS ||
-        signers.module?.toLowerCase() === ENS_VALIDATOR_ADDRESS
+        signers.module?.toLowerCase() === ENS_HCA_MODULE
 
       const updateV = isOwnableOrENS && !isUserOpHash
 

--- a/src/execution/signing.test.ts
+++ b/src/execution/signing.test.ts
@@ -126,6 +126,7 @@ vi.mock('../modules/validators/core', () => ({
     address: MOCK_VALIDATOR,
     initData: '0x',
   }),
+  ownerSetUsesEns: vi.fn().mockReturnValue(false),
   getMultiFactorValidator: vi.fn(),
   getSocialRecoveryValidator: vi.fn(),
   getWebAuthnValidator: vi.fn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -472,8 +472,9 @@ async function createRhinestoneAccount(
    * @returns Account owners
    */
   function getOwners(chain: Chain) {
+    const accountType = getAccountProvider(config).type
     const account = getAddress()
-    return getOwnersInternal(account, chain, config.provider)
+    return getOwnersInternal(accountType, account, chain, config.provider)
   }
 
   /**

--- a/src/modules/read.ts
+++ b/src/modules/read.ts
@@ -1,7 +1,7 @@
 import { type Address, type Chain, createPublicClient } from 'viem'
 import { createTransport } from '../accounts/utils'
 import type { AccountType, ProviderConfig } from '../types'
-import { OWNABLE_VALIDATOR_ADDRESS } from './validators/core'
+import { ENS_HCA_MODULE, OWNABLE_VALIDATOR_ADDRESS } from './validators/core'
 
 async function getValidators(
   accountType: AccountType,
@@ -16,6 +16,7 @@ async function getValidators(
   switch (accountType) {
     case 'safe':
     case 'startale':
+    case 'hca':
     case 'nexus': {
       const validators = await publicClient.readContract({
         abi: [
@@ -60,6 +61,7 @@ async function getValidators(
 }
 
 async function getOwners(
+  accountType: AccountType,
   account: Address,
   chain: Chain,
   provider?: ProviderConfig,
@@ -71,7 +73,10 @@ async function getOwners(
     chain,
     transport: createTransport(chain, provider),
   })
-  const moduleAddress = OWNABLE_VALIDATOR_ADDRESS
+  // HCA accounts hold owner state under the ENS HCA module, which is also
+  // OwnableValidator-based, so the getOwners/threshold reads are identical.
+  const moduleAddress =
+    accountType === 'hca' ? ENS_HCA_MODULE : OWNABLE_VALIDATOR_ADDRESS
   const [ownerResult, thresholdResult] = await publicClient.multicall({
     contracts: [
       {
@@ -147,6 +152,7 @@ async function getExecutors(
   switch (accountType) {
     case 'safe':
     case 'startale':
+    case 'hca':
     case 'nexus': {
       const executors = await publicClient.readContract({
         abi: [

--- a/src/modules/validators/core.test.ts
+++ b/src/modules/validators/core.test.ts
@@ -6,8 +6,9 @@ import {
   accountC,
   passkeyAccount,
 } from '../../../test/consts'
+import { AccountConfigurationNotSupportedError } from '../../accounts/error'
 import { MODULE_TYPE_ID_VALIDATOR } from '../common'
-import { getMockSignature, getValidator } from './core'
+import { getMockSignature, getOwnerValidator, getValidator } from './core'
 
 describe('Validators Core', () => {
   describe('Validator', () => {
@@ -126,6 +127,68 @@ describe('Validators Core', () => {
           },
         ],
         signature,
+      )
+    })
+  })
+
+  describe('Owner Validator', () => {
+    test('ENS owners require an HCA account', () => {
+      expect(() =>
+        getOwnerValidator({
+          account: { type: 'nexus' },
+          owners: {
+            type: 'ens',
+            accounts: [accountA],
+            ownerExpirations: [281474976710655],
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('ENS sub-validator in multi-factor requires an HCA account', () => {
+      expect(() =>
+        getOwnerValidator({
+          account: { type: 'nexus' },
+          owners: {
+            type: 'multi-factor',
+            validators: [
+              { type: 'ecdsa', accounts: [accountB] },
+              {
+                type: 'ens',
+                accounts: [accountA],
+                ownerExpirations: [281474976710655],
+              },
+            ],
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('HCA rejects a custom ENS owners.module', () => {
+      expect(() =>
+        getOwnerValidator({
+          account: { type: 'hca' },
+          owners: {
+            type: 'ens',
+            accounts: [accountA],
+            ownerExpirations: [281474976710655],
+            module: '0x00000000000000000000000000000000deadbeef',
+          },
+        }),
+      ).toThrow(AccountConfigurationNotSupportedError)
+    })
+
+    test('ENS owners are allowed on HCA accounts', () => {
+      const validator = getOwnerValidator({
+        account: { type: 'hca' },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [281474976710655],
+        },
+      })
+      expect(validator.address).toEqual(
+        '0x5049ecBd4d961aE6DFEED9b7ccCe7f026454970E',
       )
     })
   })

--- a/src/modules/validators/core.ts
+++ b/src/modules/validators/core.ts
@@ -12,7 +12,10 @@ import {
   toHex,
 } from 'viem'
 
-import { OwnersFieldRequiredError } from '../../accounts/error'
+import {
+  AccountConfigurationNotSupportedError,
+  OwnersFieldRequiredError,
+} from '../../accounts/error'
 import type {
   ENSValidatorConfig,
   OwnableValidatorConfig,
@@ -41,8 +44,7 @@ interface WebauthnCredential {
 
 const OWNABLE_VALIDATOR_ADDRESS: Address =
   '0x000000000013fdb5234e4e3162a810f54d9f7e98'
-const ENS_VALIDATOR_ADDRESS: Address =
-  '0xdc38f07b060374b6480c4bf06231e7d10955bca4'
+const ENS_HCA_MODULE: Address = '0x5049ecBd4d961aE6DFEED9b7ccCe7f026454970E'
 const WEBAUTHN_VALIDATOR_ADDRESS: Address =
   '0x0000000000578c4cb0e472a5462da43c495c3f33'
 const SOCIAL_RECOVERY_VALIDATOR_ADDRESS: Address =
@@ -63,9 +65,42 @@ const ECDSA_MOCK_SIGNATURE =
 const WEBAUTHN_MOCK_SIGNATURE =
   '0x0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001b9b86eb98fda3ed4d797d9e690588dfadf17b329a76a47cec935bebf92d7ddc80000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000001700000000000000000000000000000000000000000000000000000000000000019b2e9410bb6850f9f660a03d609d5a844fb96bcdc87a15139b03ee22c70f469100d2b865a215c3bf786387064effa8fcedcb1d625b5148f8a1236d5e3ff11acf000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763050000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000867b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22396a4546696a75684557724d34534f572d7443684a625545484550343456636a634a2d42716f3166544d38222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a38303830222c2263726f73734f726967696e223a66616c73657d0000000000000000000000000000000000000000000000000000'
 
+// ENS validation is only available on HCA accounts (its validator default is
+// the HCA module). True for a direct ENS owner set or an ENS sub-validator
+// nested in a multi-factor config.
+function ownerSetUsesEns(owners: OwnerSet): boolean {
+  return (
+    owners.type === 'ens' ||
+    (owners.type === 'multi-factor' &&
+      owners.validators.some((validator) => validator.type === 'ens'))
+  )
+}
+
 function getOwnerValidator(config: RhinestoneAccountConfig) {
   if (!config.owners) {
     throw new OwnersFieldRequiredError()
+  }
+  // ENS owners resolve to the HCA module, which is only valid for HCA accounts.
+  // Other account types would silently install/sign against the wrong validator.
+  if (ownerSetUsesEns(config.owners) && config.account?.type !== 'hca') {
+    throw new AccountConfigurationNotSupportedError(
+      'ENS owners are only supported on HCA accounts',
+      config.account?.type ?? 'nexus',
+    )
+  }
+  // HCA accounts use the ENS validator baked into the implementation; a custom
+  // owners.module would never be installed yet would drive signing/nonce
+  // selection, producing signatures for a validator the account does not have.
+  if (
+    config.account?.type === 'hca' &&
+    config.owners.type === 'ens' &&
+    config.owners.module &&
+    config.owners.module.toLowerCase() !== ENS_HCA_MODULE.toLowerCase()
+  ) {
+    throw new AccountConfigurationNotSupportedError(
+      'HCA accounts do not support a custom ENS owners.module',
+      'hca',
+    )
   }
   return getValidator(config.owners)
 }
@@ -209,7 +244,7 @@ function getENSValidator(
     [BigInt(threshold), ownersWithExpiration],
   )
 
-  const moduleAddress = address ?? ENS_VALIDATOR_ADDRESS
+  const moduleAddress = address ?? ENS_HCA_MODULE
 
   return {
     address: moduleAddress,
@@ -398,7 +433,7 @@ function supportsEip712(validator: Module) {
 
 export {
   OWNABLE_VALIDATOR_ADDRESS,
-  ENS_VALIDATOR_ADDRESS,
+  ENS_HCA_MODULE,
   WEBAUTHN_VALIDATOR_ADDRESS,
   MULTI_FACTOR_VALIDATOR_ADDRESS,
   WEBAUTHN_V0_VALIDATOR_ADDRESS,
@@ -413,5 +448,6 @@ export {
   getValidator,
   getMockSignature,
   supportsEip712,
+  ownerSetUsesEns,
 }
 export type { WebauthnCredential }

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -479,6 +479,19 @@ describe('policyAddresses override', () => {
 // ---------------------------------------------------------------------------
 
 describe('getSessionData', () => {
+  test('ENS session owners are rejected', () => {
+    expect(() =>
+      toSession({
+        chain: base,
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [281474976710655],
+        },
+      }),
+    ).toThrow('ENS owners are not supported for smart sessions')
+  })
+
   test('no actions → single sudoAction fallback', () => {
     const data = getSessionData(baseSession)
     expect(data.actions).toHaveLength(1)

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -55,6 +55,7 @@ import { MODULE_TYPE_ID_VALIDATOR, type Module } from '../common'
 import {
   getOwnerValidator,
   getValidator,
+  ownerSetUsesEns,
   SMART_SESSION_EMISSARY_ADDRESS,
   SMART_SESSION_EMISSARY_ADDRESS_DEV,
 } from './core'
@@ -740,6 +741,12 @@ function resolveSessionData(
   useDevContracts?: boolean,
   addresses: ResolvedPolicyAddresses = DEFAULT_POLICY_ADDRESSES,
 ): SessionData {
+  // ENS validation is HCA-only, and HCA accounts cannot install the smart
+  // session validator, so an ENS session owner would silently resolve to the
+  // HCA module and sign/enable against a validator the account does not have.
+  if (ownerSetUsesEns(session.owners)) {
+    throw new Error('ENS owners are not supported for smart sessions')
+  }
   const validator = getValidator(session.owners)
   const allowedContent = [
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import type {
   SettlementLayerFilter,
 } from './orchestrator/types'
 
-type AccountType = 'safe' | 'nexus' | 'kernel' | 'startale' | 'eoa'
+type AccountType = 'safe' | 'nexus' | 'kernel' | 'startale' | 'eoa' | 'hca'
 
 interface SafeAccount {
   type: 'safe'
@@ -33,6 +33,10 @@ interface StartaleAccount {
   salt?: Hex
 }
 
+interface HcaAccount {
+  type: 'hca'
+}
+
 interface EoaAccount {
   type: 'eoa'
 }
@@ -42,6 +46,7 @@ type AccountProviderConfig =
   | NexusAccount
   | KernelAccount
   | StartaleAccount
+  | HcaAccount
   | EoaAccount
 
 interface OwnableValidatorConfig {
@@ -750,6 +755,7 @@ export type {
   NexusAccount,
   KernelAccount,
   StartaleAccount,
+  HcaAccount,
   EoaAccount,
   RhinestoneAccountConfig,
   RhinestoneSDKConfig,


### PR DESCRIPTION
Ports ENS Hardware-Controlled Account (HCA) support to the v2 SDK — a Nexus-based smart account locked to a single immutable ENS validator and factory-approved upgrades. v1 equivalent: #548.

## Changes
- New `src/accounts/hca.ts` — factory init-data encoding, Solady CREATE3 address derivation, EIP-712 domain, signature packing. Reuses the Nexus smart-account/signing internals via the `defaultValidatorAddress` override (same pattern as `startale`).
- Wires `'hca'` through `getDeployArgs` / `getAddress` / `getEip712Domain` / `getEip1271Signature` / `getTypedDataPackedSignature` / `getSmartAccount` / `getGuardianSmartAccount` and the account-type union.
- Renames `ENS_VALIDATOR_ADDRESS` → `ENS_HCA_MODULE` (`0x5049…970E`).
- Guards: ENS owners are only valid on HCA accounts; HCA rejects custom `owners.module`, recovery, sessions, and extra modules; ENS owners are rejected for smart sessions.

## v2-specific adaptations vs #548
- No `passport` account type on `release`; HCA slots into the Nexus-grouped read switches and the account-type union accordingly.
- The smart-sessions ENS guard lands in `resolveSessionData` (reached via `toSession`), since v2 refactored `getSessionData`.
- `signing.test.ts` mock of `../modules/validators/core` extended with the new `ownerSetUsesEns` export.

## Validation
- `bun run typecheck` + `bun run check` (biome) clean.
- Unit: HCA (18), owner-validator (11), smart-sessions (54) pass. Full suite green except 3 pre-existing failures (`ecdsa`/`passkeys`/`recovery` — unrelated ESM/CJS issue, fails identically on clean `release`).

Same Sepolia HCA contracts as v1 (factory `0x3586…f943`, impl `0x7c2c…d570`, module `0x5049…970E`).