### PR TITLE
test(integration): expect SimulationFailedError for reverting intents

### DIFF
--- a/test/integration/scenarios/smoke.itest.ts
+++ b/test/integration/scenarios/smoke.itest.ts
@@ -1,5 +1,5 @@
 import { describe, test } from 'vitest'
-import { ValidationError } from '../../../src/errors/index'
+import { SimulationFailedError } from '../../../src/errors/index'
 import { sourceChain, targetChain } from '../config/chains'
 import { createIntegrationSDK } from '../config/environment'
 import {
@@ -144,9 +144,9 @@ describe.sequential('SDK integration smoke', () => {
 
     expectOutcome(execution, {
       kind: 'submit-error',
-      error: ValidationError,
-      code: 'VALIDATION_ERROR',
-      message: 'Bundle simulation failed',
+      error: SimulationFailedError,
+      code: 'SIMULATION_FAILED',
+      message: 'Simulation failed',
     })
     await expectNotDeployed(account, sourceChain)
   })

--- a/test/integration/scenarios/ssx.itest.ts
+++ b/test/integration/scenarios/ssx.itest.ts
@@ -1,6 +1,6 @@
 import type { Chain } from 'viem/chains'
 import { describe, test } from 'vitest'
-import { ValidationError } from '../../../src/errors/index'
+import { SimulationFailedError } from '../../../src/errors/index'
 import type { RhinestoneAccount, Session } from '../../../src/index'
 import { sourceChain, targetChain } from '../config/chains'
 import { createIntegrationSDK } from '../config/environment'
@@ -134,8 +134,8 @@ describe.sequential('SDK integration ssx', () => {
 
     expectOutcome(execution, {
       kind: 'submit-error',
-      error: ValidationError,
-      code: 'VALIDATION_ERROR',
+      error: SimulationFailedError,
+      code: 'SIMULATION_FAILED',
     })
     await expectNotDeployed(account, sourceChain)
   })
@@ -171,8 +171,8 @@ describe.sequential('SDK integration ssx', () => {
 
     expectOutcome(execution, {
       kind: 'submit-error',
-      error: ValidationError,
-      code: 'VALIDATION_ERROR',
+      error: SimulationFailedError,
+      code: 'SIMULATION_FAILED',
     })
     await expectNotDeployed(account, sourceChain)
   })


### PR DESCRIPTION
The orchestrator now classifies deliberately-failing simulations as `SIMULATION_FAILED` (category `UNCLASSIFIED_REVERT`, synthetic `MalformedAssemblyRevert()`) rather than `VALIDATION_ERROR`. This is intended orchestrator behaviour, so the negative integration tests are updated to match.

- `smoke` — `reports simulation failure during submit without deploying` (unfunded USDC transfer)
- `ssx` — `rejects a session-signed call with wrong selector` (out-of-scope call)
- `ssx` — `rejects a session-signed call with wrong target`

All three now assert `SimulationFailedError` / `SIMULATION_FAILED`. The smoke message assertion is relaxed to the stable `Simulation failed` prefix (the `MalformedAssemblyRevert()` suffix is a dynamic, undecodable-revert label).