### PR TITLE
feat: send settlementLayers include/exclude filter on the wire

### DIFF
--- a/.changeset/settlement-layer-filter-wire.md
+++ b/.changeset/settlement-layer-filter-wire.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Resolve the `settlementLayers` `{ exclude }` filter on the orchestrator instead of in the SDK, so excluding specific layers automatically accounts for new settlement layers as they are added — without an SDK upgrade.
+Resolve the `settlementLayers` `{ exclude }` filter on the orchestrator instead of in the SDK, so excluding specific layers automatically accounts for new settlement layers as they are added.

--- a/.changeset/settlement-layer-filter-wire.md
+++ b/.changeset/settlement-layer-filter-wire.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Send the `settlementLayers` `{ include }`/`{ exclude }` filter to the orchestrator natively instead of inverting `exclude` against a hardcoded layer list. `exclude` now stays correct as the orchestrator adds or removes settlement layers.
+Resolve the `settlementLayers` `{ exclude }` filter on the orchestrator instead of in the SDK, so excluding specific layers automatically accounts for new settlement layers as they are added — without an SDK upgrade.

--- a/.changeset/settlement-layer-filter-wire.md
+++ b/.changeset/settlement-layer-filter-wire.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Send the `settlementLayers` `{ include }`/`{ exclude }` filter to the orchestrator natively instead of inverting `exclude` against a hardcoded layer list. `exclude` now stays correct as the orchestrator adds or removes settlement layers.

--- a/src/orchestrator/client.test.ts
+++ b/src/orchestrator/client.test.ts
@@ -1,5 +1,7 @@
+import { mainnet } from 'viem/chains'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { encodeSettlementLayers, Orchestrator } from './client'
+import { Orchestrator } from './client'
+import type { SettlementLayerFilter } from './types'
 
 const authProvider = {
   getHeaders: async () => ({ 'x-api-key': 'test-key' }),
@@ -158,36 +160,46 @@ describe('Orchestrator trace IDs', () => {
   })
 })
 
-describe('encodeSettlementLayers', () => {
-  it('include passes through unchanged', () => {
-    expect(encodeSettlementLayers({ include: ['ACROSS', 'ECO'] })).toEqual([
-      'ACROSS',
-      'ECO',
-    ])
+describe('settlementLayers filter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
-  it('exclude inverts against the known-layers universe', () => {
-    expect(encodeSettlementLayers({ exclude: ['RELAY'] })).toEqual([
-      'ACROSS',
-      'ECO',
-      'OFT',
-      'NEAR',
-      'RHINO',
-      'CCTP',
-    ])
+  async function capturedSplitBody(
+    settlementLayers: SettlementLayerFilter | undefined,
+  ) {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(mockJsonResponse({ intents: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const orchestrator = new Orchestrator(
+      'https://orchestrator.test',
+      authProvider,
+    )
+    await orchestrator.getSplit({
+      chain: mainnet,
+      tokens: {},
+      settlementLayers,
+    })
+
+    return JSON.parse(fetchMock.mock.calls[0][1].body)
+  }
+
+  it('sends an include filter on the wire unchanged', async () => {
+    const body = await capturedSplitBody({ include: ['ACROSS', 'ECO'] })
+    expect(body.settlementLayers).toEqual({ include: ['ACROSS', 'ECO'] })
   })
 
-  it('exclude with unknown layer is a no-op against the universe', () => {
-    // SAME_CHAIN isn't user-selectable on the orchestrator. Excluding it
-    // should leave the universe intact rather than narrowing further.
-    expect(encodeSettlementLayers({ exclude: ['SAME_CHAIN'] })).toEqual([
-      'ACROSS',
-      'ECO',
-      'RELAY',
-      'OFT',
-      'NEAR',
-      'RHINO',
-      'CCTP',
-    ])
+  it('sends an exclude filter on the wire unchanged', async () => {
+    // The orchestrator inverts `exclude` against its own live layer set, so
+    // the SDK forwards the filter verbatim instead of enumerating layers.
+    const body = await capturedSplitBody({ exclude: ['RELAY'] })
+    expect(body.settlementLayers).toEqual({ exclude: ['RELAY'] })
+  })
+
+  it('omits settlementLayers when unset', async () => {
+    const body = await capturedSplitBody(undefined)
+    expect(body.settlementLayers).toBeUndefined()
   })
 })

--- a/src/orchestrator/client.test.ts
+++ b/src/orchestrator/client.test.ts
@@ -1,7 +1,5 @@
-import { mainnet } from 'viem/chains'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Orchestrator } from './client'
-import type { SettlementLayerFilter } from './types'
 
 const authProvider = {
   getHeaders: async () => ({ 'x-api-key': 'test-key' }),
@@ -157,49 +155,5 @@ describe('Orchestrator trace IDs', () => {
     await expect(orchestrator.getIntent('1')).rejects.toMatchObject({
       traceId: 'trace-header',
     })
-  })
-})
-
-describe('settlementLayers filter', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  async function capturedSplitBody(
-    settlementLayers: SettlementLayerFilter | undefined,
-  ) {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(mockJsonResponse({ intents: [] }))
-    vi.stubGlobal('fetch', fetchMock)
-
-    const orchestrator = new Orchestrator(
-      'https://orchestrator.test',
-      authProvider,
-    )
-    await orchestrator.getSplit({
-      chain: mainnet,
-      tokens: {},
-      settlementLayers,
-    })
-
-    return JSON.parse(fetchMock.mock.calls[0][1].body)
-  }
-
-  it('sends an include filter on the wire unchanged', async () => {
-    const body = await capturedSplitBody({ include: ['ACROSS', 'ECO'] })
-    expect(body.settlementLayers).toEqual({ include: ['ACROSS', 'ECO'] })
-  })
-
-  it('sends an exclude filter on the wire unchanged', async () => {
-    // The orchestrator inverts `exclude` against its own live layer set, so
-    // the SDK forwards the filter verbatim instead of enumerating layers.
-    const body = await capturedSplitBody({ exclude: ['RELAY'] })
-    expect(body.settlementLayers).toEqual({ exclude: ['RELAY'] })
-  })
-
-  it('omits settlementLayers when unset', async () => {
-    const body = await capturedSplitBody(undefined)
-    expect(body.settlementLayers).toBeUndefined()
   })
 })

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -1,4 +1,3 @@
-import type { SettlementLayer as CrossChainSettlementLayer } from '@rhinestone/shared-configs'
 import type { Address } from 'viem'
 import type { AuthProvider } from '../auth/provider'
 import { fromCaip2, isCaip2, toCaip2 } from './caip2'
@@ -22,7 +21,6 @@ import type {
   Portfolio,
   Quote,
   QuoteResponse,
-  SettlementLayerFilter,
   SplitIntentsInput,
   SplitIntentsResult,
   TokenRequirements,
@@ -110,9 +108,7 @@ export class Orchestrator {
     const body = convertBigIntFields({
       chainId: toCaip2(input.chain.id),
       tokens: input.tokens,
-      settlementLayers: input.settlementLayers
-        ? encodeSettlementLayers(input.settlementLayers)
-        : undefined,
+      settlementLayers: input.settlementLayers,
     })
     const json = await this.fetch(`${this.serverUrl}/intents/splits`, {
       method: 'POST',
@@ -325,30 +321,7 @@ function encodeOptions(options: IntentOptions): Record<string, unknown> {
   if (options.auxiliaryFunds) {
     wire.auxiliaryFunds = encodeAuxiliaryFunds(options.auxiliaryFunds)
   }
-  if (options.settlementLayers) {
-    wire.settlementLayers = encodeSettlementLayers(options.settlementLayers)
-  }
   return wire
-}
-
-// Inversion universe for `{ exclude }` — must mirror the orchestrator's
-// cross-chain settlement layer enum.
-const KNOWN_SETTLEMENT_LAYERS = [
-  'ACROSS',
-  'ECO',
-  'RELAY',
-  'OFT',
-  'NEAR',
-  'RHINO',
-  'CCTP',
-] as const satisfies readonly CrossChainSettlementLayer[]
-
-export function encodeSettlementLayers(
-  filter: SettlementLayerFilter,
-): readonly string[] {
-  if ('include' in filter) return filter.include
-  const excluded = new Set<string>(filter.exclude)
-  return KNOWN_SETTLEMENT_LAYERS.filter((layer) => !excluded.has(layer))
 }
 
 function decodeQuoteResponse(json: any): QuoteResponse {


### PR DESCRIPTION
The SDK's public `settlementLayers` API already accepts `{ include } | { exclude }`, but it was inverting `exclude` locally against a hardcoded layer list and sending a flat array on the wire — that list drifts whenever the orchestrator gains or drops a settlement layer.

The orchestrator now accepts the union shape natively and inverts `exclude` against its own live layer set, so the SDK forwards the filter verbatim.

- Drop `encodeSettlementLayers` + the hardcoded `KNOWN_SETTLEMENT_LAYERS` universe; pass the filter straight through in `encodeOptions` and `getSplit`.
- Public `Transaction.settlementLayers` type is unchanged — non-breaking behavior fix.

Closes [RHI-4262](https://linear.app/rhinestone/issue/RHI-4262)
Companion: rhinestonewtf/orchestrator#1598