### PR TITLE
test(integration): expand SDK encoding coverage (sigmode, preclaim, policies)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # Optional, used to run the integration tests
 INTEGRATION_RHINESTONE_API_KEY=
+# Optional, required only for funded specs (non-sponsored cross-chain,
+# spending-limit policies). The address derived from this key must hold testnet
+# native + USDC on the integration chains.
+INTEGRATION_FUNDER_PRIVATE_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,5 +61,5 @@ Once v2 is stable, we'll switch back to the standard `main` (dev) / `release` (p
 
 - Run single test: `bun run test -- path/to/file.test.ts`
 - Unit tests live next to source as `*.test.ts`.
-- Live SDK integration tests live under `/test/integration` as `*.itest.ts`. They require `INTEGRATION_RHINESTONE_API_KEY` and use `vitest.config.integration.ts`.
+- Live SDK integration tests live under `/test/integration` as `*.itest.ts`. They require `INTEGRATION_RHINESTONE_API_KEY` and use `vitest.config.integration.ts`. Funded specs (smart-session policies, on-chain source-call execution) additionally require `INTEGRATION_FUNDER_PRIVATE_KEY` — a key whose address holds testnet native + USDC on the integration chains.
 - Run the live smoke suite with `bun run test:integration:smoke -- --run`.

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,7 +1,11 @@
 # SDK Integration Tests
 
 These tests run live SDK flows against the production orchestrator on testnets.
-They are manual for now and require `INTEGRATION_RHINESTONE_API_KEY`.
+They are manual for now and require `INTEGRATION_RHINESTONE_API_KEY`. Funded
+specs (smart-session policies and on-chain source-call execution) additionally
+require `INTEGRATION_FUNDER_PRIVATE_KEY` — a key whose address holds testnet
+native + USDC on the integration chains; without it those specs fail fast with
+an actionable message.
 
 ```bash
 INTEGRATION_RHINESTONE_API_KEY=... bun run test:integration:smoke
@@ -10,7 +14,8 @@ INTEGRATION_RHINESTONE_API_KEY=... bun run test:integration:smoke
 Run every live integration scenario:
 
 ```bash
-INTEGRATION_RHINESTONE_API_KEY=... bun run test:integration -- --run
+INTEGRATION_RHINESTONE_API_KEY=... INTEGRATION_FUNDER_PRIVATE_KEY=... \
+  bun run test:integration -- --run
 ```
 
 For verbose per-intent diagnostics on passing and expected-failing cases:
@@ -37,7 +42,12 @@ Additional scenarios cover:
 
 - same-chain and cross-chain default Nexus execution
 - account kinds on same-chain routes
-- smart-session matrix coverage across account state, chain mode, and scope
-- smart-session negative cases
+- signature modes: owner ERC-1271, fresh-session hybrid, enabled-session
+  ERC-1271, and tampered-signature rejection
+- smart sessions: inline enablement across scope and chain mode, pre-enabled
+  use, and scope rejections
+- smart-session policies: spending-limit and recipient-allowlist enforcement
+  (funded)
+- preclaim source calls: enable-op ordering and on-chain execution (funded)
 - 7702 missing authorization
 - unsupported route errors

--- a/test/integration/config/environment.ts
+++ b/test/integration/config/environment.ts
@@ -2,6 +2,7 @@ import { RhinestoneSDK } from '../../../src/index'
 
 const API_KEY_ENV = 'INTEGRATION_RHINESTONE_API_KEY'
 const ORCHESTRATOR_URL_ENV = 'INTEGRATION_ORCHESTRATOR_URL'
+const FUNDER_PRIVATE_KEY_ENV = 'INTEGRATION_FUNDER_PRIVATE_KEY'
 
 export function getIntegrationApiKey(): string {
   const apiKey = process.env[API_KEY_ENV]
@@ -9,6 +10,25 @@ export function getIntegrationApiKey(): string {
     throw new Error(`${API_KEY_ENV} is required to run SDK integration tests`)
   }
   return apiKey
+}
+
+// Funder key for specs that move real testnet tokens (non-sponsored
+// cross-chain, spending-limit policies). Sponsored specs don't need it, so it's
+// only required by the funding util when a funded spec actually runs.
+export function getIntegrationFunderPrivateKey(): `0x${string}` {
+  const key = process.env[FUNDER_PRIVATE_KEY_ENV]
+  if (!key) {
+    throw new Error(
+      `${FUNDER_PRIVATE_KEY_ENV} is required for funded integration specs. ` +
+        `Set it to a private key whose address holds testnet native + USDC.`,
+    )
+  }
+  if (!/^0x[0-9a-fA-F]{64}$/.test(key)) {
+    throw new Error(
+      `${FUNDER_PRIVATE_KEY_ENV} must be a 0x-prefixed 32-byte hex private key`,
+    )
+  }
+  return key as `0x${string}`
 }
 
 // Optional endpoint override (e.g. dev orchestrator). Defaults to the SDK's

--- a/test/integration/framework/funding.ts
+++ b/test/integration/framework/funding.ts
@@ -1,0 +1,207 @@
+import {
+  type Address,
+  type Chain,
+  createPublicClient,
+  createWalletClient,
+  erc20Abi,
+  formatUnits,
+  http,
+  type PublicClient,
+  type WalletClient,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import type { RhinestoneAccount } from '../../../src/index'
+import { getTokenAddress } from '../../../src/orchestrator/registry'
+import { getIntegrationFunderPrivateKey } from '../config/environment'
+
+// Optional per-chain RPC override, e.g. INTEGRATION_RPC_URL_84532=https://...
+// Falls back to the viem chain's default public RPC.
+function getRpcUrl(chain: Chain): string | undefined {
+  return process.env[`INTEGRATION_RPC_URL_${chain.id}`]
+}
+
+let funderAccount: ReturnType<typeof privateKeyToAccount> | undefined
+function getFunder() {
+  if (!funderAccount) {
+    funderAccount = privateKeyToAccount(getIntegrationFunderPrivateKey())
+  }
+  return funderAccount
+}
+
+const publicClients = new Map<number, PublicClient>()
+function getPublicClient(chain: Chain): PublicClient {
+  let client = publicClients.get(chain.id)
+  if (!client) {
+    client = createPublicClient({ chain, transport: http(getRpcUrl(chain)) })
+    publicClients.set(chain.id, client)
+  }
+  return client
+}
+
+const walletClients = new Map<number, WalletClient>()
+function getWalletClient(chain: Chain): WalletClient {
+  let client = walletClients.get(chain.id)
+  if (!client) {
+    client = createWalletClient({
+      account: getFunder(),
+      chain,
+      transport: http(getRpcUrl(chain)),
+    })
+    walletClients.set(chain.id, client)
+  }
+  return client
+}
+
+// Raised when the funder can't cover a top-up. Distinct type so a suite can
+// fail fast with a single actionable message instead of N cascading reverts.
+export class FunderInsufficientBalanceError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FunderInsufficientBalanceError'
+  }
+}
+
+interface FundingRequest {
+  // Minimum balances the target must hold after funding (raw base units).
+  native?: bigint
+  usdc?: bigint
+}
+
+// Tops up `target` on `chain` so it holds at least the requested balances.
+// Idempotent: transfers only the shortfall, skips when already funded.
+// Throws FunderInsufficientBalanceError (run-blocking) if the funder can't
+// cover a needed transfer.
+export async function ensureFunded(
+  target: Address,
+  chain: Chain,
+  request: FundingRequest,
+): Promise<void> {
+  if (request.native !== undefined) {
+    await ensureNative(target, chain, request.native)
+  }
+  if (request.usdc !== undefined) {
+    await ensureUsdc(target, chain, request.usdc)
+  }
+}
+
+async function ensureNative(
+  target: Address,
+  chain: Chain,
+  required: bigint,
+): Promise<void> {
+  const publicClient = getPublicClient(chain)
+  const balance = await publicClient.getBalance({ address: target })
+  if (balance >= required) return
+
+  const shortfall = required - balance
+  const funder = getFunder()
+  const funderBalance = await publicClient.getBalance({
+    address: funder.address,
+  })
+  if (funderBalance < shortfall) {
+    throw new FunderInsufficientBalanceError(
+      `Funder ${funder.address} has insufficient native balance on ${chain.name}: ` +
+        `need ${formatEther(shortfall)} more, has ${formatEther(funderBalance)}. ` +
+        `Top up at the ${chain.name} faucet.`,
+    )
+  }
+
+  const walletClient = getWalletClient(chain)
+  const hash = await walletClient.sendTransaction({
+    account: funder,
+    chain,
+    to: target,
+    value: shortfall,
+  })
+  await publicClient.waitForTransactionReceipt({ hash })
+}
+
+async function ensureUsdc(
+  target: Address,
+  chain: Chain,
+  required: bigint,
+): Promise<void> {
+  const usdc = getTokenAddress('USDC', chain.id)
+  const publicClient = getPublicClient(chain)
+  const balance = await publicClient.readContract({
+    address: usdc,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: [target],
+  })
+  if (balance >= required) return
+
+  const shortfall = required - balance
+  const funder = getFunder()
+  const [funderBalance, decimals] = await Promise.all([
+    publicClient.readContract({
+      address: usdc,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [funder.address],
+    }),
+    publicClient.readContract({
+      address: usdc,
+      abi: erc20Abi,
+      functionName: 'decimals',
+    }),
+  ])
+  if (funderBalance < shortfall) {
+    throw new FunderInsufficientBalanceError(
+      `Funder ${funder.address} has insufficient USDC on ${chain.name}: ` +
+        `need ${formatUnits(shortfall, decimals)} more, ` +
+        `has ${formatUnits(funderBalance, decimals)} (${usdc}). ` +
+        `Top up the funder with USDC on ${chain.name}.`,
+    )
+  }
+
+  const walletClient = getWalletClient(chain)
+  const hash = await walletClient.writeContract({
+    account: funder,
+    chain,
+    address: usdc,
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [target, shortfall],
+  })
+  await publicClient.waitForTransactionReceipt({ hash })
+}
+
+function formatEther(wei: bigint): string {
+  return formatUnits(wei, 18)
+}
+
+export function usdcBalanceOf(address: Address, chain: Chain): Promise<bigint> {
+  return getPublicClient(chain).readContract({
+    address: getTokenAddress('USDC', chain.id),
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: [address],
+  })
+}
+
+// On-chain funding is only useful once the orchestrator's node sees it. Its
+// simulation lags the funding RPC by a few seconds, so poll the orchestrator's
+// own portfolio view until the balance shows up — otherwise a freshly-funded
+// transfer simulates against a stale zero balance and reverts intermittently.
+export async function waitForOrchestratorUsdc(
+  account: RhinestoneAccount,
+  chain: Chain,
+  min: bigint,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const portfolio = await account.getPortfolio(true)
+    const usdc = portfolio.find((token) => token.symbol === 'USDC')
+    const onChain = usdc?.chains.find((entry) => entry.chain === chain.id)
+    if (onChain && onChain.amount >= min) return
+    await sleep(2_000)
+  }
+  throw new Error(
+    `Orchestrator portfolio for ${account.getAddress()} never showed >= ${min} ` +
+      `USDC on ${chain.name} after funding`,
+  )
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/test/integration/framework/runner.ts
+++ b/test/integration/framework/runner.ts
@@ -15,9 +15,16 @@ type SuccessfulIntent = {
   durationMs: number
   prepared: PreparedTransactionData
   signed: SignedTransactionData
-  result: TransactionResult
-  status: unknown
+  result?: TransactionResult
+  status?: unknown
 }
+
+// How far the pipeline runs:
+//   - 'sign'    → prepare + sign only (encode-assert; inspect prepared/signed)
+//   - 'dryRun'  → + submit with internal_dryRun (orchestrator validates without
+//                 settlement or funds), no waitForExecution
+//   - 'execute' → full end-to-end incl. waitForExecution (default)
+export type ExecutionMode = 'sign' | 'dryRun' | 'execute'
 
 type FailedIntent = {
   phase: ErrorPhase
@@ -45,11 +52,17 @@ export async function executeIntent({
   transaction,
   label,
   signAuthorizations = false,
+  mode = 'execute',
+  transformSigned,
 }: {
   account: RhinestoneAccount
   transaction: Transaction
   label?: string
   signAuthorizations?: boolean
+  mode?: ExecutionMode
+  // Mutate the signed payload before submit, e.g. to tamper with signature
+  // bytes and assert the orchestrator rejects them.
+  transformSigned?: (signed: SignedTransactionData) => SignedTransactionData
 }): Promise<IntentExecution> {
   const startedAt = Date.now()
   let prepared: PreparedTransactionData | undefined
@@ -66,6 +79,7 @@ export async function executeIntent({
 
   try {
     signed = await account.signTransaction(prepared)
+    if (transformSigned) signed = transformSigned(signed)
   } catch (error) {
     return { phase: 'sign', label, durationMs: elapsed(), error, prepared }
   }
@@ -89,11 +103,21 @@ export async function executeIntent({
     }
   }
 
-  try {
-    result = await account.submitTransaction(
+  if (mode === 'sign') {
+    return {
+      phase: 'success',
+      label,
+      durationMs: elapsed(),
+      prepared,
       signed,
-      authorizations ? { authorizations } : undefined,
-    )
+    }
+  }
+
+  try {
+    result = await account.submitTransaction(signed, {
+      ...(authorizations ? { authorizations } : {}),
+      ...(mode === 'dryRun' ? { internal_dryRun: true } : {}),
+    })
   } catch (error) {
     return {
       phase: 'submit',
@@ -102,6 +126,17 @@ export async function executeIntent({
       error,
       prepared,
       signed,
+    }
+  }
+
+  if (mode === 'dryRun') {
+    return {
+      phase: 'success',
+      label,
+      durationMs: elapsed(),
+      prepared,
+      signed,
+      result,
     }
   }
 

--- a/test/integration/framework/signatures.ts
+++ b/test/integration/framework/signatures.ts
@@ -1,0 +1,115 @@
+import type { Hex } from 'viem'
+import type {
+  PreparedTransactionData,
+  SignedTransactionData,
+} from '../../../src/index'
+import type { OriginSignature } from '../../../src/orchestrator/types'
+import {
+  SIG_MODE_EMISSARY_EXECUTION_ERC1271,
+  SIG_MODE_ERC1271,
+} from '../../../src/orchestrator/types'
+
+// `signatureMode` lives on the prepared intent input, which the public type
+// keeps as `unknown`. Read it through a narrow cast rather than widening the
+// SDK type — tests assert on it, they don't depend on it being public.
+export function readSignatureMode(
+  prepared: PreparedTransactionData,
+): number | undefined {
+  const input = prepared.intentInput as
+    | { options?: { signatureMode?: number } }
+    | undefined
+  return input?.options?.signatureMode
+}
+
+// Single hex => ERC-1271 path; { preClaimSig, notarizedClaimSig } => the dual
+// emissary+1271 path used by sessions with verifyExecutions.
+export type OriginSignatureShape = 'single' | 'dual'
+
+function isDual(signature: OriginSignature): signature is {
+  notarizedClaimSig: `0x${string}`
+  preClaimSig: `0x${string}`
+} {
+  return typeof signature === 'object' && signature !== null
+}
+
+export function classifyOriginSignature(
+  signature: OriginSignature,
+): OriginSignatureShape {
+  return isDual(signature) ? 'dual' : 'single'
+}
+
+export function expectSignatureMode(
+  prepared: PreparedTransactionData,
+  expected: number,
+): void {
+  const actual = readSignatureMode(prepared)
+  if (actual !== expected) {
+    throw new Error(`Expected signatureMode ${expected}, got ${String(actual)}`)
+  }
+}
+
+// Asserts every origin signature has the same shape, and that the shape matches
+// the prepared signatureMode (mode/bytes consistency — the PR #476 invariant).
+export function expectOriginSignatures(
+  signed: SignedTransactionData,
+  expected: OriginSignatureShape,
+): void {
+  const signatures = signed.originSignatures
+  if (signatures.length === 0) {
+    throw new Error('Expected at least one origin signature, got none')
+  }
+  for (const [index, signature] of signatures.entries()) {
+    const shape = classifyOriginSignature(signature)
+    if (shape !== expected) {
+      throw new Error(
+        `Expected origin signature #${index} to be ${expected}, got ${shape}`,
+      )
+    }
+  }
+}
+
+// The core encoding invariant: the top-level signatureMode the SDK tells the
+// orchestrator must match the shape of the signature bytes it actually emitted.
+// A single hex signature implies the ERC-1271 path; a dual sig implies the
+// hybrid emissary-execution path. A mismatch (e.g. mode 0 with single 1271
+// bytes) makes the on-chain dispatcher pick the wrong validator.
+export function expectModeMatchesBytes(
+  prepared: PreparedTransactionData,
+  signed: SignedTransactionData,
+): void {
+  const mode = readSignatureMode(prepared)
+  const shape = classifyOriginSignature(signed.originSignatures[0])
+  const impliedMode =
+    shape === 'dual' ? SIG_MODE_EMISSARY_EXECUTION_ERC1271 : SIG_MODE_ERC1271
+  expectOriginSignatures(signed, shape)
+  if (mode !== impliedMode) {
+    throw new Error(
+      `signatureMode ${String(mode)} does not match ${shape} signature bytes ` +
+        `(which imply mode ${impliedMode})`,
+    )
+  }
+}
+
+// Overwrite the trailing `bytes` of a hex signature with 0xff. The emissary
+// preClaimSig ends in the validator's ECDSA signature, so corrupting the last
+// 65 bytes guarantees on-chain verifyExecution fails.
+export function corruptTail(hex: Hex, bytes: number): Hex {
+  const tailHex = 'ff'.repeat(bytes)
+  return `${hex.slice(0, hex.length - tailHex.length)}${tailHex}` as Hex
+}
+
+// Tampers with the execution-signature bytes of a signed (dual-sig) intent so
+// the orchestrator's simulation must reject it.
+export function tamperExecutionSignatures(
+  signed: SignedTransactionData,
+): SignedTransactionData {
+  return {
+    ...signed,
+    originSignatures: signed.originSignatures.map((signature) =>
+      isDual(signature)
+        ? { ...signature, preClaimSig: corruptTail(signature.preClaimSig, 65) }
+        : corruptTail(signature, 65),
+    ),
+    destinationSignature: corruptTail(signed.destinationSignature, 65),
+  }
+}

--- a/test/integration/scenarios/accounts.itest.ts
+++ b/test/integration/scenarios/accounts.itest.ts
@@ -10,139 +10,65 @@ import {
   expectOutcome,
 } from '../framework/runner'
 
+// Each account type's factory/init encoding is exercised by deploying and
+// running a sponsored same-chain intent on a fresh account.
 describe.sequential('SDK integration account kinds', () => {
-  test('runs a sponsored same-chain intent on a fresh Safe account', async () => {
-    const sdk = createIntegrationSDK()
-    const owner = createOwner()
-    const account = await sdk.createAccount({
-      account: { type: 'safe' },
-      owners: { type: 'ecdsa', accounts: [owner] },
+  for (const type of ['safe', 'kernel', 'startale'] as const) {
+    test(`runs a sponsored same-chain intent on a fresh ${type} account`, async () => {
+      const sdk = createIntegrationSDK()
+      const account = await sdk.createAccount({
+        account: { type },
+        owners: { type: 'ecdsa', accounts: [createOwner()] },
+      })
+
+      await expectNotDeployed(account, sourceChain)
+
+      const execution = await executeIntent({
+        account,
+        label: `accounts/${type}/same-chain/fresh`,
+        transaction: {
+          chain: sourceChain,
+          sponsored: true,
+          calls: [createNoopCall()],
+        },
+      })
+
+      expectOutcome(execution, { kind: 'success' })
+      if (execution.phase !== 'success') return
+
+      expectNoFailedOperations(execution.status)
+      expectCompletedOperation(execution.status, sourceChain.id)
+      await expectDeployed(account, sourceChain)
     })
+  }
 
-    await expectNotDeployed(account, sourceChain)
-
-    const execution = await executeIntent({
-      account,
-      label: 'accounts/safe/same-chain/fresh/sponsored',
-      transaction: {
-        chain: sourceChain,
-        sponsored: true,
-        calls: [createNoopCall()],
-      },
-    })
-
-    expectOutcome(execution, { kind: 'success' })
-    if (execution.phase !== 'success') return
-
-    expectNoFailedOperations(execution.status)
-    expectCompletedOperation(execution.status, sourceChain.id)
-    await expectDeployed(account, sourceChain)
+  test.todo('runs a sponsored same-chain intent on a fresh EOA account', () => {
+    // EOA accounts are not yet supported on sponsored testnet routes. The
+    // orchestrator returns UNPROCESSABLE_CONTENT with "the account type is
+    // not supported for the available routes".
   })
-
-  test('runs a sponsored same-chain intent on a fresh Kernel account', async () => {
-    const sdk = createIntegrationSDK()
-    const owner = createOwner()
-    const account = await sdk.createAccount({
-      account: { type: 'kernel' },
-      owners: { type: 'ecdsa', accounts: [owner] },
-    })
-
-    await expectNotDeployed(account, sourceChain)
-
-    const execution = await executeIntent({
-      account,
-      label: 'accounts/kernel/same-chain/fresh/sponsored',
-      transaction: {
-        chain: sourceChain,
-        sponsored: true,
-        calls: [createNoopCall()],
-      },
-    })
-
-    expectOutcome(execution, { kind: 'success' })
-    if (execution.phase !== 'success') return
-
-    expectNoFailedOperations(execution.status)
-    expectCompletedOperation(execution.status, sourceChain.id)
-    await expectDeployed(account, sourceChain)
-  })
-
-  test('runs a sponsored same-chain intent on a fresh Startale account', async () => {
-    const sdk = createIntegrationSDK()
-    const owner = createOwner()
-    const account = await sdk.createAccount({
-      account: { type: 'startale' },
-      owners: { type: 'ecdsa', accounts: [owner] },
-    })
-
-    await expectNotDeployed(account, sourceChain)
-
-    const execution = await executeIntent({
-      account,
-      label: 'accounts/startale/same-chain/fresh/sponsored',
-      transaction: {
-        chain: sourceChain,
-        sponsored: true,
-        calls: [createNoopCall()],
-      },
-    })
-
-    expectOutcome(execution, { kind: 'success' })
-    if (execution.phase !== 'success') return
-
-    expectNoFailedOperations(execution.status)
-    expectCompletedOperation(execution.status, sourceChain.id)
-    await expectDeployed(account, sourceChain)
-  })
-
-  test.todo(
-    'runs a sponsored same-chain intent on a fresh EOA account',
-    async () => {
-      // EOA accounts are not yet supported on sponsored testnet routes.
-      // The orchestrator returns UNPROCESSABLE_CONTENT with
-      // "the account type is not supported for the available routes".
-      //
-      // const sdk = createIntegrationSDK()
-      // const owner = createOwner()
-      // const account = await sdk.createAccount({
-      //   account: { type: 'eoa' },
-      //   owners: { type: 'ecdsa', accounts: [owner] },
-      //   eoa: owner,
-      // })
-      // const execution = await executeIntent({
-      //   account,
-      //   label: 'accounts/eoa/same-chain/fresh/sponsored',
-      //   transaction: {
-      //     chain: sourceChain,
-      //     sponsored: true,
-      //     calls: [createNoopCall()],
-      //   },
-      // })
-      // expectOutcome(execution, { kind: 'success' })
-    },
-  )
 
   test('runs a sponsored same-chain intent on a fresh Nexus 7702 account', async () => {
     const sdk = createIntegrationSDK()
-    const owner = createOwner()
-    const eoa = createOwner()
     const account = await sdk.createAccount({
       account: { type: 'nexus' },
-      owners: { type: 'ecdsa', accounts: [owner] },
-      eoa,
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+      eoa: createOwner(),
     })
     const eip7702InitSignature = await account.signEip7702InitData()
+
     const execution = await executeIntent({
       account,
-      label: 'accounts/nexus-7702/same-chain/fresh/sponsored',
+      label: 'accounts/nexus-7702/same-chain/fresh',
+      signAuthorizations: true,
       transaction: {
         chain: sourceChain,
         sponsored: true,
         calls: [createNoopCall()],
         eip7702InitSignature,
       },
-      signAuthorizations: true,
     })
+
     expectOutcome(execution, { kind: 'success' })
     if (execution.phase !== 'success') return
 

--- a/test/integration/scenarios/preclaim-ops.itest.ts
+++ b/test/integration/scenarios/preclaim-ops.itest.ts
@@ -1,0 +1,182 @@
+import { encodeFunctionData, erc20Abi } from 'viem'
+import { describe, expect, test } from 'vitest'
+import type {
+  PreparedTransactionData,
+  RhinestoneAccount,
+  Session,
+} from '../../../src/index'
+import {
+  DUMMY_PRECLAIMOP_SELECTOR,
+  DUMMY_PRECLAIMOP_TARGET,
+} from '../../../src/modules/validators/smart-sessions'
+import { getTokenAddress } from '../../../src/orchestrator/registry'
+import { sourceChain, targetChain } from '../config/chains'
+import { createIntegrationSDK } from '../config/environment'
+import {
+  createNoopCall,
+  createOwner,
+  createScopedSession,
+  noopSelector,
+  noopTarget,
+} from '../framework/fixtures'
+import {
+  ensureFunded,
+  usdcBalanceOf,
+  waitForOrchestratorUsdc,
+} from '../framework/funding'
+import {
+  executeIntent,
+  expectCompletedOperation,
+  expectOutcome,
+} from '../framework/runner'
+
+type Execution = { to: string; value: bigint; data: string }
+
+function readPreClaimExecutions(
+  prepared: PreparedTransactionData,
+): Record<number, Execution[]> | undefined {
+  const input = prepared.intentInput as
+    | { preClaimExecutions?: Record<number, Execution[]> }
+    | undefined
+  return input?.preClaimExecutions
+}
+
+describe.sequential('SDK integration preclaim-ops', () => {
+  // A fresh session needs enabling, so the SDK injects the dummy enable op as
+  // the first source-chain preclaim op; user source calls must follow it (the
+  // filler runs the enable op before the user's calls).
+  test('injects the session-enable op before user source calls', async () => {
+    const sdk = createIntegrationSDK()
+    const account = await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+      experimental_sessions: { enabled: true },
+    })
+    const session = createScopedSession({
+      chain: sourceChain,
+      owner: createOwner(),
+    })
+
+    const execution = await executeIntent({
+      account,
+      label: 'preclaim/dummy-ordering',
+      mode: 'sign',
+      transaction: await withEnableData(account, session, {
+        sourceChains: [sourceChain],
+        targetChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+        sourceCalls: { [sourceChain.id]: [createNoopCall()] },
+        signers: { type: 'experimental_session', session },
+      }),
+    })
+
+    expectOutcome(execution, { kind: 'success' })
+    if (execution.phase !== 'success') return
+
+    const preClaim = readPreClaimExecutions(execution.prepared)
+    const ops = preClaim?.[sourceChain.id]
+    expect(ops?.length).toBe(2)
+    expect(ops?.[0].to.toLowerCase()).toBe(
+      DUMMY_PRECLAIMOP_TARGET.toLowerCase(),
+    )
+    expect(ops?.[0].data).toBe(DUMMY_PRECLAIMOP_SELECTOR)
+    expect(ops?.[1].to.toLowerCase()).toBe(noopTarget.toLowerCase())
+    expect(ops?.[1].data).toBe(noopSelector)
+  })
+
+  // A plain owner intent has no session to enable and no source calls, so no
+  // preclaim ops are attached.
+  test('attaches no preclaim ops to a plain owner intent', async () => {
+    const sdk = createIntegrationSDK()
+    const account = await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+    })
+
+    const execution = await executeIntent({
+      account,
+      label: 'preclaim/none',
+      mode: 'sign',
+      transaction: {
+        sourceChains: [sourceChain],
+        targetChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+      },
+    })
+
+    expectOutcome(execution, { kind: 'success' })
+    if (execution.phase !== 'success') return
+
+    expect(readPreClaimExecutions(execution.prepared)).toBeUndefined()
+  })
+
+  // Source calls aren't just encoded — they run on-chain. A cross-chain intent
+  // moves USDC from the source (creating the source element the source call
+  // rides in), and the source call transfers USDC to a fresh recipient. After
+  // settlement that recipient must actually hold the transferred amount.
+  test('executes a user source call on-chain', async () => {
+    const sdk = createIntegrationSDK()
+    const account = await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+    })
+    await ensureFunded(account.getAddress(), sourceChain, { usdc: 1_000_000n })
+    await waitForOrchestratorUsdc(account, sourceChain, 1_000_000n)
+
+    const recipient = createOwner().address
+    const sourceCallAmount = 5_000n
+    const usdc = getTokenAddress('USDC', sourceChain.id)
+
+    const execution = await executeIntent({
+      account,
+      label: 'preclaim/execute',
+      transaction: {
+        sourceChains: [sourceChain],
+        targetChain,
+        sponsored: true,
+        calls: [],
+        tokenRequests: [{ address: 'USDC', amount: 10_000n }],
+        sourceCalls: {
+          [sourceChain.id]: [
+            {
+              to: usdc,
+              value: 0n,
+              data: encodeFunctionData({
+                abi: erc20Abi,
+                functionName: 'transfer',
+                args: [recipient, sourceCallAmount],
+              }),
+            },
+          ],
+        },
+      },
+    })
+
+    expectOutcome(execution, { kind: 'success' })
+    if (execution.phase !== 'success') return
+
+    expectCompletedOperation(execution.status, targetChain.id)
+    expect(await usdcBalanceOf(recipient, sourceChain)).toBe(sourceCallAmount)
+  })
+})
+
+async function withEnableData<T extends { signers: { type: string } }>(
+  account: RhinestoneAccount,
+  session: Session,
+  transaction: T,
+): Promise<T> {
+  const sessionDetails = await account.experimental_getSessionDetails([session])
+  const userSignature =
+    await account.experimental_signEnableSession(sessionDetails)
+
+  return {
+    ...transaction,
+    signers: {
+      ...transaction.signers,
+      enableData: {
+        userSignature,
+        hashesAndChainIds: sessionDetails.hashesAndChainIds,
+        sessionToEnableIndex: 0,
+      },
+    },
+  }
+}

--- a/test/integration/scenarios/sigmode.itest.ts
+++ b/test/integration/scenarios/sigmode.itest.ts
@@ -1,0 +1,188 @@
+import { describe, test } from 'vitest'
+import { SimulationFailedError } from '../../../src/errors/index'
+import type { RhinestoneAccount, Session } from '../../../src/index'
+import {
+  SIG_MODE_EMISSARY_EXECUTION_ERC1271,
+  SIG_MODE_ERC1271,
+} from '../../../src/orchestrator/types'
+import { sourceChain } from '../config/chains'
+import { createIntegrationSDK } from '../config/environment'
+import { expectSessionEnabled } from '../framework/assertions'
+import {
+  createNoopCall,
+  createOwner,
+  createScopedSession,
+  createUnscopedSession,
+} from '../framework/fixtures'
+import { executeIntent, expectOutcome } from '../framework/runner'
+import {
+  expectModeMatchesBytes,
+  expectOriginSignatures,
+  expectSignatureMode,
+  tamperExecutionSignatures,
+} from '../framework/signatures'
+
+describe.sequential('SDK integration sigmode', () => {
+  // A plain owner signature takes the ERC-1271 path: a single hex signature and
+  // signatureMode 1.
+  test('emits ERC-1271 mode with single signatures for a non-session owner', async () => {
+    const sdk = createIntegrationSDK()
+    const account = await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+    })
+
+    const execution = await executeIntent({
+      account,
+      label: 'sigmode/owner/erc1271',
+      mode: 'sign',
+      transaction: {
+        chain: sourceChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+      },
+    })
+
+    expectOutcome(execution, { kind: 'success' })
+    if (execution.phase !== 'success') return
+
+    expectSignatureMode(execution.prepared, SIG_MODE_ERC1271)
+    expectOriginSignatures(execution.signed, 'single')
+  })
+
+  // A fresh (not-yet-enabled) session always verifies executions, so it takes
+  // the hybrid path: dual { preClaimSig, notarizedClaimSig } signatures and
+  // signatureMode 5.
+  test('emits hybrid execution mode with dual signatures for a fresh session', async () => {
+    const sdk = createIntegrationSDK()
+    const account = await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+      experimental_sessions: { enabled: true },
+    })
+    const session = createScopedSession({
+      chain: sourceChain,
+      owner: createOwner(),
+    })
+
+    const execution = await executeIntent({
+      account,
+      label: 'sigmode/session/hybrid',
+      mode: 'sign',
+      transaction: await withEnableData(account, session, {
+        chain: sourceChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+        signers: { type: 'experimental_session', session },
+      }),
+    })
+
+    expectOutcome(execution, { kind: 'success' })
+    if (execution.phase !== 'success') return
+
+    expectSignatureMode(execution.prepared, SIG_MODE_EMISSARY_EXECUTION_ERC1271)
+    expectOriginSignatures(execution.signed, 'dual')
+    expectModeMatchesBytes(execution.prepared, execution.signed)
+  })
+
+  // An enabled session with no explicit permissions verifies nothing extra, so
+  // it drops back to the plain ERC-1271 path: single signature, mode 1 — even
+  // though a fresh session would have been the hybrid mode 5. This is the path
+  // a claim-only session takes once enabled.
+  test('emits ERC-1271 mode with single signatures for an enabled session', async () => {
+    const sdk = createIntegrationSDK()
+    const account = await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+      experimental_sessions: { enabled: true },
+    })
+    const session = createUnscopedSession({
+      chain: sourceChain,
+      owner: createOwner(),
+    })
+
+    const enable = await executeIntent({
+      account,
+      label: 'sigmode/enabled/enable',
+      transaction: await withEnableData(account, session, {
+        chain: sourceChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+        signers: { type: 'experimental_session', session },
+      }),
+    })
+    expectOutcome(enable, { kind: 'success' })
+    await expectSessionEnabled(account, session)
+
+    const execution = await executeIntent({
+      account,
+      label: 'sigmode/enabled/use',
+      mode: 'sign',
+      transaction: {
+        chain: sourceChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+        signers: { type: 'experimental_session', session },
+      },
+    })
+
+    expectOutcome(execution, { kind: 'success' })
+    if (execution.phase !== 'success') return
+
+    expectSignatureMode(execution.prepared, SIG_MODE_ERC1271)
+    expectOriginSignatures(execution.signed, 'single')
+    expectModeMatchesBytes(execution.prepared, execution.signed)
+  })
+
+  // The orchestrator's simulation must reject an intent whose execution
+  // signature was tampered with — the hybrid path's ERC-1271 fallback does not
+  // rescue corrupted preClaimSig bytes within a single operation.
+  test('rejects an intent whose execution signature was tampered with', async () => {
+    const sdk = createIntegrationSDK()
+    const account = await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [createOwner()] },
+      experimental_sessions: { enabled: true },
+    })
+    const session = createScopedSession({
+      chain: sourceChain,
+      owner: createOwner(),
+    })
+
+    const execution = await executeIntent({
+      account,
+      label: 'sigmode/tampered/reject',
+      transformSigned: tamperExecutionSignatures,
+      transaction: await withEnableData(account, session, {
+        chain: sourceChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+        signers: { type: 'experimental_session', session },
+      }),
+    })
+
+    expectOutcome(execution, {
+      kind: 'submit-error',
+      error: SimulationFailedError,
+      code: 'SIMULATION_FAILED',
+    })
+  })
+})
+
+async function withEnableData<T extends { signers: { type: string } }>(
+  account: RhinestoneAccount,
+  session: Session,
+  transaction: T,
+): Promise<T> {
+  const sessionDetails = await account.experimental_getSessionDetails([session])
+  const userSignature =
+    await account.experimental_signEnableSession(sessionDetails)
+
+  return {
+    ...transaction,
+    signers: {
+      ...transaction.signers,
+      enableData: {
+        userSignature,
+        hashesAndChainIds: sessionDetails.hashesAndChainIds,
+        sessionToEnableIndex: 0,
+      },
+    },
+  }
+}

--- a/test/integration/scenarios/ssx-policies.itest.ts
+++ b/test/integration/scenarios/ssx-policies.itest.ts
@@ -1,0 +1,184 @@
+import { type Address, encodeFunctionData, erc20Abi } from 'viem'
+import { describe, test } from 'vitest'
+import { SimulationFailedError } from '../../../src/errors/index'
+import type { RhinestoneAccount, Session } from '../../../src/index'
+import { toSession } from '../../../src/modules/validators/smart-sessions'
+import { getTokenAddress } from '../../../src/orchestrator/registry'
+import { sourceChain } from '../config/chains'
+import { createIntegrationSDK } from '../config/environment'
+import { createOwner } from '../framework/fixtures'
+import { ensureFunded, waitForOrchestratorUsdc } from '../framework/funding'
+import {
+  executeIntent,
+  expectCompletedOperation,
+  expectNoFailedOperations,
+  expectOutcome,
+} from '../framework/runner'
+
+const ALICE: Address = '0x1111111111111111111111111111111111111111'
+const BOB: Address = '0x2222222222222222222222222222222222222222'
+const CAROL: Address = '0x3333333333333333333333333333333333333333'
+
+const usdc = getTokenAddress('USDC', sourceChain.id)
+
+// Comfortably above every transfer amount below, so an allowed transfer settles
+// against a real balance and a rejected one can only be the policy talking —
+// never an insufficient-balance revert.
+const FUNDING = 100_000n
+
+function usdcTransfer(to: Address, amount: bigint) {
+  return {
+    to: usdc,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'transfer',
+      args: [to, amount],
+    }),
+  }
+}
+
+function spendingLimitSession(amount: bigint): Session {
+  return toSession({
+    chain: sourceChain,
+    owners: { type: 'ecdsa', accounts: [createOwner()] },
+    permissions: [
+      {
+        abi: erc20Abi,
+        address: usdc,
+        functions: { transfer: { spendingLimit: { token: usdc, amount } } },
+      },
+    ],
+  })
+}
+
+function allowlistSession(
+  recipients: readonly [Address, ...Address[]],
+): Session {
+  return toSession({
+    chain: sourceChain,
+    owners: { type: 'ecdsa', accounts: [createOwner()] },
+    permissions: [
+      {
+        abi: erc20Abi,
+        address: usdc,
+        functions: {
+          transfer: { params: { recipient: { anyOf: recipients } } },
+        },
+      },
+    ],
+  })
+}
+
+describe.sequential('SDK integration ssx policies', () => {
+  test('allows a transfer within the spending limit', async () => {
+    const account = await createFundedSessionAccount()
+    await expectSettled(
+      account,
+      spendingLimitSession(100n),
+      usdcTransfer(ALICE, 50n),
+      'spend/ok',
+    )
+  })
+
+  test('rejects a transfer over the spending limit', async () => {
+    const account = await createFundedSessionAccount()
+    await expectRejected(
+      account,
+      spendingLimitSession(100n),
+      usdcTransfer(ALICE, 1_000n),
+      'spend/over',
+    )
+  })
+
+  test('allows a transfer to an allowlisted recipient', async () => {
+    const account = await createFundedSessionAccount()
+    await expectSettled(
+      account,
+      allowlistSession([ALICE, BOB]),
+      usdcTransfer(ALICE, 1n),
+      'anyof/ok',
+    )
+  })
+
+  test('rejects a transfer to a non-allowlisted recipient', async () => {
+    const account = await createFundedSessionAccount()
+    await expectRejected(
+      account,
+      allowlistSession([ALICE, BOB]),
+      usdcTransfer(CAROL, 1n),
+      'anyof/bad',
+    )
+  })
+})
+
+async function createFundedSessionAccount(): Promise<RhinestoneAccount> {
+  const account = await createIntegrationSDK().createAccount({
+    owners: { type: 'ecdsa', accounts: [createOwner()] },
+    experimental_sessions: { enabled: true },
+  })
+  await ensureFunded(account.getAddress(), sourceChain, { usdc: FUNDING })
+  await waitForOrchestratorUsdc(account, sourceChain, FUNDING)
+  return account
+}
+
+async function expectSettled(
+  account: RhinestoneAccount,
+  session: Session,
+  call: ReturnType<typeof usdcTransfer>,
+  label: string,
+): Promise<void> {
+  const execution = await executeIntent({
+    account,
+    label: `ssx-policies/${label}`,
+    transaction: await sessionTransfer(account, session, call),
+  })
+  expectOutcome(execution, { kind: 'success' })
+  if (execution.phase !== 'success') return
+
+  expectNoFailedOperations(execution.status)
+  expectCompletedOperation(execution.status, sourceChain.id)
+}
+
+async function expectRejected(
+  account: RhinestoneAccount,
+  session: Session,
+  call: ReturnType<typeof usdcTransfer>,
+  label: string,
+): Promise<void> {
+  const execution = await executeIntent({
+    account,
+    label: `ssx-policies/${label}`,
+    transaction: await sessionTransfer(account, session, call),
+  })
+  expectOutcome(execution, {
+    kind: 'submit-error',
+    error: SimulationFailedError,
+    code: 'SIMULATION_FAILED',
+  })
+}
+
+async function sessionTransfer(
+  account: RhinestoneAccount,
+  session: Session,
+  call: ReturnType<typeof usdcTransfer>,
+) {
+  const sessionDetails = await account.experimental_getSessionDetails([session])
+  const userSignature =
+    await account.experimental_signEnableSession(sessionDetails)
+
+  return {
+    chain: sourceChain,
+    sponsored: true as const,
+    calls: [call],
+    signers: {
+      type: 'experimental_session' as const,
+      session,
+      enableData: {
+        userSignature,
+        hashesAndChainIds: sessionDetails.hashesAndChainIds,
+        sessionToEnableIndex: 0,
+      },
+    },
+  }
+}

--- a/test/integration/scenarios/ssx.itest.ts
+++ b/test/integration/scenarios/ssx.itest.ts
@@ -26,71 +26,71 @@ import {
   expectOutcome,
 } from '../framework/runner'
 
-type AccountState = 'fresh' | 'deployed' | 'enabled'
 type ChainMode = 'same' | 'cross'
 type Scope = 'unscoped' | 'scoped-single' | 'scoped-multi'
 
-type MatrixCase = {
-  accountState: AccountState
-  chainMode: ChainMode
-  scope: Scope
-}
-
-const matrixCases: MatrixCase[] = [
-  ...flatMap(['fresh', 'deployed', 'enabled'] as const, (accountState) =>
-    flatMap(['same', 'cross'] as const, (chainMode) =>
-      (['unscoped', 'scoped-single', 'scoped-multi'] as const).map((scope) => ({
-        accountState,
-        chainMode,
-        scope,
-      })),
-    ),
-  ),
-]
+const chainModes: ChainMode[] = ['same', 'cross']
+const scopes: Scope[] = ['unscoped', 'scoped-single', 'scoped-multi']
 
 describe.sequential('SDK integration ssx', () => {
-  for (const matrixCase of matrixCases) {
-    const label = `ssx/${matrixCase.chainMode}/${matrixCase.accountState}/${matrixCase.scope}`
+  // ENABLE mode on a fresh account: enable each session scope inline and use it
+  // in one bundle. Exercises the enable payload, per-scope permission encoding,
+  // dummy preclaim op, and dual signature end-to-end.
+  for (const chainMode of chainModes) {
+    for (const scope of scopes) {
+      test(`enables a ${scope} session inline on a fresh ${chainMode}-chain account`, async () => {
+        const account = await createSessionAccount()
+        const sessionChain = getExecutionChain(chainMode)
+        const session = createSession(scope, {
+          chain: sessionChain,
+          owner: createOwner(),
+        })
 
-    test(`uses ${matrixCase.scope} session on ${matrixCase.accountState} ${matrixCase.chainMode}-chain account`, async () => {
-      const sdk = createIntegrationSDK()
-      const owner = createOwner()
-      const sessionOwner = createOwner()
-      const account = await sdk.createAccount({
-        owners: { type: 'ecdsa', accounts: [owner] },
-        experimental_sessions: { enabled: true },
-      })
-      const sessionChain = getExecutionChain(matrixCase.chainMode)
-      const session = createSession(matrixCase.scope, {
-        chain: sessionChain,
-        owner: sessionOwner,
-      })
-      const transaction = createSessionTransaction(matrixCase.chainMode, {
-        session,
-      })
-
-      if (matrixCase.accountState === 'deployed') {
-        await deployAccount(account, matrixCase.chainMode, `${label}/deploy`)
-      }
-
-      if (matrixCase.accountState === 'enabled') {
-        await enableSession(
-          account,
-          session,
-          matrixCase.chainMode,
-          `${label}/enable`,
-        )
-      } else {
         await expectSessionDisabled(account, session)
-      }
+
+        const execution = await executeIntent({
+          account,
+          label: `ssx/${chainMode}/fresh/${scope}`,
+          transaction: await addEnableData(
+            account,
+            session,
+            createSessionTransaction(chainMode, { session }),
+          ),
+        })
+
+        expectOutcome(execution, { kind: 'success' })
+        if (execution.phase !== 'success') return
+
+        expectNoFailedOperations(execution.status)
+        expectCompletedOperation(execution.status, sessionChain.id)
+        await expectDeployed(account, sessionChain)
+        await expectSessionEnabled(account, session)
+      })
+    }
+  }
+
+  // USE mode: enable a session for real, then use it end-to-end. Proves the
+  // enabled-session signing path settles on-chain.
+  for (const chainMode of chainModes) {
+    test(`uses a pre-enabled session on a ${chainMode}-chain account`, async () => {
+      const account = await createSessionAccount()
+      const sessionChain = getExecutionChain(chainMode)
+      const session = createScopedSession({
+        chain: sessionChain,
+        owner: createOwner(),
+      })
+
+      await enableSession(
+        account,
+        session,
+        chainMode,
+        `ssx/${chainMode}/enable`,
+      )
 
       const execution = await executeIntent({
         account,
-        label: `${label}/execute`,
-        transaction:
-          matrixCase.accountState === 'enabled'
-            ? transaction
-            : await addEnableData(account, session, transaction),
+        label: `ssx/${chainMode}/use`,
+        transaction: createSessionTransaction(chainMode, { session }),
       })
 
       expectOutcome(execution, { kind: 'success' })
@@ -98,102 +98,60 @@ describe.sequential('SDK integration ssx', () => {
 
       expectNoFailedOperations(execution.status)
       expectCompletedOperation(execution.status, sessionChain.id)
-      await expectDeployed(account, sessionChain)
       await expectSessionEnabled(account, session)
     })
   }
 
   test('rejects a session-signed call with wrong selector', async () => {
-    const sdk = createIntegrationSDK()
-    const owner = createOwner()
-    const sessionOwner = createOwner()
-    const account = await sdk.createAccount({
-      owners: { type: 'ecdsa', accounts: [owner] },
-      experimental_sessions: { enabled: true },
-    })
-    const session = createScopedSession({
-      chain: sourceChain,
-      owner: sessionOwner,
-    })
-
-    await expectSessionDisabled(account, session)
-
-    const execution = await executeIntent({
-      account,
-      label: 'ssx/wrong-selector/submit-error',
-      transaction: await addEnableData(account, session, {
-        chain: sourceChain,
-        sponsored: true,
-        calls: [createOutOfScopeCall()],
-        signers: {
-          type: 'experimental_session',
-          session,
-        },
-      }),
-    })
-
-    expectOutcome(execution, {
-      kind: 'submit-error',
-      error: SimulationFailedError,
-      code: 'SIMULATION_FAILED',
-    })
-    await expectNotDeployed(account, sourceChain)
+    await expectScopedCallRejected(createOutOfScopeCall(), 'wrong-selector')
   })
 
   test('rejects a session-signed call with wrong target', async () => {
-    const sdk = createIntegrationSDK()
-    const owner = createOwner()
-    const sessionOwner = createOwner()
-    const account = await sdk.createAccount({
-      owners: { type: 'ecdsa', accounts: [owner] },
-      experimental_sessions: { enabled: true },
-    })
-    const session = createScopedSession({
-      chain: sourceChain,
-      owner: sessionOwner,
-    })
-
-    await expectSessionDisabled(account, session)
-
-    const execution = await executeIntent({
-      account,
-      label: 'ssx/wrong-target/submit-error',
-      transaction: await addEnableData(account, session, {
-        chain: sourceChain,
-        sponsored: true,
-        calls: [createWrongTargetCall()],
-        signers: {
-          type: 'experimental_session',
-          session,
-        },
-      }),
-    })
-
-    expectOutcome(execution, {
-      kind: 'submit-error',
-      error: SimulationFailedError,
-      code: 'SIMULATION_FAILED',
-    })
-    await expectNotDeployed(account, sourceChain)
+    await expectScopedCallRejected(createWrongTargetCall(), 'wrong-target')
   })
 })
 
-function flatMap<T, U>(
-  values: readonly T[],
-  mapper: (value: T) => readonly U[],
-): U[] {
-  return values.flatMap((value) => mapper(value))
+async function expectScopedCallRejected(
+  call: ReturnType<typeof createOutOfScopeCall>,
+  label: string,
+): Promise<void> {
+  const account = await createSessionAccount()
+  const session = createScopedSession({
+    chain: sourceChain,
+    owner: createOwner(),
+  })
+
+  await expectSessionDisabled(account, session)
+
+  const execution = await executeIntent({
+    account,
+    label: `ssx/${label}/reject`,
+    transaction: await addEnableData(account, session, {
+      chain: sourceChain,
+      sponsored: true,
+      calls: [call],
+      signers: { type: 'experimental_session', session },
+    }),
+  })
+
+  expectOutcome(execution, {
+    kind: 'submit-error',
+    error: SimulationFailedError,
+    code: 'SIMULATION_FAILED',
+  })
+  await expectNotDeployed(account, sourceChain)
+}
+
+function createSessionAccount() {
+  return createIntegrationSDK().createAccount({
+    owners: { type: 'ecdsa', accounts: [createOwner()] },
+    experimental_sessions: { enabled: true },
+  })
 }
 
 function createSession(
   scope: Scope,
-  {
-    chain,
-    owner,
-  }: {
-    chain: Chain
-    owner: ReturnType<typeof createOwner>
-  },
+  { chain, owner }: { chain: Chain; owner: ReturnType<typeof createOwner> },
 ): Session {
   if (scope === 'unscoped') return createUnscopedSession({ chain, owner })
   if (scope === 'scoped-multi')
@@ -212,24 +170,13 @@ function createSessionTransaction(
   const base = {
     sponsored: true,
     calls: [createNoopCall()],
-    signers: {
-      type: 'experimental_session' as const,
-      session,
-    },
+    signers: { type: 'experimental_session' as const, session },
   }
 
   if (chainMode === 'cross') {
-    return {
-      ...base,
-      sourceChains: [sourceChain],
-      targetChain,
-    }
+    return { ...base, sourceChains: [sourceChain], targetChain }
   }
-
-  return {
-    ...base,
-    chain: sourceChain,
-  }
+  return { ...base, chain: sourceChain }
 }
 
 async function addEnableData(
@@ -252,33 +199,6 @@ async function addEnableData(
       },
     },
   }
-}
-
-async function deployAccount(
-  account: RhinestoneAccount,
-  chainMode: ChainMode,
-  label: string,
-): Promise<void> {
-  const transaction =
-    chainMode === 'cross'
-      ? {
-          sourceChains: [sourceChain],
-          targetChain,
-          sponsored: true,
-          calls: [createNoopCall()],
-        }
-      : {
-          chain: sourceChain,
-          sponsored: true,
-          calls: [createNoopCall()],
-        }
-  const execution = await executeIntent({ account, label, transaction })
-  expectOutcome(execution, { kind: 'success' })
-  if (execution.phase !== 'success') return
-
-  expectNoFailedOperations(execution.status)
-  expectCompletedOperation(execution.status, getExecutionChain(chainMode).id)
-  await expectDeployed(account, getExecutionChain(chainMode))
 }
 
 async function enableSession(


### PR DESCRIPTION
Expands the live SDK integration suite around the encoding/decoding surfaces ahead of a wider refactor. Net **34 passing + 1 todo** against the prod testnet orchestrator (~2–3 min).

## Coverage
- **sigmode** — the `signatureMode` ↔ signature-bytes invariant: plain owner (mode 1, single), fresh session (mode 5, dual), enabled session with no explicit permissions (mode 1, single — the path a claim-only session takes once enabled), and a tampered execution signature (rejected at simulation).
- **preclaim-ops** — dummy enable-op ordered before user source calls (encode-assert); a user source call executing on-chain, observed via recipient balance.
- **ssx** — reshaped the 18-cell matrix to 6 fresh-ENABLE (scope × chain) + 2 pre-enabled-USE (same/cross, incl. the cross-chain session TODO) + 2 scope rejections; dropped the redundant `deployed` row.
- **ssx-policies** — spending-limit and recipient-allowlist enforcement, each proven by an allowed transfer settling **and** an out-of-policy one rejecting.
- **accounts** — kept per-type deploy coverage, DRY'd the Safe/Kernel/Startale trio into a loop.
- **funding util** (`INTEGRATION_FUNDER_PRIVATE_KEY`) for funded specs, with an orchestrator-portfolio poll that avoids a funding-sync race.
- **runner** — `sign`/`dryRun` execution modes and a signed-payload transform hook (used by the encode-assert and rejection tests).

## Notes for review
- The `dryRun` mode (orchestrator-side validation without settlement/funds) requires a dry-run-capable API key; it's kept in the runner but currently unused, ready to flip on when such a key is wired.
- Possible SDK bug surfaced while writing the allowlist test: a **single-element** `anyOf: [addr]` recipient policy reverts even the allowed recipient (`MalformedAssemblyRevert`); examples only ever use ≥2 elements. Happy to file a repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)