### PR TITLE
ci(integration): pass INTEGRATION_FUNDER_PRIVATE_KEY to the suite

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,6 +34,9 @@ jobs:
       # bundles simulate against the matching dev deployment. Empty for prod
       # falls back to the SDK's built-in prod URL + prod contracts.
       INTEGRATION_ORCHESTRATOR_URL: ${{ inputs.target == 'dev' && 'https://dev.v1.orchestrator.rhinestone.dev' || '' }}
+      # Funder for the funded specs in the `all` suite (smoke needs none). The
+      # address must hold testnet native + USDC; same testnet key for prod/dev.
+      INTEGRATION_FUNDER_PRIVATE_KEY: ${{ secrets.INTEGRATION_FUNDER_PRIVATE_KEY }}
 
     steps:
       # Resolve the API key explicitly per target. A ternary like


### PR DESCRIPTION
The `all` integration suite now includes funded specs (smart-session policies, on-chain source-call execution) that require `INTEGRATION_FUNDER_PRIVATE_KEY`. The workflow only wired in the API key, so those specs failed with `INTEGRATION_FUNDER_PRIVATE_KEY is required for funded integration specs` ([example run](https://github.com/rhinestonewtf/sdk/actions/runs/27288567428/job/80602545180)).

Exposes the existing repo secret to the job env. The funder is testnet-only and orchestrator-target-independent, so one value covers both prod and dev. Smoke suite is unaffected (no funded specs).

Follow-up to #564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)