### PR TITLE
chore: add context7 library claim file

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/rhinestonewtf/sdk",
+  "public_key": "pk_3YNHBdkQM5LaJvYHAeSyL"
+}


### PR DESCRIPTION
Adds `context7.json` at the repo root so we can claim the `rhinestonewtf/sdk` library on Context7. Context7 reads the public key from this file to verify ownership.