### PR TITLE
feat: expose signIntent for headless intent flows

### DIFF
--- a/.changeset/expose-sign-intent.md
+++ b/.changeset/expose-sign-intent.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Expose `signIntent` on the account to sign orchestrator-prepared intents in headless flows, and export the `SignedIntentData` type.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -49,17 +49,16 @@ describe('createRhinestoneAccount', () => {
     mockGetTargetExecutionSignature.mockResolvedValue('0x33')
 
     const account = await createRhinestoneAccount(config)
-    const result = await account.signIntent(signData, base, signers, {
-      targetExecution: true,
-    })
+    const result = await account.signIntent(signData, base, signers)
 
-    // Keep headless integrations on the canonical SDK SmartSession signer.
+    // Mirror the canonical signTransaction path: origin/destination always
+    // signed in claim mode (targetExecution=false), target-exec sig separate.
     expect(mockSignIntent).toHaveBeenCalledWith(
       config,
       signData,
       base,
       signers,
-      true,
+      false,
     )
     expect(mockGetTargetExecutionSignature).toHaveBeenCalledWith(
       config,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,76 @@
+import { base } from 'viem/chains'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { accountA } from '../test/consts'
+import type { SignData } from './orchestrator'
+import type { SessionSignerSet } from './types'
+
+const { mockGetTargetExecutionSignature, mockSignIntent } = vi.hoisted(() => ({
+  mockGetTargetExecutionSignature: vi.fn(),
+  mockSignIntent: vi.fn(),
+}))
+
+vi.mock('./execution/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./execution/utils')>()
+  return {
+    ...actual,
+    getTargetExecutionSignature: mockGetTargetExecutionSignature,
+    signIntent: mockSignIntent,
+  }
+})
+
+const { createRhinestoneAccount } = await import('.')
+
+describe('createRhinestoneAccount', () => {
+  beforeEach(() => {
+    mockGetTargetExecutionSignature.mockReset()
+    mockSignIntent.mockReset()
+  })
+
+  test('signIntent delegates to SDK intent signing utilities', async () => {
+    const config = {
+      owners: { type: 'ecdsa' as const, accounts: [accountA], threshold: 1 },
+    }
+    const signData = {
+      origin: [],
+      destination: {},
+    } as unknown as SignData
+    const signers = {
+      type: 'experimental_session',
+      session: {
+        chain: base,
+        owners: { type: 'ecdsa' as const, accounts: [accountA] },
+      },
+    } as unknown as SessionSignerSet
+
+    mockSignIntent.mockResolvedValue({
+      originSignatures: ['0x11'],
+      destinationSignature: '0x22',
+    })
+    mockGetTargetExecutionSignature.mockResolvedValue('0x33')
+
+    const account = await createRhinestoneAccount(config)
+    const result = await account.signIntent(signData, base, signers, {
+      targetExecution: true,
+    })
+
+    // Keep headless integrations on the canonical SDK SmartSession signer.
+    expect(mockSignIntent).toHaveBeenCalledWith(
+      config,
+      signData,
+      base,
+      signers,
+      true,
+    )
+    expect(mockGetTargetExecutionSignature).toHaveBeenCalledWith(
+      config,
+      signData,
+      base,
+      signers,
+    )
+    expect(result).toEqual({
+      originSignatures: ['0x11'],
+      destinationSignature: '0x22',
+      targetExecutionSignature: '0x33',
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,6 @@ interface RhinestoneAccount {
     signData: SignData,
     targetChain: DestinationChain,
     signers?: SignerSet,
-    options?: { targetExecution?: boolean },
   ) => Promise<SignedIntentData>
   submitTransaction: (
     signedTransaction: SignedTransactionData,
@@ -394,25 +393,25 @@ async function createRhinestoneAccount(
    * Sign an orchestrator intent operation.
    * This is used by headless flows that prepare the intent outside the SDK but
    * still need the SDK-owned SmartSession signature packing and target-execution
-   * signature routing.
+   * signature routing. Mirrors the canonical {@link signTransaction} path: origin
+   * and destination are always signed in claim mode, and the target-execution
+   * signature is derived separately (returned only when the intent requires it).
    * @param signData Sign data returned by the orchestrator (origin/destination/targetExecution typed data)
    * @param targetChain Chain where the destination execution runs
    * @param signers Signers to use for signing
-   * @param options Optional signature routing controls
    * @returns Intent signatures ready for submission
    */
   async function signIntent(
     signData: SignData,
     targetChain: DestinationChain,
     signers?: SignerSet,
-    options?: { targetExecution?: boolean },
   ): Promise<SignedIntentData> {
     const { originSignatures, destinationSignature } = await signIntentInternal(
       config,
       signData,
       targetChain,
       signers,
-      options?.targetExecution,
+      false,
     )
     const targetExecutionSignature = await getTargetExecutionSignatureInternal(
       config,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
   waitForExecution as waitForExecutionInternal,
 } from './execution'
 import {
+  getTargetExecutionSignature as getTargetExecutionSignatureInternal,
   getTransactionMessages as getTransactionMessagesInternal,
   type PreparedQuotes,
   type PreparedTransactionData,
@@ -44,6 +45,7 @@ import {
   type SignedTransactionData,
   type SignedUserOperationData,
   signAuthorizations as signAuthorizationsInternal,
+  signIntent as signIntentInternal,
   signMessage as signMessageInternal,
   signTransaction as signTransactionInternal,
   signTypedData as signTypedDataInternal,
@@ -83,6 +85,7 @@ import type {
   Quote,
   SettlementLayer,
   SettlementLayerFilter,
+  SignData,
   SplitIntentsInput,
   SplitIntentsResult,
   TokenRequirements,
@@ -181,6 +184,12 @@ interface RhinestoneAccount {
     chain: Chain,
     signers: SignerSet | undefined,
   ) => Promise<Hex>
+  signIntent: (
+    signData: SignData,
+    targetChain: DestinationChain,
+    signers?: SignerSet,
+    options?: { targetExecution?: boolean },
+  ) => Promise<SignedIntentData>
   submitTransaction: (
     signedTransaction: SignedTransactionData,
     options?: SubmitTransactionOptions,
@@ -212,6 +221,12 @@ interface RhinestoneAccount {
   } | null>
   getValidators: (chain: Chain) => Promise<Address[]>
   getExecutors: (chain: Chain) => Promise<Address[]>
+}
+
+interface SignedIntentData {
+  originSignatures: OriginSignature[]
+  destinationSignature: Hex
+  targetExecutionSignature: Hex | undefined
 }
 
 /**
@@ -376,6 +391,44 @@ async function createRhinestoneAccount(
   }
 
   /**
+   * Sign an orchestrator intent operation.
+   * This is used by headless flows that prepare the intent outside the SDK but
+   * still need the SDK-owned SmartSession signature packing and target-execution
+   * signature routing.
+   * @param signData Sign data returned by the orchestrator (origin/destination/targetExecution typed data)
+   * @param targetChain Chain where the destination execution runs
+   * @param signers Signers to use for signing
+   * @param options Optional signature routing controls
+   * @returns Intent signatures ready for submission
+   */
+  async function signIntent(
+    signData: SignData,
+    targetChain: DestinationChain,
+    signers?: SignerSet,
+    options?: { targetExecution?: boolean },
+  ): Promise<SignedIntentData> {
+    const { originSignatures, destinationSignature } = await signIntentInternal(
+      config,
+      signData,
+      targetChain,
+      signers,
+      options?.targetExecution,
+    )
+    const targetExecutionSignature = await getTargetExecutionSignatureInternal(
+      config,
+      signData,
+      targetChain,
+      signers,
+    )
+
+    return {
+      originSignatures,
+      destinationSignature,
+      targetExecutionSignature,
+    }
+  }
+
+  /**
    * Submit a transaction
    * @param signedTransaction Signed transaction data
    * @param options Optional submission options
@@ -533,6 +586,7 @@ async function createRhinestoneAccount(
     signAuthorizations,
     signMessage,
     signTypedData,
+    signIntent,
     submitTransaction,
     prepareUserOperation,
     signUserOperation,
@@ -678,6 +732,7 @@ export type {
   ApprovalRequired,
   // Intent signing
   OriginSignature,
+  SignedIntentData,
   // Operation status types (blanc API)
   OperationStatus,
   FailureReason,

--- a/src/index.ts
+++ b/src/index.ts
@@ -732,6 +732,7 @@ export type {
   ApprovalRequired,
   // Intent signing
   OriginSignature,
+  SignData,
   SignedIntentData,
   // Operation status types (blanc API)
   OperationStatus,


### PR DESCRIPTION
Port of #568 to the `release` (v2) branch — the original couldn't be rebased due to extensive merge conflicts.

Adds a `signIntent` method on the Rhinestone account so headless flows that prepare the intent outside the SDK can still use the SDK-owned SmartSession signature packing and target-execution signature routing. Exports the new `SignedIntentData` type, plus a unit test verifying `signIntent` delegates to the canonical SDK signing utilities, and a `minor` changeset.

Differences from #568, due to the v2 refactor on `release`:
- The public method accepts a `SignData` (the orchestrator's prepared typed-data payload) instead of an `IntentOp`, matching the internal `signIntent`/`getTargetExecutionSignature` signatures on `release`. `IntentOp` no longer exists in v2.
- `targetChain` is typed as `DestinationChain` (EVM + non-EVM) rather than `Chain`.
- No `OriginSignature` re-export change needed — it's already exported from `/orchestrator` on `release`.

Companion to #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)