### PR TITLE
feat(hca): support custom factory via account config

### DIFF
--- a/.changeset/hca-custom-factory.md
+++ b/.changeset/hca-custom-factory.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Support a custom HCA factory via `account.factory`, which defines the deploy address and, through its implementation, the account's default validator.

--- a/src/accounts/hca.test.ts
+++ b/src/accounts/hca.test.ts
@@ -196,6 +196,20 @@ describe('Accounts: HCA', () => {
       })
       expect(result).toBeNull()
     })
+
+    test('custom factory overrides the deploy target', () => {
+      const customFactory: Address =
+        '0x00000000000000000000000000000000c0ffee00'
+      const result = getDeployArgs({
+        account: { type: 'hca', factory: customFactory },
+        owners: {
+          type: 'ens',
+          accounts: [accountA],
+          ownerExpirations: [Number(maxUint48)],
+        },
+      })
+      expect(result?.factory).toEqual(customFactory)
+    })
   })
 
   describe('Get Address', () => {
@@ -221,6 +235,23 @@ describe('Accounts: HCA', () => {
         },
       })
       expect(address).toEqual(address2)
+    })
+
+    test('Custom factory produces a different address', () => {
+      const owners = {
+        type: 'ens' as const,
+        accounts: [accountA],
+        ownerExpirations: [Number(maxUint48)],
+      }
+      const address = getAddress({ account: { type: 'hca' }, owners })
+      const customAddress = getAddress({
+        account: {
+          type: 'hca',
+          factory: '0x00000000000000000000000000000000c0ffee00',
+        },
+        owners,
+      })
+      expect(customAddress).not.toEqual(address)
     })
 
     test('Different primary owners produce different addresses', () => {

--- a/src/accounts/hca.ts
+++ b/src/accounts/hca.ts
@@ -60,6 +60,11 @@ function getDeployArgs(config: RhinestoneAccountConfig) {
     )
   }
 
+  const factory =
+    config.account?.type === 'hca' && config.account.factory
+      ? config.account.factory
+      : HCA_FACTORY_ADDRESS
+
   if (config.initData) {
     if (!('factory' in config.initData)) {
       return null
@@ -114,7 +119,7 @@ function getDeployArgs(config: RhinestoneAccountConfig) {
   })
 
   return {
-    factory: HCA_FACTORY_ADDRESS,
+    factory,
     factoryData,
     salt: zeroHash,
     implementation: HCA_IMPLEMENTATION_ADDRESS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -473,7 +473,23 @@ async function createRhinestoneAccount(
   function getOwners(chain: Chain) {
     const accountType = getAccountProvider(config).type
     const account = getAddress()
-    return getOwnersInternal(accountType, account, chain, config.provider)
+    // For HCA, the module lives behind the factory (custom factories define
+    // their own). Resolve from the configured or initData factory so reads hit
+    // the right module.
+    const hcaFactory =
+      config.account?.type === 'hca'
+        ? (config.account.factory ??
+          (config.initData && 'factory' in config.initData
+            ? config.initData.factory
+            : undefined))
+        : undefined
+    return getOwnersInternal(
+      accountType,
+      account,
+      chain,
+      config.provider,
+      hcaFactory,
+    )
   }
 
   /**

--- a/src/modules/read.ts
+++ b/src/modules/read.ts
@@ -66,6 +66,7 @@ async function getOwners(
   account: Address,
   chain: Chain,
   provider?: ProviderConfig,
+  hcaFactory?: Address,
 ): Promise<{
   accounts: Address[]
   threshold: number
@@ -74,10 +75,28 @@ async function getOwners(
     chain,
     transport: createTransport(chain, provider),
   })
-  // HCA accounts hold owner state under the ENS HCA module, which is also
-  // OwnableValidator-based, so the getOwners/threshold reads are identical.
-  const moduleAddress =
-    accountType === 'hca' ? ENS_HCA_MODULE : OWNABLE_VALIDATOR_ADDRESS
+  // HCA accounts hold owner state under the HCA module (the factory's init-data
+  // parser), which is OwnableValidator-based, so the getOwners/threshold reads
+  // are identical. A custom factory defines its own module, so resolve it from
+  // the factory; otherwise fall back to the canonical module.
+  let moduleAddress: Address = OWNABLE_VALIDATOR_ADDRESS
+  if (accountType === 'hca') {
+    moduleAddress = hcaFactory
+      ? await publicClient.readContract({
+          abi: [
+            {
+              name: 'initDataParser',
+              type: 'function',
+              stateMutability: 'view',
+              inputs: [],
+              outputs: [{ name: '', type: 'address' }],
+            },
+          ],
+          functionName: 'initDataParser',
+          address: hcaFactory,
+        })
+      : ENS_HCA_MODULE
+  }
   const [ownerResult, thresholdResult] = await publicClient.multicall({
     contracts: [
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,10 @@ interface PassportAccount {
 
 interface HcaAccount {
   type: 'hca'
+  // Custom HCA factory. Defines the CREATE3 deploy address and, via its
+  // implementation, the account's default validator (the HCA module).
+  // Defaults to the canonical HCA factory.
+  factory?: Address
 }
 
 interface EoaAccount {


### PR DESCRIPTION
Adds an optional `factory` to the `hca` account config. A custom factory defines the CREATE3 deploy address and, through its implementation, the account's default validator (the HCA module).

```ts
account: { type: 'hca', factory: '0x…' }
```

- `getAddress` already derives via `predictCreate3Address(deployArgs.factory, …)`, so a custom factory yields a custom address for free.
- **Signing is unaffected.** For HCA the owner validator *is* the account's default validator, so the SDK keeps `validator.address === defaultValidatorAddress` → the default-validator (zero-address) nonce/signature path is used. The account validates through its own default validator regardless of the literal module address. This is why no module override is needed: the factory's implementation defines the module on-chain.
- **Owner reads** resolve the module from the factory. `getOwners` calls `factory.initDataParser()` (the factory's registered `IHCAInitDataParser`, i.e. the `HCAModule`/`OwnableValidator`) for custom-factory accounts, falling back to the canonical module otherwise. The factory is taken from `account.factory` or, for existing accounts, `initData.factory`.

A custom factory must follow the canonical HCA shape (Solady CREATE3, `createAccount(bytes ownerInitData)`, module installed as the Nexus default validator).

Closes [RHI-4422](https://linear.app/rhinestone/issue/RHI-4422)