### PR TITLE
fix(ecdsa): enable() initializes Nexus default validator

### DIFF
--- a/.changeset/ecdsa-enable-default-validator.md
+++ b/.changeset/ecdsa-enable-default-validator.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Fix `enable` (ECDSA) on Nexus accounts. The OwnableValidator is the Nexus default validator and cannot be added via `installModule` (`DefaultValidatorAlreadyInstalled`); on passkey-bootstrapped accounts it is also never initialized, so `addOwner` reverts with `NotInitialized`. `enable` now initializes the default validator directly via `onInstall`, and throws a clear error (instead of an opaque simulation revert) when ECDSA is already enabled.

--- a/src/accounts/error.ts
+++ b/src/accounts/error.ts
@@ -101,6 +101,20 @@ class SmartSessionsNotEnabledError extends AccountError {
   }
 }
 
+class DefaultValidatorAlreadyInitializedError extends AccountError {
+  constructor(params?: {
+    context?: any
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        'ECDSA is already enabled on this account. Use `addOwner` / `removeOwner` / `changeThreshold` to manage owners instead of `enable`.',
+      ...params,
+    })
+  }
+}
+
 class SigningNotSupportedForAccountError extends AccountError {
   constructor(params?: {
     context?: any
@@ -246,6 +260,7 @@ export {
   EoaAccountMustHaveAccountError,
   FactoryArgsNotAvailableError,
   SmartSessionsNotEnabledError,
+  DefaultValidatorAlreadyInitializedError,
   SigningNotSupportedForAccountError,
   Eip7702NotSupportedForAccountError,
   AccountConfigurationNotSupportedError,

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -83,6 +83,7 @@ import {
   getGuardianSmartAccount as getNexusGuardianSmartAccount,
   getInstallData as getNexusInstallData,
   getSmartAccount as getNexusSmartAccount,
+  isDefaultValidatorConfigured as isNexusDefaultValidatorConfigured,
   packSignature as packNexusSignature,
   signEip7702InitData as signNexusEip7702InitData,
 } from './nexus'
@@ -322,12 +323,18 @@ async function getValidatorInstallationCalls(
     if (
       module.address.toLowerCase() === defaultValidatorAddress.toLowerCase()
     ) {
-      const initialized = await isValidatorInitialized(
-        getAddress(config),
-        chain,
-        defaultValidatorAddress,
-        config.provider,
-      )
+      // Treat the validator as initialized if the account's deployment will
+      // initialize it (config check, covers not-yet-deployed accounts) or if
+      // it is already initialized on-chain (covers accounts where ECDSA was
+      // enabled separately after deployment).
+      const initialized =
+        isNexusDefaultValidatorConfigured(config) ||
+        (await isValidatorInitialized(
+          getAddress(config),
+          chain,
+          defaultValidatorAddress,
+          config.provider,
+        ))
       if (initialized) {
         throw new DefaultValidatorAlreadyInitializedError()
       }

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -22,7 +22,10 @@ import {
 } from '../execution'
 import { getIntentExecutor, getSetup } from '../modules'
 import { MODULE_TYPE_ID_VALIDATOR, type Module } from '../modules/common'
-import { getValidators as getValidatorsInternal } from '../modules/read'
+import {
+  getValidators as getValidatorsInternal,
+  isValidatorInitialized,
+} from '../modules/read'
 import { getOwnerValidator } from '../modules/validators'
 import { getSocialRecoveryValidator } from '../modules/validators/core'
 import type { ResolvedSessionSignerSet } from '../modules/validators/smart-sessions'
@@ -36,6 +39,7 @@ import type {
 import {
   AccountConfigurationNotSupportedError,
   AccountError,
+  DefaultValidatorAlreadyInitializedError,
   Eip712DomainNotAvailableError,
   Eip7702AccountMustHaveEoaError,
   Eip7702NotSupportedForAccountError,
@@ -72,6 +76,7 @@ import {
 import {
   getAddress as getNexusAddress,
   getDefaultValidatorAddress as getNexusDefaultValidatorAddress,
+  getDefaultValidatorInitData as getNexusDefaultValidatorInitData,
   getDeployArgs as getNexusDeployArgs,
   getEip712Domain as getNexusEip712Domain,
   getEip7702InitCall as getNexusEip7702InitCall,
@@ -297,6 +302,45 @@ function getModuleInstallationCalls(
     value: 0n,
     data,
   }))
+}
+
+// Like `getModuleInstallationCalls`, but aware of the Nexus default validator.
+// On Nexus the OwnableValidator is the hardwired default validator: it can't be
+// added via `installModule` (reverts `DefaultValidatorAlreadyInstalled`), and
+// passkey-bootstrapped accounts never initialize it, so `addOwner` reverts with
+// `NotInitialized`. For that case we initialize it directly via `onInstall`.
+async function getValidatorInstallationCalls(
+  config: RhinestoneConfig,
+  chain: Chain,
+  module: Module,
+): Promise<Call[]> {
+  const account = getAccountProvider(config)
+  if (account.type === 'nexus') {
+    const defaultValidatorAddress = getNexusDefaultValidatorAddress(
+      account.version,
+    )
+    if (
+      module.address.toLowerCase() === defaultValidatorAddress.toLowerCase()
+    ) {
+      const initialized = await isValidatorInitialized(
+        getAddress(config),
+        chain,
+        defaultValidatorAddress,
+        config.provider,
+      )
+      if (initialized) {
+        throw new DefaultValidatorAlreadyInitializedError()
+      }
+      return [
+        {
+          to: defaultValidatorAddress,
+          value: 0n,
+          data: getNexusDefaultValidatorInitData(module),
+        },
+      ]
+    }
+  }
+  return getModuleInstallationCalls(config, module)
 }
 
 // SentinelList head pointer used by ERC-7579 module managers (Nexus, Safe7579,
@@ -972,6 +1016,7 @@ function getAccountProvider(config: RhinestoneConfig): AccountProviderConfig {
 export {
   getEip712Domain,
   getModuleInstallationCalls,
+  getValidatorInstallationCalls,
   getModuleUninstallationCalls,
   getAddress,
   checkAddress,

--- a/src/accounts/nexus.ts
+++ b/src/accounts/nexus.ts
@@ -256,6 +256,26 @@ function getInstallData(module: Module) {
   })
 }
 
+// On Nexus the OwnableValidator is the hardwired default validator. It cannot
+// be added via `installModule` (reverts `DefaultValidatorAlreadyInstalled`), so
+// it is initialized out-of-band by calling its `onInstall` directly with the
+// same init data `installModule` would have passed (`abi.encode(threshold, owners)`).
+function getDefaultValidatorInitData(module: Module): Hex {
+  return encodeFunctionData({
+    abi: [
+      {
+        type: 'function',
+        name: 'onInstall',
+        inputs: [{ type: 'bytes', name: 'data' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ],
+    functionName: 'onInstall',
+    args: [module.initData],
+  })
+}
+
 function getDefaultValidatorAddress(
   version:
     | '1.0.2'
@@ -593,6 +613,7 @@ function isAbiDecodingError(error: unknown): boolean {
 export {
   getEip712Domain,
   getInstallData,
+  getDefaultValidatorInitData,
   getAddress,
   getDefaultValidatorAddress,
   packSignature,

--- a/src/accounts/nexus.ts
+++ b/src/accounts/nexus.ts
@@ -276,6 +276,24 @@ function getDefaultValidatorInitData(module: Module): Hex {
   })
 }
 
+// Whether the deploy bootstrap will initialize the default validator — i.e. the
+// account is configured with an Ownable/ECDSA owner set. Mirrors the
+// `defaultValidatorInitData` computation in `getDeployArgs`, so a counterfactual
+// (not-yet-deployed) account whose deployment initializes the default validator
+// is treated as already-initialized rather than emitting a second `onInstall`.
+function isDefaultValidatorConfigured(
+  config: RhinestoneAccountConfig,
+): boolean {
+  if (config.initData) {
+    return false
+  }
+  const moduleSetup = getModuleSetup(config)
+  const defaultValidator = moduleSetup.validators.find(
+    (v) => v.address === NEXUS_DEFAULT_VALIDATOR_ADDRESS,
+  )
+  return defaultValidator ? size(defaultValidator.initData) > 0 : false
+}
+
 function getDefaultValidatorAddress(
   version:
     | '1.0.2'
@@ -614,6 +632,7 @@ export {
   getEip712Domain,
   getInstallData,
   getDefaultValidatorInitData,
+  isDefaultValidatorConfigured,
   getAddress,
   getDefaultValidatorAddress,
   packSignature,

--- a/src/actions/ecdsa.test.ts
+++ b/src/actions/ecdsa.test.ts
@@ -1,7 +1,7 @@
 import { type Address, encodeAbiParameters, encodeFunctionData } from 'viem'
 import { base } from 'viem/chains'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { accountA } from '../../test/consts'
+import { accountA, passkeyAccount } from '../../test/consts'
 import { RhinestoneSDK } from '..'
 import { resolveCallInputs } from '../execution/utils'
 import {
@@ -92,13 +92,16 @@ function expectedOnInstallCalldata(threshold: number, owners: Address[]) {
 }
 
 describe('ECDSA Actions', () => {
+  // Enabling ECDSA on a passkey account is the real scenario: the OwnableValidator
+  // (the Nexus default validator) is not initialized at deploy, so `enable`
+  // initializes it via `onInstall`.
   describe('Install Ownable Validator', async () => {
     const read = await import('../modules/read')
     const rhinestone = new RhinestoneSDK({ apiKey: 'test' })
     const rhinestoneAccount = await rhinestone.createAccount({
       owners: {
-        type: 'ecdsa',
-        accounts: [accountA],
+        type: 'passkey',
+        accounts: [passkeyAccount],
       },
     })
 
@@ -158,7 +161,7 @@ describe('ECDSA Actions', () => {
       ])
     })
 
-    test('throws when the default validator is already initialized', async () => {
+    test('throws when the default validator is already initialized on-chain', async () => {
       vi.mocked(read.isValidatorInitialized).mockResolvedValue(true)
       await expect(
         resolveCallInputs(
@@ -168,6 +171,35 @@ describe('ECDSA Actions', () => {
           accountAddress,
         ),
       ).rejects.toThrow(/ECDSA is already enabled/)
+    })
+  })
+
+  // An ECDSA-configured account initializes the default validator at deployment,
+  // so `enable` is redundant. This is detected from config without an on-chain
+  // read, so it also holds for not-yet-deployed (counterfactual) accounts.
+  describe('Enable on an account already configured with ECDSA', async () => {
+    const read = await import('../modules/read')
+    const rhinestone = new RhinestoneSDK({ apiKey: 'test' })
+    const rhinestoneAccount = await rhinestone.createAccount({
+      owners: {
+        type: 'ecdsa',
+        accounts: [accountA],
+      },
+    })
+
+    test('throws without reading chain state', async () => {
+      vi.mocked(read.isValidatorInitialized)
+        .mockClear()
+        .mockResolvedValue(false)
+      await expect(
+        resolveCallInputs(
+          [enableEcdsa([MOCK_OWNER_A])],
+          rhinestoneAccount.config,
+          base,
+          accountAddress,
+        ),
+      ).rejects.toThrow(/ECDSA is already enabled/)
+      expect(read.isValidatorInitialized).not.toHaveBeenCalled()
     })
   })
 

--- a/src/actions/ecdsa.test.ts
+++ b/src/actions/ecdsa.test.ts
@@ -1,6 +1,6 @@
-import { encodeAbiParameters, encodeFunctionData } from 'viem'
+import { type Address, encodeAbiParameters, encodeFunctionData } from 'viem'
 import { base } from 'viem/chains'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { accountA } from '../../test/consts'
 import { RhinestoneSDK } from '..'
 import { resolveCallInputs } from '../execution/utils'
@@ -13,9 +13,10 @@ import {
 } from './ecdsa'
 
 // `getModuleUninstallationCalls` reads the on-chain validator list to compute
-// the SentinelList `prev` pointer for the uninstall. The test account isn't
-// deployed, so stub the read with a known single-validator list. The address
-// is inlined because `vi.mock` is hoisted above any module-scope `const`.
+// the SentinelList `prev` pointer for the uninstall. `enable` reads whether the
+// Nexus default validator is already initialized. The test account isn't
+// deployed, so stub both reads. The address is inlined because `vi.mock` is
+// hoisted above any module-scope `const`.
 vi.mock('../modules/read', async (importActual) => {
   const actual = await importActual<typeof import('../modules/read')>()
   return {
@@ -23,6 +24,7 @@ vi.mock('../modules/read', async (importActual) => {
     getValidators: vi
       .fn()
       .mockResolvedValue(['0x000000000013fdb5234e4e3162a810f54d9f7e98']),
+    isValidatorInitialized: vi.fn().mockResolvedValue(false),
   }
 })
 
@@ -64,14 +66,44 @@ const MOCK_OWNER_B = '0xeddfcb50d18f6d3d51c4f7cbca5ed6bdebc59817'
 const MOCK_OWNER_C = '0xb31e76f19defe76edc4b7eceeb4b0a2d6ddaca39'
 const accountAddress = '0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0'
 
+// On Nexus the OwnableValidator is the default validator: `enable` initializes
+// it via `onInstall(abi.encode(threshold, owners))` instead of `installModule`.
+function expectedOnInstallCalldata(threshold: number, owners: Address[]) {
+  const initData = encodeAbiParameters(
+    [{ type: 'uint256' }, { type: 'address[]' }],
+    [
+      BigInt(threshold),
+      owners.map((owner) => owner.toLowerCase() as Address).sort(),
+    ],
+  )
+  return encodeFunctionData({
+    abi: [
+      {
+        type: 'function',
+        name: 'onInstall',
+        inputs: [{ type: 'bytes', name: 'data' }],
+        outputs: [],
+        stateMutability: 'nonpayable',
+      },
+    ],
+    functionName: 'onInstall',
+    args: [initData],
+  })
+}
+
 describe('ECDSA Actions', () => {
   describe('Install Ownable Validator', async () => {
+    const read = await import('../modules/read')
     const rhinestone = new RhinestoneSDK({ apiKey: 'test' })
     const rhinestoneAccount = await rhinestone.createAccount({
       owners: {
         type: 'ecdsa',
         accounts: [accountA],
       },
+    })
+
+    beforeEach(() => {
+      vi.mocked(read.isValidatorInitialized).mockResolvedValue(false)
     })
 
     test('1/1 Owners', async () => {
@@ -83,9 +115,9 @@ describe('ECDSA Actions', () => {
       )
       expect(calls).toEqual([
         {
-          to: accountAddress,
+          to: OWNABLE_VALIDATOR_ADDRESS,
           value: 0n,
-          data: '0x9517e29f0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000013fdb5234e4e3162a810f54d9f7e9800000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000d1aefebdceefc094f1805b241fa5e6db63a9181a',
+          data: expectedOnInstallCalldata(1, [MOCK_OWNER_A]),
         },
       ])
     })
@@ -99,9 +131,9 @@ describe('ECDSA Actions', () => {
       )
       expect(calls).toEqual([
         {
-          to: accountAddress,
+          to: OWNABLE_VALIDATOR_ADDRESS,
           value: 0n,
-          data: '0x9517e29f0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000013fdb5234e4e3162a810f54d9f7e98000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000d1aefebdceefc094f1805b241fa5e6db63a9181a000000000000000000000000eddfcb50d18f6d3d51c4f7cbca5ed6bdebc59817',
+          data: expectedOnInstallCalldata(1, [MOCK_OWNER_A, MOCK_OWNER_B]),
         },
       ])
     })
@@ -115,11 +147,27 @@ describe('ECDSA Actions', () => {
       )
       expect(calls).toEqual([
         {
-          to: accountAddress,
+          to: OWNABLE_VALIDATOR_ADDRESS,
           value: 0n,
-          data: '0x9517e29f0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000013fdb5234e4e3162a810f54d9f7e98000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000003000000000000000000000000b31e76f19defe76edc4b7eceeb4b0a2d6ddaca39000000000000000000000000d1aefebdceefc094f1805b241fa5e6db63a9181a000000000000000000000000eddfcb50d18f6d3d51c4f7cbca5ed6bdebc59817',
+          data: expectedOnInstallCalldata(2, [
+            MOCK_OWNER_A,
+            MOCK_OWNER_B,
+            MOCK_OWNER_C,
+          ]),
         },
       ])
+    })
+
+    test('throws when the default validator is already initialized', async () => {
+      vi.mocked(read.isValidatorInitialized).mockResolvedValue(true)
+      await expect(
+        resolveCallInputs(
+          [enableEcdsa([MOCK_OWNER_A])],
+          rhinestoneAccount.config,
+          base,
+          accountAddress,
+        ),
+      ).rejects.toThrow(/ECDSA is already enabled/)
     })
   })
 

--- a/src/actions/ecdsa.ts
+++ b/src/actions/ecdsa.ts
@@ -1,7 +1,7 @@
 import { type Address, encodeFunctionData } from 'viem'
 import {
-  getModuleInstallationCalls,
   getModuleUninstallationCalls,
+  getValidatorInstallationCalls,
 } from '../accounts'
 import {
   getOwnableValidator,
@@ -18,8 +18,8 @@ import type { CalldataInput, LazyCallInput } from '../types'
 function enable(owners: Address[], threshold = 1): LazyCallInput {
   const module = getOwnableValidator(threshold, owners)
   return {
-    async resolve({ config }) {
-      return getModuleInstallationCalls(config, module)
+    async resolve({ chain, config }) {
+      return getValidatorInstallationCalls(config, chain, module)
     },
   }
 }

--- a/src/modules/read.ts
+++ b/src/modules/read.ts
@@ -206,26 +206,25 @@ async function isValidatorInitialized(
     chain,
     transport: createTransport(chain, provider),
   })
-  try {
-    return await publicClient.readContract({
-      abi: [
-        {
-          name: 'isInitialized',
-          type: 'function',
-          stateMutability: 'view',
-          inputs: [{ name: 'smartAccount', type: 'address' }],
-          outputs: [{ name: '', type: 'bool' }],
-        },
-      ],
-      functionName: 'isInitialized',
-      address: validatorAddress,
-      args: [account],
-    })
-  } catch {
-    // Treat read failures (e.g. undeployed account) as not-initialized so the
-    // common first-time enable path still produces an `onInstall` call.
-    return false
-  }
+  // `isInitialized` is a plain storage read on the validator singleton and
+  // returns `false` for an uninitialized (or undeployed) account without
+  // reverting. We deliberately let real read failures (provider/ABI errors)
+  // propagate rather than coercing them to `false`, which could otherwise
+  // produce an `onInstall` call for an already-initialized account.
+  return publicClient.readContract({
+    abi: [
+      {
+        name: 'isInitialized',
+        type: 'function',
+        stateMutability: 'view',
+        inputs: [{ name: 'smartAccount', type: 'address' }],
+        outputs: [{ name: '', type: 'bool' }],
+      },
+    ],
+    functionName: 'isInitialized',
+    address: validatorAddress,
+    args: [account],
+  })
 }
 
 export { getValidators, getExecutors, getOwners, isValidatorInitialized }

--- a/src/modules/read.ts
+++ b/src/modules/read.ts
@@ -196,4 +196,36 @@ async function getExecutors(
   }
 }
 
-export { getValidators, getExecutors, getOwners }
+async function isValidatorInitialized(
+  account: Address,
+  chain: Chain,
+  validatorAddress: Address,
+  provider?: ProviderConfig,
+): Promise<boolean> {
+  const publicClient = createPublicClient({
+    chain,
+    transport: createTransport(chain, provider),
+  })
+  try {
+    return await publicClient.readContract({
+      abi: [
+        {
+          name: 'isInitialized',
+          type: 'function',
+          stateMutability: 'view',
+          inputs: [{ name: 'smartAccount', type: 'address' }],
+          outputs: [{ name: '', type: 'bool' }],
+        },
+      ],
+      functionName: 'isInitialized',
+      address: validatorAddress,
+      args: [account],
+    })
+  } catch {
+    // Treat read failures (e.g. undeployed account) as not-initialized so the
+    // common first-time enable path still produces an `onInstall` call.
+    return false
+  }
+}
+
+export { getValidators, getExecutors, getOwners, isValidatorInitialized }


### PR DESCRIPTION
v2 port of #577.

## Summary

`enable()` (ECDSA) produced an `installModule(OwnableValidator)` call. On Nexus the OwnableValidator is the **hardwired default validator**, which breaks two ways:

- It can't be added via `installModule` → reverts `DefaultValidatorAlreadyInstalled`.
- On passkey-bootstrapped accounts it's never initialized (the deploy takes the `initNexusNoRegistry` branch), so the obvious workaround `addOwner` reverts with `NotInitialized`.

Net effect: a passkey user could not add an ECDSA signer at all — the orchestrator just returned an opaque `UnclassifiedRevert` / 400.

## Fix

New chain-aware `getValidatorInstallationCalls`. When the validator being enabled is the account's Nexus default validator:

- Initialize it directly via **`onInstall(abi.encode(threshold, owners))`** instead of `installModule`.
- If it's **already enabled**, throw a clear `DefaultValidatorAlreadyInitializedError` (pointing to `addOwner`/`changeThreshold`) instead of an opaque on-chain revert. "Already enabled" = the deploy config initializes it (detected from config, so it holds for not-yet-deployed accounts too) **or** it's already initialized on-chain (covers ECDSA enabled separately after deploy).

Other account types (Safe/Kernel/Startale) and non-default validators are unchanged — they keep using `installModule`.

### Nexus version handling

The branch keys off `module.address === getDefaultValidatorAddress(account.version)` — exactly the on-chain invariant (`DefaultValidatorAlreadyInstalled` fires iff you install the address that *is* that account's default validator). `enable` always installs `OWNABLE_VALIDATOR_ADDRESS`, which is the default validator only for `undefined`/`rhinestone-1.0.0`. For `1.0.2`/`1.2.0`/`rhinestone-1.0.0-beta` the default validator is a *different* contract, so `installModule(OwnableValidator)` is a normal non-default install that does **not** revert — falling through to `installModule` is correct there (and forcing `onInstall` would wrongly initialize a validator not in the account's module list).

### Read-failure handling

`isValidatorInitialized` is a plain storage read that returns `false` for uninitialized/undeployed accounts without reverting, so real provider/ABI errors are allowed to propagate rather than being coerced to `false` (which could build an `onInstall` for an already-initialized account).

Scope is Nexus-only and default-validator-only. The generic `installModule(...)` action is intentionally left as-is.

Companion PR (v1 / `main`): #577