### PR TITLE
Sort JCS keys by Unicode code point

### DIFF
--- a/src/jwt-server/jcs.ts
+++ b/src/jwt-server/jcs.ts
@@ -58,7 +58,7 @@ function serialize(value: unknown): string {
 
   // Object — sort keys by Unicode code-point order
   const obj = value as Record<string, unknown>
-  const keys = Object.keys(obj).sort()
+  const keys = Object.keys(obj).sort(compareUnicodeCodePoints)
   const members: string[] = []
   for (const key of keys) {
     const v = obj[key]
@@ -66,4 +66,18 @@ function serialize(value: unknown): string {
     members.push(`${JSON.stringify(key)}:${serialize(v)}`)
   }
   return `{${members.join(',')}}`
+}
+
+function compareUnicodeCodePoints(a: string, b: string): number {
+  const aPoints = Array.from(a)
+  const bPoints = Array.from(b)
+  const len = Math.min(aPoints.length, bPoints.length)
+
+  for (let i = 0; i < len; i++) {
+    const aPoint = aPoints[i].codePointAt(0)!
+    const bPoint = bPoints[i].codePointAt(0)!
+    if (aPoint !== bPoint) return aPoint - bPoint
+  }
+
+  return aPoints.length - bPoints.length
 }

--- a/src/jwt-server/jwt-server.test.ts
+++ b/src/jwt-server/jwt-server.test.ts
@@ -105,6 +105,10 @@ describe('jcsCanonicalise', () => {
     expect(jcsCanonicalise({ z: 1, a: 2, m: 3 })).toBe('{"a":2,"m":3,"z":1}')
   })
 
+  it('sorts keys by Unicode code point order', () => {
+    expect(jcsCanonicalise({ '\uE000': 1, '😀': 2 })).toBe('{"":1,"😀":2}')
+  })
+
   it('sorts nested object keys', () => {
     expect(jcsCanonicalise({ b: { d: 1, c: 2 }, a: 3 })).toBe(
       '{"a":3,"b":{"c":2,"d":1}}',


### PR DESCRIPTION
JCS object keys are specified to sort by Unicode code point order. JavaScript string sorting uses UTF-16 code units, which can place keys containing non-BMP characters before lower code point BMP keys.

This adds an explicit code point comparator and covers the ordering with a regression test.