### PR TITLE
fix(startale): derive EIP-712 domain for adopted accounts

### DIFF
--- a/.changeset/startale-adopted-eip712-domain.md
+++ b/.changeset/startale-adopted-eip712-domain.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Allow Startale accounts adopted via `initData` to sign intents: `getEip712Domain` no longer throws for existing accounts and derives the domain from `getAddress(config)`.

--- a/src/accounts/startale.ts
+++ b/src/accounts/startale.ts
@@ -20,10 +20,7 @@ import type {
   RhinestoneAccountConfig,
   StartaleAccount,
 } from '../types'
-import {
-  AccountConfigurationNotSupportedError,
-  Eip712DomainNotAvailableError,
-} from './error'
+import { AccountConfigurationNotSupportedError } from './error'
 import {
   getGuardianSmartAccount as getNexusGuardianSmartAccount,
   getInstallData as getNexusInstallData,
@@ -238,11 +235,9 @@ function getAddress(config: RhinestoneAccountConfig) {
 }
 
 function getEip712Domain(config: RhinestoneAccountConfig, chain: Chain) {
-  if (config.initData) {
-    throw new Eip712DomainNotAvailableError(
-      'Existing Startale accounts are not yet supported',
-    )
-  }
+  // Works for adopted accounts too: getAddress resolves the initData cases
+  // (returns initData.address, or recomputes the CREATE2 address from
+  // initData.factory/factoryData).
   return {
     name: 'Startale',
     version: STARTALE_VERSION,


### PR DESCRIPTION
`getEip712Domain` in `src/accounts/startale.ts` threw `Existing Startale accounts are not yet supported` whenever `config.initData` was set, blocking K1-validated intent signing for Startale accounts that were deployed elsewhere (e.g. via the Startale SDK / Pimlico user-ops) and adopted into Rhinestone via `initData`.

The domain is fully derivable for these accounts — `name`/`version`/`salt` are constants and `verifyingContract` is `getAddress(config)`, which already resolves the `initData` address. This removes the throw and derives the domain in all cases.

Verified end-to-end on Base Sepolia: a vanilla Startale account adopted via `initData` now signs and executes a Rhinestone intent.

Targets `main` (v1) for now.

Closes [RHI-4564](https://linear.app/rhinestone/issue/RHI-4564)