### PR TITLE
fix(startale): skip K1 default validator in setup()

### DIFF
--- a/.changeset/startale-setup-skip-default-validator.md
+++ b/.changeset/startale-setup-skip-default-validator.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `setup()` reverting on Startale K1 accounts: skip the built-in K1 default validator so only genuinely missing modules (e.g. the intent executor) are installed.

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -7,6 +7,7 @@ import {
   type HashTypedDataParameters,
   type Hex,
   hashTypedData,
+  isAddressEqual,
   type PublicClient,
   size,
   type TypedData,
@@ -111,6 +112,7 @@ import {
   getInstallData as getStartaleInstallData,
   getSmartAccount as getStartaleSmartAccount,
   packSignature as packStartaleSignature,
+  K1_DEFAULT_VALIDATOR_ADDRESS as STARTALE_K1_VALIDATOR_ADDRESS,
 } from './startale'
 import {
   createTransport,
@@ -680,7 +682,16 @@ async function setup(config: RhinestoneConfig, chain: Chain): Promise<boolean> {
     ...modules.executors,
     ...modules.fallbacks,
     ...modules.hooks,
-  ]
+  ].filter(
+    // Startale's K1 validator is the account's built-in default validator, set
+    // at deployment — it is never a regular 7579 module, so isModuleInstalled
+    // reports false and trying to install it reverts. Skip it.
+    (module) =>
+      !(
+        account.type === 'startale' &&
+        isAddressEqual(module.address, STARTALE_K1_VALIDATOR_ADDRESS)
+      ),
+  )
   // Check if the modules are already installed
   const installedResults = await publicClient.multicall({
     contracts: allModules.map((module) => ({


### PR DESCRIPTION
For a Startale account on the K1 path (`owners.module = 0x00000072…dec7b1`), `setup()` tried to install the K1 validator as a regular 7579 module and reverted (`0xabc3af79`).

Root cause: `getSetup()` returns the owner validator in its `validators` list, and for the K1 path that's the **K1 default validator** — the account's built-in default validator set at deployment, occupying a dedicated slot. `isModuleInstalled(1, K1, …)` therefore returns `false`, so `setup()` concluded it had to install it.

Fix: when computing the install set, skip the Startale K1 default validator (scoped to `account.type === 'startale'` + the K1 address, so the Ownable-path owner validator is still installed when missing). `setup()` then installs only the genuinely missing modules — typically just the intent executor — making an adopted vanilla Startale account intent-ready.

Validated on Base Sepolia: installing only the intent executor on an existing vanilla Startale account (the exact call set this fix leaves behind) lets Rhinestone drive intents on it (together with #583).

Targets `main` (v1) for now.

Closes [RHI-4565](https://linear.app/rhinestone/issue/RHI-4565)

Related: #583