### PR TITLE
docs: improve public-API JSDoc and add SDK reference generator

### DIFF
--- a/.changeset/sdk-reference-jsdoc.md
+++ b/.changeset/sdk-reference-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Improve JSDoc across the public API (account methods, `RhinestoneSDK`, actions, and utils) for richer in-editor docs and to power the generated SDK reference.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 .env
 
 examples/
+# TypeDoc reference extraction artifact
+scripts/reference/typedoc.json.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,10 @@ Once v2 is stable, we'll switch back to the standard `main` (dev) / `release` (p
 - Public API is the union of `src/index.ts` re-exports and the subpath exports in `src/package.json` (`/actions`, `/errors`, `/jwt-server`, `/smart-sessions`, etc.) — adding, renaming, or removing exports is a breaking change
 - The project uses `changeset` to manage releases. Create a changeset file for each fix or feature, and use the `sdk-changesets` skill when adding, editing, or reviewing SDK changelog wording.
 
+## SDK reference docs
+
+The public docs site's "SDK Reference" is generated from this repo's JSDoc (`scripts/reference/`, run with `bun run reference`; see `scripts/reference/README.md`). When you add, rename, or remove a public export, or change its JSDoc, regenerate with the `docs` repo checked out as a sibling and commit the updated `docs/sdk-reference` output — Mintlify builds from committed content. The generator warns about public exports (in already-documented modules) that are missing from `scripts/reference/manifest.ts`; add new symbols there (the mapping is curated, not automatic).
+
 ## Testing
 
 - Run single test: `bun run test -- path/to/file.test.ts`

--- a/bun.lock
+++ b/bun.lock
@@ -19,13 +19,14 @@
         "ts-node": "^10.9.2",
         "tsc-alias": "^1.8.13",
         "tsc-esm-fix": "^3.1.2",
+        "typedoc": "^0.28.19",
         "typescript": "^5.8.2",
         "vitest": "^3.1.2",
       },
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "2.0.0-beta.19",
+      "version": "2.0.0-beta.28",
       "dependencies": {
         "@rhinestone/shared-configs": "1.6.7",
         "solady": "^0.1.26",
@@ -150,6 +151,8 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.2", "", { "os": "win32", "cpu": "x64" }, "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="],
 
+    "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
+
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
@@ -224,6 +227,16 @@
 
     "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@size-limit/esbuild": ["@size-limit/esbuild@11.2.0", "", { "dependencies": { "esbuild": "^0.25.0", "nanoid": "^5.1.0" }, "peerDependencies": { "size-limit": "11.2.0" } }, "sha512-vSg9H0WxGQPRzDnBzeDyD9XT0Zdq0L+AI3+77/JhxznbSCMJMMr8ndaWVQRhOsixl97N0oD4pRFw2+R1Lcvi6A=="],
 
     "@size-limit/esbuild-why": ["@size-limit/esbuild-why@11.2.0", "", { "dependencies": { "esbuild-visualizer": "^0.7.0", "open": "^10.1.0" }, "peerDependencies": { "size-limit": "11.2.0" } }, "sha512-VtoQbbkvFbF314LWEaEp1+IjG0DH+9w6nP//D6Gd48SEAPLoBgqk287mjYTF9WYxg9N5lo8KjpXxEFk4gOXNpw=="],
@@ -246,7 +259,11 @@
 
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/node": ["@types/node@22.14.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -280,19 +297,19 @@
 
     "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
-    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -349,6 +366,8 @@
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
@@ -440,6 +459,8 @@
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
+    "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
+
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
@@ -448,15 +469,21 @@
 
     "lru-cache": ["lru-cache@11.1.0", "", {}, "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="],
 
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
+
+    "markdown-it": ["markdown-it@14.2.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
@@ -517,6 +544,8 @@
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "quansync": ["quansync@0.2.10", "", {}, "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A=="],
 
@@ -608,7 +637,11 @@
 
     "type-flag": ["type-flag@3.0.0", "", {}, "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA=="],
 
+    "typedoc": ["typedoc@0.28.19", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.23.0", "lunr": "^2.3.9", "markdown-it": "^14.1.1", "minimatch": "^10.2.5", "yaml": "^2.8.3" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw=="],
+
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -636,6 +669,8 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
@@ -660,7 +695,11 @@
 
     "esbuild-visualizer/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "glob/minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
+
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -686,6 +725,8 @@
 
     "esbuild-visualizer/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
     "tsc-alias/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "tsc-esm-fix/fs-extra/jsonfile": ["jsonfile@6.1.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ=="],
@@ -693,6 +734,8 @@
     "tsc-esm-fix/fs-extra/universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "vitest/tinyglobby/fdir": ["fdir@6.4.4", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "tsc-alias/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "check": "biome check",
     "typecheck": "tsc --noEmit",
     "test:types": "tsc --noEmit -p tsconfig.type-tests.json",
+    "reference:extract": "typedoc --options scripts/reference/typedoc.json",
+    "reference:generate": "bun run scripts/reference/generate.ts",
+    "reference": "bun run reference:extract && bun run reference:generate",
     "changeset": "changeset",
     "changeset:release": "bun run build && changeset publish",
     "changeset:version": "changeset version && bun run scripts/sync-version.ts",
@@ -34,6 +37,7 @@
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.13",
     "tsc-esm-fix": "^3.1.2",
+    "typedoc": "^0.28.19",
     "typescript": "^5.8.2",
     "vitest": "^3.1.2"
   }

--- a/scripts/reference/README.md
+++ b/scripts/reference/README.md
@@ -1,0 +1,47 @@
+# SDK reference generation
+
+Generates the Mintlify "SDK Reference" tab in the [docs repo](../../../docs) from
+the SDK's JSDoc.
+
+## How it works
+
+1. `typedoc --json` (config: `typedoc.json`) extracts a structured model of the
+   public API into `typedoc.json.out` (a gitignored build artifact).
+2. `generate.ts` walks the curated `manifest.ts`, looks up each symbol in that
+   model, and renders one MDX page per symbol against a fixed template
+   (Import / Usage / Parameters / Returns / See also). It then patches the
+   `SDK Reference` tab into `docs/docs.json`.
+
+```
+bun run reference            # extract + generate (run from the sdk repo root)
+bun run reference:extract    # typedoc JSON only
+bun run reference:generate   # render MDX from existing JSON
+```
+
+Output paths default to the sibling `docs` repo and can be overridden:
+
+- `SDK_REF_OUT` — output dir (default `../../docs/sdk-reference`)
+- `SDK_REF_DOCS_JSON` — docs.json to patch (default `../../docs/docs.json`)
+
+## Scope
+
+Hot path only: entry points, the account instance, actions, and utils. Types,
+errors, jwt-server, and the standalone `/smart-sessions` module are out of scope.
+Edit `manifest.ts` to change what is documented and how it is grouped.
+
+## Content sources
+
+- **Prose, params, returns** come from JSDoc on the exported symbol. For account
+  instance methods, the canonical JSDoc lives on the `RhinestoneAccount`
+  interface members (that is what TypeDoc reads), not the inner implementations.
+- **Code samples** come from `@example` blocks in the JSDoc. Without one, a
+  minimal usage snippet is synthesized from the signature.
+- **`@remarks`** renders as a `<Note>`; experimental entries get a `<Warning>`.
+- **Hand-written pages** listed in `MANUAL_PAGES` (e.g. `introduction.mdx`)
+  survive regeneration.
+
+## Note for maintainers
+
+The generated MDX is committed to the docs repo — Mintlify builds from repo
+content, so the pages must be present in git. Re-run `bun run reference` and
+commit the result whenever the public API or its JSDoc changes.

--- a/scripts/reference/generate.ts
+++ b/scripts/reference/generate.ts
@@ -71,16 +71,42 @@ function resolveNode(entry: SymbolEntry): TDNode | undefined {
   return (mod.children ?? []).find((c: TDNode) => c.name === entry.symbol)
 }
 
-function signatureOf(node: TDNode, entry: SymbolEntry): TDNode | undefined {
-  if (!node) return undefined
+// All call signatures for a symbol (an overloaded method has more than one).
+function signaturesOf(node: TDNode, entry: SymbolEntry): TDNode[] {
+  if (!node) return []
   if (entry.callStyle === 'constructor') {
     const ctor =
       node.kind === 512
         ? node
         : (node.children ?? []).find((c: TDNode) => c.kind === 512)
-    return ctor?.signatures?.[0]
+    return ctor?.signatures ?? []
   }
-  return node.signatures?.[0]
+  return node.signatures ?? []
+}
+
+// Merge parameters across overloads: union the types per parameter name, keep
+// the first description, and treat a param as required unless optional everywhere.
+function mergeParameters(sigs: TDNode[]): TDNode[] {
+  const byName = new Map<string, TDNode>()
+  for (const sig of sigs) {
+    for (const p of sig.parameters ?? []) {
+      const existing = byName.get(p.name)
+      if (!existing) {
+        byName.set(p.name, {
+          name: p.name,
+          types: [typeToString(p.type)],
+          optional: !!p.flags?.isOptional,
+          comment: p.comment,
+        })
+      } else {
+        const t = typeToString(p.type)
+        if (!existing.types.includes(t)) existing.types.push(t)
+        existing.optional = existing.optional && !!p.flags?.isOptional
+        existing.comment = existing.comment ?? p.comment
+      }
+    }
+  }
+  return [...byName.values()]
 }
 
 // The class-level comment lives on the class node, not its constructor.
@@ -293,17 +319,20 @@ function importLine(entry: SymbolEntry): string {
 }
 
 function usageSnippet(entry: SymbolEntry, sig: TDNode | undefined): string {
-  const params = (sig?.parameters ?? [])
+  const paramNames = (sig?.parameters ?? [])
     .filter((p: TDNode) => !p.flags?.isOptional)
     .map((p: TDNode) => p.name)
-    .join(', ')
+  const params = paramNames.join(', ')
   const isPromise =
     sig?.type?.type === 'reference' && sig.type.name === 'Promise'
   const awaitKw = isPromise ? 'await ' : ''
   const ret = isPromise ? sig.type.typeArguments?.[0] : sig?.type
+  // Avoid shadowing a parameter with the return variable (TDZ / invalid example).
+  let varName = returnFieldName(entry)
+  if (paramNames.includes(varName)) varName = 'result'
   const assign =
     ret && !(ret.type === 'intrinsic' && ret.name === 'void')
-      ? `const ${returnFieldName(entry)} = `
+      ? `const ${varName} = `
       : ''
   switch (entry.callStyle) {
     case 'accountMethod':
@@ -342,11 +371,13 @@ function instanceNote(entry: SymbolEntry): string | undefined {
 
 function renderPage(entry: SymbolEntry): string | null {
   const node = resolveNode(entry)
-  const sig = signatureOf(node, entry)
   if (!node) {
     console.error(`! could not resolve ${entry.source}#${entry.symbol}`)
     return null
   }
+  const sigs = signaturesOf(node, entry)
+  // Prefer the signature carrying the JSDoc for prose/usage; overloads merge below.
+  const sig = sigs.find((s: TDNode) => s.comment) ?? sigs[0]
   const isCtor = entry.callStyle === 'constructor'
   const sigComment = sig?.comment
   // For a constructor page, the page-level prose lives on the class comment;
@@ -425,16 +456,16 @@ function renderPage(entry: SymbolEntry): string | null {
     out.push('')
   }
 
-  // Parameters.
-  const params = sig?.parameters ?? []
+  // Parameters (merged across overloads).
+  const params = mergeParameters(sigs)
   if (params.length) {
     out.push('## Parameters')
     out.push('')
     for (const p of params) {
-      const required = p.flags?.isOptional ? '' : ' required'
+      const required = p.optional ? '' : ' required'
       const desc = renderParts(p.comment?.summary)
       out.push(
-        `<ParamField path="${p.name}" type="${escapeAttr(typeToString(p.type))}"${required}>`,
+        `<ParamField path="${p.name}" type="${escapeAttr(p.types.join(' | '))}"${required}>`,
       )
       if (desc) out.push(`  ${desc}`)
       out.push('</ParamField>')
@@ -442,8 +473,9 @@ function renderPage(entry: SymbolEntry): string | null {
     }
   }
 
-  // Returns (omitted for constructors).
-  const retType = sig?.type
+  // Returns (omitted for constructors). Union return types across overloads.
+  const retTypes = sigs.map((s: TDNode) => s.type).filter(Boolean)
+  const retType = retTypes[0]
   const isVoid = retType?.type === 'intrinsic' && retType.name === 'void'
   if (retType && !isVoid && !isCtor) {
     out.push('## Returns')
@@ -451,7 +483,10 @@ function renderPage(entry: SymbolEntry): string | null {
     const retDesc = renderParts(blockTag(sigComment, '@returns')[0]?.content)
     // Unwrap Promise<T> so an object-literal return expands into per-field rows.
     const unwrapped = unwrapPromise(retType)
-    const fields = objectFields(unwrapped)
+    const unionType = [
+      ...new Set(retTypes.map((t: TDNode) => typeToString(unwrapPromise(t)))),
+    ].join(' | ')
+    const fields = retTypes.length === 1 ? objectFields(unwrapped) : undefined
     if (fields) {
       if (retDesc) {
         out.push(retDesc)
@@ -467,7 +502,7 @@ function renderPage(entry: SymbolEntry): string | null {
       }
     } else {
       out.push(
-        `<ResponseField name="${returnFieldName(entry)}" type="${escapeAttr(typeToString(unwrapped))}">`,
+        `<ResponseField name="${returnFieldName(entry)}" type="${escapeAttr(unionType)}">`,
       )
       if (retDesc) out.push(`  ${retDesc}`)
       out.push('</ResponseField>')

--- a/scripts/reference/generate.ts
+++ b/scripts/reference/generate.ts
@@ -329,7 +329,12 @@ function usageSnippet(entry: SymbolEntry, sig: TDNode | undefined): string {
   const ret = isPromise ? sig.type.typeArguments?.[0] : sig?.type
   // Avoid shadowing a parameter with the return variable (TDZ / invalid example).
   let varName = returnFieldName(entry)
-  if (paramNames.includes(varName)) varName = 'result'
+  if (paramNames.includes(varName)) {
+    varName =
+      ['result', 'output', 'value', 'res'].find(
+        (c) => !paramNames.includes(c),
+      ) ?? `${varName}_`
+  }
   const assign =
     ret && !(ret.type === 'intrinsic' && ret.name === 'void')
       ? `const ${varName} = `

--- a/scripts/reference/generate.ts
+++ b/scripts/reference/generate.ts
@@ -346,15 +346,22 @@ function usageSnippet(entry: SymbolEntry, sig: TDNode | undefined): string {
       return `${assign}${awaitKw}sdk.${entry.symbol}(${params})`
     case 'constructor':
       return `const sdk = new ${entry.symbol}({\n  // ...config\n})`
-    case 'action':
-      // Actions return calls; the realistic usage is passing them to
-      // prepareTransaction (or sendUserOperation) on an account instance.
+    case 'action': {
+      // Actions produce calls passed to prepareTransaction on an account.
+      // Some return a single call, others a Promise of a calls array — shape
+      // the snippet accordingly so it stays valid.
+      const retT = sig?.type
+      const isProm = retT?.type === 'reference' && retT.name === 'Promise'
+      const inner = isProm ? retT.typeArguments?.[0] : retT
+      const call = `${isProm ? 'await ' : ''}${entry.symbol}(${params})`
+      const calls = inner?.type === 'array' ? call : `[${call}]`
       return [
         `const transaction = await account.prepareTransaction({`,
         `  chain,`,
-        `  calls: [${entry.symbol}(${params})],`,
+        `  calls: ${calls},`,
         `})`,
       ].join('\n')
+    }
     default:
       return `${assign}${awaitKw}${entry.symbol}(${params})`
   }

--- a/scripts/reference/generate.ts
+++ b/scripts/reference/generate.ts
@@ -535,7 +535,12 @@ function build(nodes: Node[], trail: string[]): (string | NavGroup)[] {
       const page = pagePath(node, trail)
       const mdx = renderPage(node)
       if (!mdx) continue
-      const file = join(OUT_DIR, '..', `${page}.mdx`)
+      // `page` is doc-root-relative (starts with NAV_BASE); strip that prefix so
+      // files land inside OUT_DIR — the same dir cleanGenerated wipes.
+      const rel = page.startsWith(`${NAV_BASE}/`)
+        ? page.slice(NAV_BASE.length + 1)
+        : page
+      const file = join(OUT_DIR, `${rel}.mdx`)
       mkdirSync(dirname(file), { recursive: true })
       writeFileSync(file, mdx)
       pages.push(page)

--- a/scripts/reference/generate.ts
+++ b/scripts/reference/generate.ts
@@ -1,0 +1,685 @@
+// Generates Mintlify MDX reference pages for the public SDK surface.
+//
+// Pipeline: `typedoc --json` emits a structured model of the public API; this
+// script walks the curated manifest, looks up each symbol in that model, and
+// renders one MDX page per symbol against a fixed viem-style template
+// (Import / Usage / Parameters / Returns), then patches the "SDK Reference"
+// tab into the docs repo's docs.json.
+//
+// Run: bun run scripts/reference/generate.ts
+// Output dir: $SDK_REF_OUT (default: ../../../docs/sdk-reference)
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { manifest, type Node, type SymbolEntry } from './manifest'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const TYPEDOC_JSON = join(HERE, 'typedoc.json.out')
+const OUT_DIR =
+  process.env.SDK_REF_OUT ?? resolve(HERE, '../../../docs/sdk-reference')
+const NAV_BASE = 'sdk-reference'
+
+// ---------------------------------------------------------------------------
+// TypeDoc JSON traversal
+// ---------------------------------------------------------------------------
+
+type TDNode = any
+
+const project = JSON.parse(readFileSync(TYPEDOC_JSON, 'utf8'))
+
+function moduleName(source: string): string {
+  return source === '.' ? 'index' : source.replace(/^\.\//, '')
+}
+
+function importSubpath(source: string): string {
+  return source === '.' ? '' : source.replace(/^\./, '')
+}
+
+function findModule(source: string): TDNode | undefined {
+  const name = moduleName(source)
+  return (project.children ?? []).find((c: TDNode) => c.name === name)
+}
+
+function resolveNode(entry: SymbolEntry): TDNode | undefined {
+  const mod = findModule(entry.source)
+  if (!mod) return undefined
+  if (entry.container) {
+    const parent = (mod.children ?? []).find(
+      (c: TDNode) => c.name === entry.container,
+    )
+    if (!parent) return undefined
+    if (entry.callStyle === 'constructor') {
+      return (parent.children ?? []).find((c: TDNode) => c.kind === 512)
+    }
+    return (parent.children ?? []).find((c: TDNode) => c.name === entry.symbol)
+  }
+  if (entry.callStyle === 'constructor') {
+    // Class symbol: render its constructor.
+    const cls = (mod.children ?? []).find(
+      (c: TDNode) => c.name === entry.symbol,
+    )
+    return cls
+  }
+  return (mod.children ?? []).find((c: TDNode) => c.name === entry.symbol)
+}
+
+function signatureOf(node: TDNode, entry: SymbolEntry): TDNode | undefined {
+  if (!node) return undefined
+  if (entry.callStyle === 'constructor') {
+    const ctor =
+      node.kind === 512
+        ? node
+        : (node.children ?? []).find((c: TDNode) => c.kind === 512)
+    return ctor?.signatures?.[0]
+  }
+  return node.signatures?.[0]
+}
+
+// The class-level comment lives on the class node, not its constructor.
+function classComment(entry: SymbolEntry): TDNode | undefined {
+  if (entry.callStyle !== 'constructor') return undefined
+  const mod = findModule(entry.source)
+  const cls = (mod?.children ?? []).find((c: TDNode) => c.name === entry.symbol)
+  return cls?.comment
+}
+
+// ---------------------------------------------------------------------------
+// Type rendering (types are out of scope as pages — render as plain names)
+// ---------------------------------------------------------------------------
+
+function typeToString(t: TDNode | undefined): string {
+  if (!t) return 'unknown'
+  switch (t.type) {
+    case 'intrinsic':
+      return t.name
+    case 'literal':
+      return typeof t.value === 'string' ? `'${t.value}'` : String(t.value)
+    case 'reference': {
+      // Drop type arguments when they expand to something huge (e.g. viem's
+      // TypedDataDefinition) — the bare name is far more readable.
+      const inner = (t.typeArguments ?? []).map(typeToString).join(', ')
+      const args = inner && inner.length <= 40 ? `<${inner}>` : ''
+      return `${t.name}${args}`
+    }
+    case 'array':
+      return `${typeToString(t.elementType)}[]`
+    case 'union':
+      return t.types.map(typeToString).join(' | ')
+    case 'intersection':
+      return t.types.map(typeToString).join(' & ')
+    case 'tuple':
+      return `[${(t.elements ?? []).map(typeToString).join(', ')}]`
+    case 'reflection': {
+      const d = t.declaration
+      if (d?.signatures?.length) {
+        const sig = d.signatures[0]
+        const params = (sig.parameters ?? [])
+          .map((p: TDNode) => `${p.name}: ${typeToString(p.type)}`)
+          .join(', ')
+        return `(${params}) => ${typeToString(sig.type)}`
+      }
+      if (d?.children?.length) {
+        const fields = d.children
+          .map((c: TDNode) => `${c.name}: ${typeToString(c.type)}`)
+          .join('; ')
+        return fields.length <= 80 ? `{ ${fields} }` : 'object'
+      }
+      return '{}'
+    }
+    case 'indexedAccess':
+      return `${typeToString(t.objectType)}[${typeToString(t.indexType)}]`
+    case 'typeOperator':
+      return `${t.operator} ${typeToString(t.target)}`
+    case 'query':
+      return `typeof ${typeToString(t.queryType)}`
+    case 'templateLiteral': {
+      const tail = (t.tail ?? [])
+        .map(
+          ([type, lit]: [TDNode, string]) => `\${${typeToString(type)}}${lit}`,
+        )
+        .join('')
+      return `\`${t.head}${tail}\``
+    }
+    case 'named-tuple-member':
+      return `${t.name}: ${typeToString(t.element)}`
+    case 'optional':
+      return `${typeToString(t.elementType)}?`
+    case 'rest':
+      return `...${typeToString(t.elementType)}`
+    case 'conditional':
+    case 'mapped':
+      return t.name ?? 'object'
+    default:
+      return t.name ?? 'unknown'
+  }
+}
+
+function unwrapPromise(t: TDNode | undefined): TDNode | undefined {
+  if (t?.type === 'reference' && t.name === 'Promise') {
+    return t.typeArguments?.[0] ?? t
+  }
+  return t
+}
+
+// Names for the single return value, where the verb-stripped default is wrong.
+const RETURN_NAME_OVERRIDES: Record<string, string> = {
+  signMessage: 'signature',
+  signTypedData: 'signature',
+  signEip7702InitData: 'signature',
+  experimental_signEnableSession: 'signature',
+  signIntent: 'signatures',
+  waitForExecution: 'result',
+  deploy: 'success',
+  setup: 'success',
+  toViewOnlyAccount: 'account',
+}
+
+const RETURN_VERBS =
+  /^(get|set|is|has|sign|prepare|submit|send|create|wait|split|deploy|setup|check|to|enable|disable|add|remove|change|recover|install|uninstall)/
+
+// A meaningful name for the returned value (e.g. getAddress -> "address"),
+// used for both the ResponseField name and the usage snippet's variable.
+function returnFieldName(entry: SymbolEntry): string {
+  if (entry.callStyle === 'action') return 'call'
+  if (RETURN_NAME_OVERRIDES[entry.symbol]) {
+    return RETURN_NAME_OVERRIDES[entry.symbol]
+  }
+  const base = entry.symbol.replace(/^experimental_/, '')
+  const m = base.match(RETURN_VERBS)
+  if (m) {
+    const rest = base.slice(m[0].length)
+    if (rest) return rest.charAt(0).toLowerCase() + rest.slice(1)
+  }
+  return 'result'
+}
+
+// Split a rendered summary into a one-line description (first paragraph) and an
+// optional extended explainer (the remaining paragraphs).
+function splitSummary(summary: string): { short: string; rest: string } {
+  const paras = summary.split(/\n\s*\n/)
+  return {
+    short: oneLine(paras[0] ?? ''),
+    rest: paras.slice(1).join('\n\n').trim(),
+  }
+}
+
+// Returns the properties of an object-literal type, or undefined if the type is
+// not a plain object literal (named types and unions are left as a single row).
+function objectFields(t: TDNode | undefined): TDNode[] | undefined {
+  if (
+    t?.type === 'reflection' &&
+    t.declaration?.children?.length &&
+    !t.declaration.signatures?.length
+  ) {
+    return t.declaration.children
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Comment / doc-comment rendering
+// ---------------------------------------------------------------------------
+
+// Map of bare symbol name -> page path, for {@link} and @see resolution.
+// Names that collide across subpaths are dropped (rendered as inline code).
+const nameToPage = buildNameToPage()
+
+function buildNameToPage(): Map<string, string | null> {
+  const map = new Map<string, string | null>()
+  const walk = (nodes: Node[], trail: string[]) => {
+    for (const node of nodes) {
+      if (node.kind === 'group') {
+        walk(node.items, [...trail, slug(node.group)])
+      } else {
+        const page = pagePath(node, trail)
+        const name = node.symbol
+        map.set(name, map.has(name) ? null : page)
+      }
+    }
+  }
+  walk(manifest, [NAV_BASE])
+  return map
+}
+
+function renderParts(parts: TDNode[] | undefined): string {
+  if (!parts) return ''
+  return parts
+    .map((p) => {
+      if (p.kind === 'inline-tag' && p.tag === '@link') {
+        const label = p.text?.trim() ?? ''
+        const target = label.replace(/\(\)$/, '')
+        const page = nameToPage.get(target)
+        return page ? `[${label}](/${page})` : `\`${label}\``
+      }
+      return p.text ?? ''
+    })
+    .join('')
+    .trim()
+}
+
+function blockTag(comment: TDNode | undefined, tag: string): TDNode[] {
+  return (comment?.blockTags ?? []).filter((t: TDNode) => t.tag === tag)
+}
+
+// ---------------------------------------------------------------------------
+// Page rendering
+// ---------------------------------------------------------------------------
+
+function slug(name: string): string {
+  return name
+    .replace(/_/g, '-')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .toLowerCase()
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+function pagePath(entry: SymbolEntry, trail: string[]): string {
+  return [...trail, slug(entry.title ?? entry.symbol)].join('/')
+}
+
+function importLine(entry: SymbolEntry): string {
+  const name = entry.callStyle === 'constructor' ? entry.symbol : entry.symbol
+  return `import { ${name} } from '@rhinestone/sdk${importSubpath(entry.source)}'`
+}
+
+function usageSnippet(entry: SymbolEntry, sig: TDNode | undefined): string {
+  const params = (sig?.parameters ?? [])
+    .filter((p: TDNode) => !p.flags?.isOptional)
+    .map((p: TDNode) => p.name)
+    .join(', ')
+  const isPromise =
+    sig?.type?.type === 'reference' && sig.type.name === 'Promise'
+  const awaitKw = isPromise ? 'await ' : ''
+  const ret = isPromise ? sig.type.typeArguments?.[0] : sig?.type
+  const assign =
+    ret && !(ret.type === 'intrinsic' && ret.name === 'void')
+      ? `const ${returnFieldName(entry)} = `
+      : ''
+  switch (entry.callStyle) {
+    case 'accountMethod':
+      return `${assign}${awaitKw}account.${entry.symbol}(${params})`
+    case 'sdkMethod':
+      return `${assign}${awaitKw}sdk.${entry.symbol}(${params})`
+    case 'constructor':
+      return `const sdk = new ${entry.symbol}({\n  // ...config\n})`
+    case 'action':
+      // Actions return calls; the realistic usage is passing them to
+      // prepareTransaction (or sendUserOperation) on an account instance.
+      return [
+        `const transaction = await account.prepareTransaction({`,
+        `  chain,`,
+        `  calls: [${entry.symbol}(${params})],`,
+        `})`,
+      ].join('\n')
+    default:
+      return `${assign}${awaitKw}${entry.symbol}(${params})`
+  }
+}
+
+function instanceNote(entry: SymbolEntry): string | undefined {
+  if (entry.callStyle === 'accountMethod') {
+    const page = nameToPage.get('createAccount')
+    const link = page ? `[\`createAccount\`](/${page})` : '`createAccount`'
+    return `Method on an account instance returned by ${link}.`
+  }
+  if (entry.callStyle === 'sdkMethod') {
+    const page = nameToPage.get('RhinestoneSDK')
+    const link = page ? `[\`RhinestoneSDK\`](/${page})` : '`RhinestoneSDK`'
+    return `Method on a ${link} instance.`
+  }
+  return undefined
+}
+
+function renderPage(entry: SymbolEntry): string | null {
+  const node = resolveNode(entry)
+  const sig = signatureOf(node, entry)
+  if (!node) {
+    console.error(`! could not resolve ${entry.source}#${entry.symbol}`)
+    return null
+  }
+  const isCtor = entry.callStyle === 'constructor'
+  const sigComment = sig?.comment
+  // For a constructor page, the page-level prose lives on the class comment;
+  // params/returns come from the constructor signature.
+  const docComment = isCtor
+    ? (classComment(entry) ?? sigComment)
+    : (sigComment ?? node.comment)
+  const comment = docComment
+  const title = entry.title ?? entry.symbol
+  const { short, rest } = splitSummary(renderParts(comment?.summary))
+
+  const out: string[] = []
+  out.push('---')
+  out.push(`title: ${yaml(title)}`)
+  if (short) out.push(`description: ${yaml(stripMd(short))}`)
+  out.push('---')
+  out.push('')
+
+  if (entry.experimental) {
+    out.push(
+      '<Warning>This API is experimental and may change in a future release.</Warning>',
+    )
+    out.push('')
+  }
+
+  // The one-line summary is rendered by Mintlify from the frontmatter
+  // `description`; only the extended explainer (if any) goes in the body.
+  if (rest) {
+    out.push(rest)
+    out.push('')
+  }
+
+  for (const r of blockTag(comment, '@remarks')) {
+    out.push(`<Note>${oneLine(renderParts(r.content))}</Note>`)
+    out.push('')
+  }
+
+  const note = instanceNote(entry)
+  if (note) {
+    out.push(note)
+    out.push('')
+  }
+
+  // Import (only for directly-importable symbols).
+  if (
+    entry.callStyle === 'function' ||
+    entry.callStyle === 'action' ||
+    entry.callStyle === 'constructor'
+  ) {
+    out.push('## Import')
+    out.push('')
+    out.push('```ts')
+    out.push(importLine(entry))
+    out.push('```')
+    out.push('')
+  }
+
+  // Usage: prefer authored @example blocks, else a synthesized snippet.
+  const examples = [
+    ...blockTag(docComment, '@example'),
+    ...(sigComment && sigComment !== docComment
+      ? blockTag(sigComment, '@example')
+      : []),
+  ]
+  out.push('## Usage')
+  out.push('')
+  if (examples.length) {
+    for (const ex of examples) {
+      out.push(renderParts(ex.content))
+      out.push('')
+    }
+  } else {
+    out.push('```ts')
+    out.push(usageSnippet(entry, sig))
+    out.push('```')
+    out.push('')
+  }
+
+  // Parameters.
+  const params = sig?.parameters ?? []
+  if (params.length) {
+    out.push('## Parameters')
+    out.push('')
+    for (const p of params) {
+      const required = p.flags?.isOptional ? '' : ' required'
+      const desc = renderParts(p.comment?.summary)
+      out.push(
+        `<ParamField path="${p.name}" type="${escapeAttr(typeToString(p.type))}"${required}>`,
+      )
+      if (desc) out.push(`  ${desc}`)
+      out.push('</ParamField>')
+      out.push('')
+    }
+  }
+
+  // Returns (omitted for constructors).
+  const retType = sig?.type
+  const isVoid = retType?.type === 'intrinsic' && retType.name === 'void'
+  if (retType && !isVoid && !isCtor) {
+    out.push('## Returns')
+    out.push('')
+    const retDesc = renderParts(blockTag(sigComment, '@returns')[0]?.content)
+    // Unwrap Promise<T> so an object-literal return expands into per-field rows.
+    const unwrapped = unwrapPromise(retType)
+    const fields = objectFields(unwrapped)
+    if (fields) {
+      if (retDesc) {
+        out.push(retDesc)
+        out.push('')
+      }
+      for (const f of fields) {
+        const optional = f.flags?.isOptional ? '' : ' required'
+        out.push(
+          `<ResponseField name="${f.name}" type="${escapeAttr(typeToString(f.type))}"${optional}>`,
+        )
+        out.push('</ResponseField>')
+        out.push('')
+      }
+    } else {
+      out.push(
+        `<ResponseField name="${returnFieldName(entry)}" type="${escapeAttr(typeToString(unwrapped))}">`,
+      )
+      if (retDesc) out.push(`  ${retDesc}`)
+      out.push('</ResponseField>')
+      out.push('')
+    }
+  }
+
+  // See also. TypeDoc merges consecutive @see tags into one blockTag whose
+  // content already carries `-` bullets, so normalize rather than re-bullet.
+  const sees = blockTag(sigComment ?? docComment, '@see')
+  if (sees.length) {
+    out.push('## See also')
+    out.push('')
+    for (const s of sees) {
+      for (const line of renderParts(s.content).split('\n')) {
+        const t = line.trim().replace(/^-\s*/, '')
+        if (t) out.push(`- ${t}`)
+      }
+    }
+    out.push('')
+  }
+
+  return `${out
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd()}\n`
+}
+
+function oneLine(s: string): string {
+  return s.replace(/\s*\n\s*/g, ' ').trim()
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, "'")
+}
+
+// Quote a value for YAML frontmatter (descriptions may contain `:` etc.).
+function yaml(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+// Strip markdown links/code from a string destined for frontmatter prose.
+function stripMd(s: string): string {
+  return s.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1').replace(/`/g, '')
+}
+
+// ---------------------------------------------------------------------------
+// Walk manifest: assign page paths, render, collect nav
+// ---------------------------------------------------------------------------
+
+type NavGroup = { group: string; pages: (string | NavGroup)[] }
+
+function build(nodes: Node[], trail: string[]): (string | NavGroup)[] {
+  const pages: (string | NavGroup)[] = []
+  for (const node of nodes) {
+    if (node.kind === 'group') {
+      const nav: NavGroup = {
+        group: node.group,
+        pages: build(node.items, [...trail, slug(node.group)]),
+      }
+      // Drop groups whose symbols all failed to resolve (e.g. after a symbol is
+      // removed from the SDK but not yet from the manifest).
+      if (nav.pages.length) pages.push(nav)
+    } else {
+      const page = pagePath(node, trail)
+      const mdx = renderPage(node)
+      if (!mdx) continue
+      const file = join(OUT_DIR, '..', `${page}.mdx`)
+      mkdirSync(dirname(file), { recursive: true })
+      writeFileSync(file, mdx)
+      pages.push(page)
+    }
+  }
+  return pages
+}
+
+// The reference is nested as a single collapsible group at the bottom of the
+// host tab's pages, rather than its own top-level tab.
+const SECTION_NAME = 'SDK Reference'
+const HOST_TAB = process.env.SDK_REF_TAB ?? 'Wallet'
+const DOCS_JSON =
+  process.env.SDK_REF_DOCS_JSON ?? resolve(HERE, '../../../docs/docs.json')
+
+function patchDocsJson(pages: (string | NavGroup)[]) {
+  if (!existsSync(DOCS_JSON)) {
+    console.error(`! docs.json not found at ${DOCS_JSON}; skipping nav patch`)
+    return
+  }
+  const docs = JSON.parse(readFileSync(DOCS_JSON, 'utf8'))
+  const tabs = docs.navigation?.tabs
+  if (!Array.isArray(tabs)) {
+    console.error('! docs.json has no navigation.tabs; skipping nav patch')
+    return
+  }
+  // Drop any standalone "SDK Reference" tab from earlier runs.
+  const stale = tabs.findIndex((t: any) => t.tab === SECTION_NAME)
+  if (stale >= 0) tabs.splice(stale, 1)
+
+  const host = tabs.find((t: any) => t.tab === HOST_TAB)
+  if (!host || !Array.isArray(host.pages)) {
+    console.error(
+      `! "${HOST_TAB}" tab (with a pages array) not found; skipping nav patch`,
+    )
+    return
+  }
+  const section: NavGroup = { group: SECTION_NAME, pages }
+  const existing = host.pages.findIndex(
+    (p: any) => typeof p === 'object' && p.group === SECTION_NAME,
+  )
+  if (existing >= 0) {
+    host.pages[existing] = section
+  } else {
+    host.pages.push(section)
+  }
+  writeFileSync(DOCS_JSON, `${JSON.stringify(docs, null, 2)}\n`)
+  console.info(`Patched "${SECTION_NAME}" group into "${HOST_TAB}" tab`)
+}
+
+// Hand-written pages that live alongside the generated ones and must survive
+// regeneration (the manual-content channel). Empty for now.
+const MANUAL_PAGES: string[] = []
+
+function cleanGenerated() {
+  if (!existsSync(OUT_DIR)) {
+    mkdirSync(OUT_DIR, { recursive: true })
+    return
+  }
+  // Remove every generated subtree but keep hand-written top-level pages.
+  for (const entry of readdirSync(OUT_DIR, { withFileTypes: true })) {
+    if (entry.isFile() && MANUAL_PAGES.includes(entry.name)) continue
+    rmSync(join(OUT_DIR, entry.name), { recursive: true, force: true })
+  }
+}
+
+// Public value exports we have intentionally left undocumented. The coverage
+// check below treats these as expected, so it only warns about genuinely new
+// or forgotten exports. Listed here (rather than silently skipped) so the
+// deliberate exclusions stay visible.
+const UNDOCUMENTED_OK = new Set<string>([
+  'createRhinestoneAccount', // superseded by RhinestoneSDK in the reference
+  'experimental_getModuleSetup', // advanced/internal
+  'walletClientToAccount', // adapter, deferred
+  'wrapParaAccount', // adapter, deferred
+])
+
+// Warn about function/class/method exports that live in modules the manifest
+// already documents, but are themselves missing from it. Scoped this way so
+// out-of-scope modules (jwt-server, errors, types, the standalone
+// /smart-sessions module) are never flagged.
+function warnMissingCoverage() {
+  const documented = new Set(nameToPage.keys())
+  const containers = new Set<string>()
+  const modules = new Set<string>()
+  const walk = (nodes: Node[]) => {
+    for (const n of nodes) {
+      if (n.kind === 'group') walk(n.items)
+      else {
+        modules.add(moduleName(n.source))
+        if (n.container) containers.add(n.container)
+      }
+    }
+  }
+  walk(manifest)
+
+  const missing: string[] = []
+  const consider = (mod: string, name: string) => {
+    if (!documented.has(name) && !UNDOCUMENTED_OK.has(name)) {
+      missing.push(`${mod}: ${name}`)
+    }
+  }
+  for (const modName of modules) {
+    const mod = findModule(modName === 'index' ? '.' : `./${modName}`)
+    for (const child of mod?.children ?? []) {
+      if (containers.has(child.name)) {
+        for (const m of child.children ?? []) {
+          if (m.kind === 2048) consider(modName, m.name) // methods
+        }
+      }
+      if (child.kind === 64 || child.kind === 128) {
+        consider(modName, child.name) // functions, classes
+      }
+    }
+  }
+
+  if (missing.length) {
+    console.error(
+      `! ${missing.length} public export(s) in documented modules are missing from the manifest:`,
+    )
+    for (const m of missing) console.error(`    ${m}`)
+    console.error(
+      '  Add them to manifest.ts, or to UNDOCUMENTED_OK in generate.ts if intentional.',
+    )
+  }
+}
+
+function main() {
+  cleanGenerated()
+
+  const navPages = build(manifest as Node[], [NAV_BASE])
+  patchDocsJson(navPages)
+  warnMissingCoverage()
+
+  console.info(`Generated ${countPages(navPages)} pages under ${OUT_DIR}`)
+}
+
+function countPages(pages: (string | NavGroup)[]): number {
+  let n = 0
+  for (const p of pages) {
+    if (typeof p === 'string') n++
+    else n += countPages(p.pages)
+  }
+  return n
+}
+
+main()

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -239,11 +239,15 @@ export const manifest: Group[] = [
             './actions/smart-sessions',
             true,
           ),
-          action(
-            'createCrossChainPermission',
-            './actions/smart-sessions',
-            true,
-          ),
+          // Returns a CrossChainPermit (not a call), so it is a plain function,
+          // not an `action` wrapped in prepareTransaction `calls`.
+          {
+            kind: 'symbol',
+            symbol: 'createCrossChainPermission',
+            source: './actions/smart-sessions',
+            callStyle: 'function',
+            experimental: true,
+          },
         ],
       },
     ],

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -1,0 +1,260 @@
+// Curated mapping from public SDK symbols to reference pages.
+//
+// This is the single source of truth for BOTH the symbol -> page mapping and the
+// docs.json navigation tree. Leaves are symbols, keyed by (source, container,
+// symbol) so that names that collide across subpaths (e.g. `enable` in ecdsa,
+// passkeys, and mfa) resolve unambiguously.
+//
+// Scope is intentionally the hot path: the RhinestoneSDK entry point, the
+// account instance, actions, and utils. Types, errors, jwt-server, the
+// standalone createRhinestoneAccount function, and the /smart-sessions module
+// are out of scope for now.
+
+export type SymbolEntry = {
+  kind: 'symbol'
+  symbol: string
+  // Subpath export the symbol is reached through: '.', './actions/ecdsa', './utils', etc.
+  source: string
+  // Owning interface/class for instance methods.
+  container?: 'RhinestoneAccount' | 'RhinestoneSDK'
+  // How the symbol is reached, for the Import/Usage section.
+  callStyle:
+    | 'function'
+    | 'action'
+    | 'constructor'
+    | 'accountMethod'
+    | 'sdkMethod'
+  experimental?: boolean
+  // Nav label / page title override (defaults to `symbol`).
+  title?: string
+}
+
+export type Group = {
+  kind: 'group'
+  group: string
+  experimental?: boolean
+  items: Node[]
+}
+
+export type Node = Group | SymbolEntry
+
+const accountMethod = (symbol: string, experimental = false): SymbolEntry => ({
+  kind: 'symbol',
+  symbol,
+  source: '.',
+  container: 'RhinestoneAccount',
+  callStyle: 'accountMethod',
+  experimental,
+})
+
+const action = (
+  symbol: string,
+  source: string,
+  experimental = false,
+): SymbolEntry => ({
+  kind: 'symbol',
+  symbol,
+  source,
+  callStyle: 'action',
+  experimental,
+})
+
+const util = (symbol: string, experimental = false): SymbolEntry => ({
+  kind: 'symbol',
+  symbol,
+  source: './utils',
+  callStyle: 'function',
+  experimental,
+})
+
+export const manifest: Group[] = [
+  {
+    kind: 'group',
+    group: 'RhinestoneSDK',
+    items: [
+      {
+        kind: 'symbol',
+        symbol: 'RhinestoneSDK',
+        source: '.',
+        callStyle: 'constructor',
+        title: 'RhinestoneSDK',
+      },
+      {
+        kind: 'symbol',
+        symbol: 'createAccount',
+        source: '.',
+        container: 'RhinestoneSDK',
+        callStyle: 'sdkMethod',
+      },
+      {
+        kind: 'symbol',
+        symbol: 'getIntentStatus',
+        source: '.',
+        container: 'RhinestoneSDK',
+        callStyle: 'sdkMethod',
+      },
+      {
+        kind: 'symbol',
+        symbol: 'splitIntents',
+        source: '.',
+        container: 'RhinestoneSDK',
+        callStyle: 'sdkMethod',
+      },
+    ],
+  },
+  {
+    kind: 'group',
+    group: 'Account',
+    items: [
+      {
+        kind: 'group',
+        group: 'Deployment',
+        items: [
+          accountMethod('deploy'),
+          accountMethod('isDeployed'),
+          accountMethod('setup'),
+          accountMethod('getInitData'),
+          accountMethod('signEip7702InitData'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'Transactions',
+        items: [
+          accountMethod('prepareTransaction'),
+          accountMethod('getTransactionMessages'),
+          accountMethod('signTransaction'),
+          accountMethod('signAuthorizations'),
+          accountMethod('signIntent'),
+          accountMethod('submitTransaction'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'User operations',
+        items: [
+          accountMethod('prepareUserOperation'),
+          accountMethod('signUserOperation'),
+          accountMethod('submitUserOperation'),
+          accountMethod('sendUserOperation'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'Signing',
+        items: [accountMethod('signMessage'), accountMethod('signTypedData')],
+      },
+      {
+        kind: 'group',
+        group: 'Execution',
+        items: [accountMethod('waitForExecution')],
+      },
+      {
+        kind: 'group',
+        group: 'Reads',
+        items: [
+          accountMethod('getAddress'),
+          accountMethod('getPortfolio'),
+          accountMethod('getOwners'),
+          accountMethod('getValidators'),
+          accountMethod('getExecutors'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'Smart sessions',
+        experimental: true,
+        items: [
+          accountMethod('experimental_getSessionDetails', true),
+          accountMethod('experimental_isSessionEnabled', true),
+          accountMethod('experimental_signEnableSession', true),
+        ],
+      },
+    ],
+  },
+  {
+    kind: 'group',
+    group: 'Actions',
+    items: [
+      {
+        kind: 'group',
+        group: 'ECDSA',
+        items: [
+          action('enable', './actions/ecdsa'),
+          action('disable', './actions/ecdsa'),
+          action('addOwner', './actions/ecdsa'),
+          action('removeOwner', './actions/ecdsa'),
+          action('changeThreshold', './actions/ecdsa'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'Passkeys',
+        items: [
+          action('enable', './actions/passkeys'),
+          action('disable', './actions/passkeys'),
+          action('addOwner', './actions/passkeys'),
+          action('removeOwner', './actions/passkeys'),
+          action('changeThreshold', './actions/passkeys'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'MFA',
+        items: [
+          action('enable', './actions/mfa'),
+          action('disable', './actions/mfa'),
+          action('changeThreshold', './actions/mfa'),
+          action('setSubValidator', './actions/mfa'),
+          action('removeSubValidator', './actions/mfa'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'Recovery',
+        items: [
+          action('enable', './actions/recovery'),
+          action('recoverEcdsaOwnership', './actions/recovery'),
+          action('recoverPasskeyOwnership', './actions/recovery'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'Modules',
+        items: [
+          action('installModule', './actions'),
+          action('uninstallModule', './actions'),
+          action('deploy', './actions'),
+        ],
+      },
+      {
+        kind: 'group',
+        group: 'Smart sessions',
+        experimental: true,
+        items: [
+          action('experimental_enable', './actions/smart-sessions', true),
+          action('experimental_disable', './actions/smart-sessions', true),
+          action(
+            'experimental_enableSession',
+            './actions/smart-sessions',
+            true,
+          ),
+          action(
+            'createCrossChainPermission',
+            './actions/smart-sessions',
+            true,
+          ),
+        ],
+      },
+    ],
+  },
+  {
+    kind: 'group',
+    group: 'Utils',
+    items: [
+      util('experimental_getV0InitData', true),
+      util('experimental_getRhinestoneInitData', true),
+      util('toViewOnlyAccount'),
+    ],
+  },
+]

--- a/scripts/reference/typedoc.json
+++ b/scripts/reference/typedoc.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "../../src/index.ts",
+    "../../src/actions/index.ts",
+    "../../src/actions/ecdsa.ts",
+    "../../src/actions/mfa.ts",
+    "../../src/actions/passkeys.ts",
+    "../../src/actions/smart-sessions.ts",
+    "../../src/actions/recovery.ts",
+    "../../src/utils/index.ts",
+    "../../src/modules/validators/smart-sessions.ts"
+  ],
+  "entryPointStrategy": "resolve",
+  "tsconfig": "../../tsconfig.json",
+  "json": "./typedoc.json.out",
+  "pretty": true,
+  "excludeExternals": true,
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "skipErrorChecking": true
+}

--- a/src/actions/smart-sessions.ts
+++ b/src/actions/smart-sessions.ts
@@ -155,8 +155,9 @@ function resolveTokenForChain(
 }
 
 /**
- * Build a {@link CrossChainPermit} from an ergonomic input shape that
- * accepts:
+ * Build a {@link CrossChainPermit} from an ergonomic input shape.
+ *
+ * Accepts:
  *   - a single `from`/`to` leg or arrays of legs
  *   - `TokenSymbol` ("USDC", "USDT", ...) which is resolved to the
  *     per-chain ERC-20 address via the shared token registry

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,85 +141,244 @@ interface SubmitTransactionOptions {
 }
 
 interface RhinestoneAccount {
+  /** The resolved account configuration. */
   config: RhinestoneAccountConfig
-  deploy: (
+  /**
+   * Deploy the account on a given chain.
+   * @param chain Chain to deploy the account on
+   * @param params Optional deployment parameters (session, sponsorship)
+   * @returns `true` once the deployment is submitted
+   */
+  deploy(
     chain: Chain,
     params?: { session?: Session; sponsored?: boolean },
-  ) => Promise<boolean>
-  isDeployed: (chain: Chain) => Promise<boolean>
-  setup: (chain: Chain) => Promise<boolean>
+  ): Promise<boolean>
+  /**
+   * Check whether the account is deployed on a given chain.
+   * @param chain Chain to check
+   * @returns `true` if the account is deployed, `false` otherwise
+   */
+  isDeployed(chain: Chain): Promise<boolean>
+  /**
+   * Set up an existing account on a given chain by installing any missing modules.
+   * @param chain Chain to set the account up on
+   * @returns `true` once setup is submitted
+   */
+  setup(chain: Chain): Promise<boolean>
+  /**
+   * Get the account initialization data, used to deploy the account onchain.
+   * @returns The factory address and factory data
+   */
   getInitData(): {
     factory: Address
     factoryData: Hex
   }
-  signEip7702InitData: () => Promise<Hex>
-  prepareTransaction: (
-    transaction: Transaction,
-  ) => Promise<PreparedTransactionData>
-  getTransactionMessages: (
+  /**
+   * Prepare and sign the EIP-7702 account initialization data.
+   * @returns The init data signature
+   */
+  signEip7702InitData(): Promise<Hex>
+  /**
+   * Prepare a transaction for signing.
+   * @param transaction Transaction to prepare
+   * @returns The prepared transaction data
+   * @see {@link signTransaction} to sign the prepared transaction
+   * @see {@link submitTransaction} to submit the signed transaction
+   */
+  prepareTransaction(transaction: Transaction): Promise<PreparedTransactionData>
+  /**
+   * Get the typed-data messages to sign for a prepared transaction.
+   * @param preparedTransaction Prepared transaction data
+   * @param options Optional override; pass `{ intentId }` to inspect a specific quote from `preparedTransaction.quotes.all`
+   * @returns The origin, destination, and (when required) target-execution typed-data messages
+   * @see {@link prepareTransaction} to prepare the transaction data for signing
+   */
+  getTransactionMessages(
     preparedTransaction: PreparedTransactionData,
     options?: QuoteSelection,
-  ) => {
+  ): {
     origin: TypedDataDefinition[]
     destination: TypedDataDefinition
     targetExecution?: TypedDataDefinition
   }
-  signTransaction: (
+  /**
+   * Sign a prepared transaction.
+   * @param preparedTransaction Prepared transaction data
+   * @param options Optional override; pass `{ intentId }` to sign a specific quote from `preparedTransaction.quotes.all`
+   * @returns The signed transaction data
+   * @see {@link prepareTransaction} to prepare the transaction data for signing
+   * @see {@link submitTransaction} to submit the signed transaction
+   */
+  signTransaction(
     preparedTransaction: PreparedTransactionData,
     options?: QuoteSelection,
-  ) => Promise<SignedTransactionData>
-  signAuthorizations: (
+  ): Promise<SignedTransactionData>
+  /**
+   * Sign the EIP-7702 authorizations required for a transaction.
+   * @param preparedTransaction Prepared transaction data
+   * @returns The signed authorization list
+   * @see {@link prepareTransaction} to prepare the transaction data for signing
+   */
+  signAuthorizations(
     preparedTransaction: PreparedTransactionData,
-  ) => Promise<SignedAuthorizationList>
-  signMessage: (
+  ): Promise<SignedAuthorizationList>
+  /**
+   * Sign a message (EIP-191).
+   * @param message Message to sign
+   * @param chain Chain to sign the message for
+   * @param signers Signers to use, or `undefined` for the account default
+   * @returns The signature
+   * @see {@link signTypedData} to sign EIP-712 typed data
+   */
+  signMessage(
     message: SignableMessage,
     chain: Chain,
     signers: SignerSet | undefined,
-  ) => Promise<Hex>
-  signTypedData: <
+  ): Promise<Hex>
+  /**
+   * Sign typed data (EIP-712).
+   * @param parameters Typed-data parameters
+   * @param chain Chain to sign the typed data for
+   * @param signers Signers to use, or `undefined` for the account default
+   * @returns The signature
+   * @see {@link signMessage} to sign an EIP-191 message
+   */
+  signTypedData<
     typedData extends TypedData | Record<string, unknown> = TypedData,
     primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
   >(
     parameters: HashTypedDataParameters<typedData, primaryType>,
     chain: Chain,
     signers: SignerSet | undefined,
-  ) => Promise<Hex>
-  signIntent: (
+  ): Promise<Hex>
+  /**
+   * Sign an orchestrator intent operation. Used by headless flows that prepare
+   * the intent outside the SDK but still need the SDK-owned smart-session
+   * signature packing and target-execution signature routing.
+   * @param signData Sign data returned by the orchestrator (origin/destination/targetExecution typed data)
+   * @param targetChain Chain where the destination execution runs
+   * @param signers Signers to use, or `undefined` for the account default
+   * @returns The intent signatures, ready for submission
+   * @see {@link signTransaction} for the canonical signing path
+   */
+  signIntent(
     signData: SignData,
     targetChain: DestinationChain,
     signers?: SignerSet,
-  ) => Promise<SignedIntentData>
-  submitTransaction: (
+  ): Promise<SignedIntentData>
+  /**
+   * Submit a signed transaction.
+   * @param signedTransaction Signed transaction data
+   * @param options Optional submission options (e.g. EIP-7702 `authorizations`)
+   * @returns The transaction result (an intent ID)
+   * @see {@link signTransaction} to sign the transaction data
+   * @see {@link signAuthorizations} to sign the required EIP-7702 authorizations
+   * @see {@link waitForExecution} to wait for the transaction to execute onchain
+   */
+  submitTransaction(
     signedTransaction: SignedTransactionData,
     options?: SubmitTransactionOptions,
-  ) => Promise<TransactionResult>
-  prepareUserOperation: (
+  ): Promise<TransactionResult>
+  /**
+   * Prepare a user operation for signing.
+   * @param transaction User operation to prepare
+   * @returns The prepared user operation data
+   * @see {@link signUserOperation} to sign the prepared user operation
+   * @see {@link submitUserOperation} to submit the signed user operation
+   * @see {@link sendUserOperation} to prepare, sign, and submit in one call
+   */
+  prepareUserOperation(
     transaction: UserOperationTransaction,
-  ) => Promise<PreparedUserOperationData>
-  signUserOperation: (
+  ): Promise<PreparedUserOperationData>
+  /**
+   * Sign a prepared user operation.
+   * @param preparedUserOperation Prepared user operation data
+   * @returns The signed user operation data
+   * @see {@link prepareUserOperation} to prepare the user operation data for signing
+   * @see {@link submitUserOperation} to submit the signed user operation
+   */
+  signUserOperation(
     preparedUserOperation: PreparedUserOperationData,
-  ) => Promise<SignedUserOperationData>
-  submitUserOperation: (
+  ): Promise<SignedUserOperationData>
+  /**
+   * Submit a signed user operation.
+   * @param signedUserOperation Signed user operation data
+   * @returns The user operation result (a UserOp hash)
+   * @see {@link signUserOperation} to sign the user operation data
+   * @see {@link waitForExecution} to wait for the user operation to execute onchain
+   */
+  submitUserOperation(
     signedUserOperation: SignedUserOperationData,
-  ) => Promise<UserOperationResult>
-  sendUserOperation: (
+  ): Promise<UserOperationResult>
+  /**
+   * Prepare, sign, and submit a user operation in a single call.
+   * @param transaction User operation to send
+   * @returns The user operation result (a UserOp hash)
+   * @see {@link waitForExecution} to wait for the user operation to execute onchain
+   */
+  sendUserOperation(
     transaction: UserOperationTransaction,
-  ) => Promise<UserOperationResult>
+  ): Promise<UserOperationResult>
+  /**
+   * Wait for a submitted transaction or user operation to execute onchain.
+   * Polls the orchestrator until the intent reaches a terminal state; on failure
+   * an `IntentFailedError` is thrown.
+   * @param result The result returned by a submit/send call
+   * @returns The per-chain operation status (for intents) or a UserOp receipt
+   */
   waitForExecution(result: TransactionResult): Promise<TransactionStatus>
   waitForExecution(result: UserOperationResult): Promise<UserOperationReceipt>
-  getAddress: () => Address
-  getPortfolio: (onTestnets?: boolean) => Promise<Portfolio>
-  experimental_getSessionDetails: (
-    sessions: Session[],
-  ) => Promise<SessionDetails>
-  experimental_isSessionEnabled: (session: Session) => Promise<boolean>
-  experimental_signEnableSession: (details: SessionDetails) => Promise<Hex>
-  getOwners: (chain: Chain) => Promise<{
+  /**
+   * Get the account address.
+   * @returns The smart account address
+   */
+  getAddress(): Address
+  /**
+   * Get the account portfolio (token balances across chains).
+   * @param onTestnets Whether to query testnet balances (default is `false`)
+   * @returns The account balances
+   */
+  getPortfolio(onTestnets?: boolean): Promise<Portfolio>
+  /**
+   * Resolve the smart-session details for a set of sessions.
+   * @param sessions Sessions to resolve
+   * @returns The resolved session details
+   */
+  experimental_getSessionDetails(sessions: Session[]): Promise<SessionDetails>
+  /**
+   * Check whether a smart session is enabled on the account.
+   * @param session Session to check
+   * @returns `true` if the session is enabled
+   */
+  experimental_isSessionEnabled(session: Session): Promise<boolean>
+  /**
+   * Sign the data required to enable a smart session.
+   * @param details Session details to enable
+   * @returns The enable-session signature
+   */
+  experimental_signEnableSession(details: SessionDetails): Promise<Hex>
+  /**
+   * Get the account owners.
+   * @remarks Only returns ECDSA owners; owners managed by other validator types are not included.
+   * @param chain Chain to read the owners from
+   * @returns The owner addresses and threshold, or `null` if unavailable
+   */
+  getOwners(chain: Chain): Promise<{
     accounts: Address[]
     threshold: number
   } | null>
-  getValidators: (chain: Chain) => Promise<Address[]>
-  getExecutors: (chain: Chain) => Promise<Address[]>
+  /**
+   * Get the account validator modules.
+   * @param chain Chain to read the validators from
+   * @returns The validator module addresses
+   */
+  getValidators(chain: Chain): Promise<Address[]>
+  /**
+   * Get the account executor modules.
+   * @param chain Chain to read the executors from
+   * @returns The executor module addresses
+   */
+  getExecutors(chain: Chain): Promise<Address[]>
 }
 
 interface SignedIntentData {
@@ -246,11 +405,6 @@ async function createRhinestoneAccount(
     throw new OwnersFieldRequiredError()
   }
 
-  /**
-   * Deploys the account on a given chain
-   * @param chain Chain to deploy the account on
-   * @param session Session to deploy the account on (optional)
-   */
   function deploy(
     chain: Chain,
     params?: { session?: Session; sponsored?: boolean },
@@ -258,28 +412,14 @@ async function createRhinestoneAccount(
     return deployInternal(config, chain, params)
   }
 
-  /**
-   * Checks if the account is deployed on a given chain
-   * @param chain Chain to check if the account is deployed on
-   * @returns true if the account is deployed, false otherwise
-   */
   function isDeployed(chain: Chain) {
     return isDeployedInternal(config, chain)
   }
 
-  /**
-   * Sets up the existing account on a given chain
-   * by installing the missing modules (if any).
-   * @param chain Chain to set up the account on
-   */
   function setup(chain: Chain) {
     return setupInternal(config, chain)
   }
 
-  /**
-   * Get the account initialization data. Used for deploying the account onchain.
-   * @returns factory address and factory data
-   */
   function getInitData(): {
     factory: Address
     factoryData: Hex
@@ -297,29 +437,14 @@ async function createRhinestoneAccount(
     }
   }
 
-  /**
-   * Prepare and sign the EIP-7702 account initialization data
-   * @returns init data signature
-   */
   function signEip7702InitData() {
     return signEip7702InitDataInternal(config)
   }
 
-  /**
-   * Prepare a transaction data
-   * @param transaction Transaction to prepare
-   * @returns prepared transaction data
-   */
   function prepareTransaction(transaction: Transaction) {
     return prepareTransactionInternal(config, transaction)
   }
 
-  /**
-   * Get the transaction typed data message to sign
-   * @param preparedTransaction Prepared transaction data
-   * @param options Optional override; pass `{ intentId }` to inspect a specific quote from `preparedTransaction.quotes.all`
-   * @see {@link prepareTransaction} to prepare the transaction data for signing
-   */
   function getTransactionMessages(
     preparedTransaction: PreparedTransactionData,
     options?: QuoteSelection,
@@ -327,13 +452,6 @@ async function createRhinestoneAccount(
     return getTransactionMessagesInternal(config, preparedTransaction, options)
   }
 
-  /**
-   * Sign a transaction
-   * @param preparedTransaction Prepared transaction data
-   * @param options Optional override; pass `{ intentId }` to sign a specific quote from `preparedTransaction.quotes.all`
-   * @returns signed transaction data
-   * @see {@link prepareTransaction} to prepare the transaction data for signing
-   */
   function signTransaction(
     preparedTransaction: PreparedTransactionData,
     options?: QuoteSelection,
@@ -341,23 +459,10 @@ async function createRhinestoneAccount(
     return signTransactionInternal(config, preparedTransaction, options)
   }
 
-  /**
-   * Sign the required EIP-7702 authorizations for a transaction
-   * @param preparedTransaction Prepared transaction data
-   * @returns signed authorizations
-   * @see {@link prepareTransaction} to prepare the transaction data for signing
-   */
   function signAuthorizations(preparedTransaction: PreparedTransactionData) {
     return signAuthorizationsInternal(config, preparedTransaction)
   }
 
-  /**
-   * Sign a message (EIP-191)
-   * @param message Message to sign
-   * @param chain Chain to sign the message on
-   * @param signers Signers to use for signing
-   * @returns signature
-   */
   function signMessage(
     message: SignableMessage,
     chain: Chain,
@@ -366,13 +471,6 @@ async function createRhinestoneAccount(
     return signMessageInternal(config, message, chain, signers)
   }
 
-  /**
-   * Sign a typed data (EIP-712)
-   * @param parameters Typed data parameters
-   * @param chain Chain to sign the typed data on
-   * @param signers Signers to use for signing
-   * @returns signature
-   */
   function signTypedData<
     typedData extends TypedData | Record<string, unknown> = TypedData,
     primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
@@ -389,18 +487,6 @@ async function createRhinestoneAccount(
     )
   }
 
-  /**
-   * Sign an orchestrator intent operation.
-   * This is used by headless flows that prepare the intent outside the SDK but
-   * still need the SDK-owned SmartSession signature packing and target-execution
-   * signature routing. Mirrors the canonical {@link signTransaction} path: origin
-   * and destination are always signed in claim mode, and the target-execution
-   * signature is derived separately (returned only when the intent requires it).
-   * @param signData Sign data returned by the orchestrator (origin/destination/targetExecution typed data)
-   * @param targetChain Chain where the destination execution runs
-   * @param signers Signers to use for signing
-   * @returns Intent signatures ready for submission
-   */
   async function signIntent(
     signData: SignData,
     targetChain: DestinationChain,
@@ -427,15 +513,6 @@ async function createRhinestoneAccount(
     }
   }
 
-  /**
-   * Submit a transaction
-   * @param signedTransaction Signed transaction data
-   * @param options Optional submission options
-   * @param options.authorizations EIP-7702 authorizations to submit
-   * @returns transaction result object (a UserOp hash)
-   * @see {@link signTransaction} to sign the transaction data
-   * @see {@link signAuthorizations} to sign the required EIP-7702 authorizations
-   */
   function submitTransaction(
     signedTransaction: SignedTransactionData,
     options?: SubmitTransactionOptions,
@@ -448,52 +525,21 @@ async function createRhinestoneAccount(
     )
   }
 
-  /**
-   * Prepare a user operation data
-   * @param transaction User operation to prepare
-   * @returns prepared user operation data
-   */
   function prepareUserOperation(transaction: UserOperationTransaction) {
     return prepareUserOperationInternal(config, transaction)
   }
 
-  /**
-   * Sign a user operation
-   * @param preparedUserOperation Prepared user operation data
-   * @returns signed user operation data
-   * @see {@link prepareUserOperation} to prepare the user operation data for signing
-   */
   function signUserOperation(preparedUserOperation: PreparedUserOperationData) {
     return signUserOperationInternal(config, preparedUserOperation)
   }
-  /**
-   * Submit a transaction
-   * @param signedTransaction Signed transaction data
-   * @returns transaction result object (a UserOp hash)
-   * @see {@link signUserOperation} to sign the user operation data
-   */
   function submitUserOperation(signedUserOperation: SignedUserOperationData) {
     return submitUserOperationInternal(config, signedUserOperation)
   }
 
-  /**
-   * Sign and send a user operation
-   * @param transaction User operation to send
-   * @returns user operation result object (a UserOp hash)
-   */
   function sendUserOperation(transaction: UserOperationTransaction) {
     return sendUserOperationInternal(config, transaction)
   }
 
-  /**
-   * Wait for the transaction execution onchain.
-   *
-   * Polls the orchestrator until the intent reaches a terminal state
-   * (`COMPLETED` or `FAILED`). On failure an {@link IntentFailedError} is thrown.
-   *
-   * @param result Transaction result object returned by {@link sendTransaction}
-   * @returns Per-chain operation breakdown (for intents) or a UserOp receipt
-   */
   function waitForExecution(
     result: TransactionResult,
   ): Promise<TransactionStatus>
@@ -504,39 +550,20 @@ async function createRhinestoneAccount(
     return waitForExecutionInternal(config, result)
   }
 
-  /**
-   * Get account address
-   * @returns Address of the smart account
-   */
   function getAddress() {
     return getAddressInternal(config)
   }
 
-  /**
-   * Get account portfolio
-   * @param onTestnets Whether to query the testnet balances (default is `false`)
-   * @returns Account balances
-   */
   function getPortfolio(onTestnets = false) {
     return getPortfolioInternal(config, onTestnets)
   }
 
-  /**
-   * Get account owners (ECDSA)
-   * @param chain Chain to get the owners on
-   * @returns Account owners
-   */
   function getOwners(chain: Chain) {
     const accountType = getAccountProvider(config).type
     const account = getAddress()
     return getOwnersInternal(accountType, account, chain, config.provider)
   }
 
-  /**
-   * Get account validator modules
-   * @param chain Chain to get the validators on
-   * @returns List of account validators
-   */
   function getValidators(chain: Chain) {
     const accountType = getAccountProvider(config).type
     const account = getAddress()
@@ -604,6 +631,10 @@ async function createRhinestoneAccount(
   }
 }
 
+/**
+ * Stateful entry point that holds shared configuration (auth, provider, bundler,
+ * paymaster) and creates accounts from it.
+ */
 class RhinestoneSDK {
   private authProvider: AuthProvider
   private endpointUrl?: string
@@ -613,6 +644,10 @@ class RhinestoneSDK {
   private useDevContracts?: boolean
   private headers?: Record<string, string>
 
+  /**
+   * Create a Rhinestone SDK instance.
+   * @param options Shared configuration applied to every account created by this instance
+   */
   constructor(options: RhinestoneSDKConfig) {
     this.authProvider = createAuthProvider(options)
     this.endpointUrl = options.endpointUrl
@@ -623,6 +658,26 @@ class RhinestoneSDK {
     this.headers = options.headers
   }
 
+  /**
+   * Create an account using this instance's shared configuration.
+   * @param config Per-account configuration (owners, account type, modules, sessions)
+   * @returns The account instance
+   * @example
+   * ```ts
+   * import { RhinestoneSDK } from '@rhinestone/sdk'
+   * import { privateKeyToAccount } from 'viem/accounts'
+   *
+   * const owner = privateKeyToAccount('0x...')
+   *
+   * const sdk = new RhinestoneSDK({
+   *   auth: { mode: 'apiKey', apiKey: process.env.RHINESTONE_API_KEY! },
+   * })
+   *
+   * const account = await sdk.createAccount({
+   *   owners: { type: 'ecdsa', accounts: [owner] },
+   * })
+   * ```
+   */
   createAccount(config: RhinestoneAccountConfig) {
     const rhinestoneConfig: RhinestoneConfig = {
       ...config,
@@ -637,6 +692,11 @@ class RhinestoneSDK {
     return createRhinestoneAccount(rhinestoneConfig)
   }
 
+  /**
+   * Get the current status of a submitted intent.
+   * @param intentId The intent ID returned when the transaction was submitted
+   * @returns The intent status
+   */
   getIntentStatus(intentId: string) {
     return getIntentStatusInternal(
       this.authProvider,
@@ -646,6 +706,11 @@ class RhinestoneSDK {
     )
   }
 
+  /**
+   * Split a transaction into multiple intents across chains.
+   * @param input The intents to split
+   * @returns The split-intents result
+   */
   splitIntents(input: SplitIntentsInput) {
     return splitIntentsInternal(
       this.authProvider,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,27 @@ import { getSetup as experimental_getModuleSetup } from '../modules'
 import type { RhinestoneAccountConfig } from '../types'
 import { walletClientToAccount, wrapParaAccount } from './walletClient'
 
+/**
+ * Compute the v0 (legacy) initialization data for an account configuration.
+ *
+ * Use this to reconstruct the `initData` for an account originally created with
+ * the Rhinestone SDK v0, then pass it back into `createAccount`.
+ * @param config Account configuration
+ * @returns The account address, factory, factory data, and whether the intent executor is installed
+ * @example
+ * ```ts
+ * import { experimental_getV0InitData } from '@rhinestone/sdk/utils'
+ *
+ * const initData = experimental_getV0InitData({
+ *   owners: { type: 'ecdsa', accounts: [owner] },
+ * })
+ *
+ * const account = await sdk.createAccount({
+ *   owners: { type: 'ecdsa', accounts: [owner] },
+ *   initData,
+ * })
+ * ```
+ */
 function experimental_getV0InitData(config: RhinestoneAccountConfig): {
   address: Address
   factory: Address
@@ -28,6 +49,28 @@ function experimental_getV0InitData(config: RhinestoneAccountConfig): {
   }
 }
 
+/**
+ * Compute the Rhinestone initialization data for an account configuration.
+ *
+ * Use this to reconstruct the `initData` for an account originally created with
+ * the Rhinestone SDK, then pass it back into `createAccount` instead of
+ * providing the factory and factory data manually.
+ * @param config Account configuration
+ * @returns The account address, plus factory data when the account is not yet deployed
+ * @example
+ * ```ts
+ * import { experimental_getRhinestoneInitData } from '@rhinestone/sdk/utils'
+ *
+ * const initData = experimental_getRhinestoneInitData({
+ *   owners: { type: 'ecdsa', accounts: [owner] },
+ * })
+ *
+ * const account = await sdk.createAccount({
+ *   owners: { type: 'ecdsa', accounts: [owner] },
+ *   initData,
+ * })
+ * ```
+ */
 function experimental_getRhinestoneInitData(config: RhinestoneAccountConfig):
   | {
       address: Address
@@ -58,6 +101,22 @@ function experimental_getRhinestoneInitData(config: RhinestoneAccountConfig):
   }
 }
 
+/**
+ * Create a view-only viem `Account` for an address. Any signing operation throws.
+ *
+ * Useful as an account owner when signing happens elsewhere (e.g. a server-held
+ * session signer), so the SDK can read from the account without holding a key.
+ * @param address Address to wrap
+ * @returns A viem account that can be read from but not signed with
+ * @example
+ * ```ts
+ * import { toViewOnlyAccount } from '@rhinestone/sdk/utils'
+ *
+ * const account = await sdk.createAccount({
+ *   owners: { type: 'ecdsa', accounts: [toViewOnlyAccount(userAddress)] },
+ * })
+ * ```
+ */
 function toViewOnlyAccount(address: Address): Account {
   const errorMessage = 'Signing is not supported for view-only accounts'
   return toAccount({


### PR DESCRIPTION
Improves JSDoc across the public SDK surface and adds a TypeDoc-based generator that renders the docs site's "SDK Reference" tab.

- Canonical JSDoc moved onto the `RhinestoneAccount` interface (method-signature syntax so TypeDoc binds params); documented `RhinestoneSDK`, the utils, and smart-session actions; added `@see` interlinks and `@example`s.
- `scripts/reference/` — TypeDoc JSON → curated `manifest.ts` → Mintlify MDX (`bun run reference`; see `scripts/reference/README.md`). Root-level tooling, not published.
- Coverage tripwire warns about public exports in already-documented modules that are missing from the manifest.

The generated MDX lands in the docs repo (companion PR).

Part of [RHI-3672](https://linear.app/rhinestone/issue/RHI-3672/reference-for-sdk).