### PR TITLE
feat(sdk): add experimental_disableSession action

### DIFF
--- a/.changeset/add-disable-session.md
+++ b/.changeset/add-disable-session.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add `experimental_disableSession` to the smart-sessions actions. Removes a single enabled session from an account via the emissary's `removeConfig`. The account executes the call itself, so the user authorizes it by signing the outer transaction — no separate session-digest signature is needed. Takes the resolved session and an `expires` deadline (`Date`).

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -229,6 +229,11 @@ export const manifest: Group[] = [
             './actions/smart-sessions',
             true,
           ),
+          action(
+            'experimental_disableSession',
+            './actions/smart-sessions',
+            true,
+          ),
         ],
       },
     ],

--- a/src/actions/smart-sessions.ts
+++ b/src/actions/smart-sessions.ts
@@ -4,6 +4,7 @@ import {
   getModuleUninstallationCalls,
 } from '../accounts'
 import {
+  getDisableSessionCall,
   getEnableSessionCall,
   getSmartSessionValidator,
 } from '../modules/validators/smart-sessions'
@@ -77,4 +78,41 @@ function experimental_enableSession(
   }
 }
 
-export { experimental_disable, experimental_enable, experimental_enableSession }
+/**
+ * Disable a smart session
+ *
+ * Removes a single session from the smart-session emissary via `removeConfig`.
+ * The account executes the call itself, so the emissary skips the disable
+ * user-signature — the user authorizes it by signing the outer transaction as
+ * usual (no separate, blind session-digest signature). The `session` must be a
+ * resolved `Session` (the return value of `toSession(...)`) on the chain where
+ * the session is being disabled.
+ *
+ * @param session resolved session to disable
+ * @param expires deadline after which this disable call is no longer valid;
+ *   must be in the future
+ * @returns Calls to disable the smart session
+ */
+function experimental_disableSession(
+  session: Session,
+  expires: Date,
+): LazyCallInput {
+  return {
+    async resolve({ accountAddress, config }) {
+      return getDisableSessionCall(
+        accountAddress,
+        session,
+        BigInt(Math.floor(expires.getTime() / 1000)),
+        config.provider,
+        config.useDevContracts,
+      )
+    },
+  }
+}
+
+export {
+  experimental_disable,
+  experimental_disableSession,
+  experimental_enable,
+  experimental_enableSession,
+}

--- a/src/modules/validators/smart-sessions-disable.test.ts
+++ b/src/modules/validators/smart-sessions-disable.test.ts
@@ -1,0 +1,103 @@
+import { baseSepolia } from 'viem/chains'
+import { describe, expect, test, vi } from 'vitest'
+
+// getDisableSessionCall reads the emissary nonce via createPublicClient; stub it.
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>()
+  return {
+    ...actual,
+    createPublicClient: () => ({
+      readContract: async () => 7n,
+    }),
+  }
+})
+
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  type Hex,
+  keccak256,
+  zeroAddress,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import smartSessionEmissaryAbi from '../abi/smart-session-emissary'
+import {
+  getDisableSessionCall,
+  SMART_SESSION_EMISSARY_ADDRESS,
+  toSession,
+} from './smart-sessions'
+
+const MOCK_NONCE = 7n
+const LOCK_TAG: Hex = '0x000000000000000000000000'
+const SIGNED_PERMISSION_DISABLE_TYPEHASH: Hex =
+  '0x098b3120e60a8adc9d970dec9c1f8796974a3ab6154f995ad56ee7b9a38d8836'
+
+const account = '0x1111111111111111111111111111111111111111' as const
+const owner = privateKeyToAccount(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+)
+const session = toSession({
+  chain: baseSepolia,
+  owners: { type: 'ecdsa', accounts: [owner] },
+})
+const expires = 1893456000n
+
+describe('getDisableSessionCall', () => {
+  test('encodes a no-allocator removeConfig with an empty user signature', async () => {
+    const call = await getDisableSessionCall(
+      account,
+      session,
+      expires,
+      undefined,
+      false,
+    )
+
+    expect(call.to.toLowerCase()).toBe(
+      SMART_SESSION_EMISSARY_ADDRESS.toLowerCase(),
+    )
+
+    const { functionName, args } = decodeFunctionData({
+      abi: smartSessionEmissaryAbi,
+      data: call.data,
+    })
+    expect(functionName).toBe('removeConfig')
+
+    const [decodedAccount, config, disableData] = args
+    expect(decodedAccount.toLowerCase()).toBe(account.toLowerCase())
+    expect(config.allocator).toBe(zeroAddress)
+    expect(config.permissionId).toBe(session.permissionId)
+
+    // No signatures: the account is msg.sender, so the emissary skips both.
+    expect(disableData.userSig).toBe('0x')
+    expect(disableData.allocatorSig).toBe('0x')
+    expect(disableData.expires).toBe(expires)
+    expect(disableData.session.chainDigestIndex).toBe(0)
+
+    const [chainDigest] = disableData.session.hashesAndChainIds
+    expect(chainDigest.chainId).toBe(BigInt(baseSepolia.id))
+
+    // The leaf must equal HashLibV2.disableDigest(permissionId, account, nonce,
+    // expires, lockTag) computed from the on-chain nonce.
+    const expectedDigest = keccak256(
+      encodeAbiParameters(
+        [
+          { type: 'bytes32' },
+          { type: 'address' },
+          { type: 'bytes32' },
+          { type: 'bytes12' },
+          { type: 'uint256' },
+          { type: 'uint256' },
+        ],
+        [
+          SIGNED_PERMISSION_DISABLE_TYPEHASH,
+          account,
+          session.permissionId,
+          LOCK_TAG,
+          expires,
+          MOCK_NONCE,
+        ],
+      ),
+    )
+    expect(chainDigest.sessionDigest).toBe(expectedDigest)
+  })
+})

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -689,6 +689,88 @@ async function getEnableSessionCall(
   }
 }
 
+// SignedPermissionDisable(address account,bytes32 permissionId,bytes12 lockTag,uint256 expires,uint256 nonce)
+// Vendored from contracts/smart-sessions-v2/src/lib/HashLibV2.sol.
+const SIGNED_PERMISSION_DISABLE_TYPEHASH: Hex =
+  '0x098b3120e60a8adc9d970dec9c1f8796974a3ab6154f995ad56ee7b9a38d8836'
+
+// Builds a `removeConfig` call that disables a single smart session.
+//
+// The disable user-signature (`disableData.userSig`) is left empty: the
+// emissary only verifies it when `msg.sender != account`
+// (SignatureLib.verifySignatures), and here the account itself executes the
+// call, so the disable is authorized by the outer transaction the user signs
+// normally. The `disableDigest` leaf still has to match on-chain, so we build
+// it from the current emissary nonce + `expires`. No-allocator flow only
+// (`allocator == zeroAddress`), matching how enable is used today.
+async function getDisableSessionCall(
+  account: Address,
+  session: Session,
+  expires: bigint,
+  provider: ProviderConfig | undefined,
+  useDevContracts?: boolean,
+) {
+  const lockTag: Hex = '0x000000000000000000000000'
+  const permissionId = getPermissionId(session)
+  const nonce = await getSessionNonce(
+    account,
+    session,
+    lockTag,
+    provider,
+    useDevContracts,
+  )
+  // SmartSessionLens reuses the session multichain wrapper for the disable
+  // digest, plugging this leaf in as `sessionDigest` (HashLibV2.disableDigest).
+  const disableDigest = keccak256(
+    encodeAbiParameters(
+      [
+        { type: 'bytes32' },
+        { type: 'address' },
+        { type: 'bytes32' },
+        { type: 'bytes12' },
+        { type: 'uint256' },
+        { type: 'uint256' },
+      ],
+      [
+        SIGNED_PERMISSION_DISABLE_TYPEHASH,
+        account,
+        permissionId,
+        lockTag,
+        expires,
+        nonce,
+      ],
+    ),
+  )
+  const hashesAndChainIds = [
+    { chainId: BigInt(session.chain.id), sessionDigest: disableDigest },
+  ]
+  return {
+    to: getSmartSessionEmissaryAddress(useDevContracts),
+    data: encodeFunctionData({
+      abi: smartSessionEmissaryAbi,
+      functionName: 'removeConfig',
+      args: [
+        account,
+        {
+          scope: SCOPE_MULTICHAIN,
+          resetPeriod: RESET_PERIOD_ONE_WEEK,
+          allocator: zeroAddress,
+          permissionId,
+        },
+        {
+          allocatorSig: '0x',
+          userSig: '0x',
+          expires,
+          session: {
+            chainDigestIndex: 0,
+            hashesAndChainIds,
+          },
+        },
+      ],
+    }),
+  }
+}
+
 function toSession<const TAbis extends readonly Abi[]>(
   definition: SessionDefinition<TAbis>,
   options: { useDevContracts?: boolean } = {},
@@ -1584,6 +1666,7 @@ export {
   getSessionData,
   getPolicyData,
   getEnableSessionCall,
+  getDisableSessionCall,
   getPermissionId,
   getSmartSessionValidator,
   getSessionDetails,

--- a/test/integration/scenarios/ssx.itest.ts
+++ b/test/integration/scenarios/ssx.itest.ts
@@ -1,5 +1,6 @@
 import type { Chain } from 'viem/chains'
 import { describe, test } from 'vitest'
+import { experimental_disableSession } from '../../../src/actions/smart-sessions'
 import { SimulationFailedError } from '../../../src/errors/index'
 import type { RhinestoneAccount, Session } from '../../../src/index'
 import { sourceChain, targetChain } from '../config/chains'
@@ -102,6 +103,42 @@ describe.sequential('SDK integration ssx', () => {
     })
   }
 
+  // DISABLE: enable a session for real, then disable it via
+  // experimental_disableSession. The account executes removeConfig itself, so
+  // the disable needs no separate user signature — only the outer (owner) tx.
+  for (const chainMode of chainModes) {
+    test(`disables a session on a ${chainMode}-chain account`, async () => {
+      const account = await createSessionAccount()
+      const session = createScopedSession({
+        chain: getExecutionChain(chainMode),
+        owner: createOwner(),
+      })
+
+      await enableSession(
+        account,
+        session,
+        chainMode,
+        `ssx/${chainMode}/disable-enable`,
+      )
+
+      const execution = await executeIntent({
+        account,
+        label: `ssx/${chainMode}/disable`,
+        transaction: createDisableTransaction(chainMode, { session }),
+      })
+
+      expectOutcome(execution, { kind: 'success' })
+      if (execution.phase !== 'success') return
+
+      expectNoFailedOperations(execution.status)
+      expectCompletedOperation(
+        execution.status,
+        getExecutionChain(chainMode).id,
+      )
+      await expectSessionDisabled(account, session)
+    })
+  }
+
   test('rejects a session-signed call with wrong selector', async () => {
     await expectScopedCallRejected(createOutOfScopeCall(), 'wrong-selector')
   })
@@ -177,6 +214,21 @@ function createSessionTransaction(
     return { ...base, sourceChains: [sourceChain], targetChain }
   }
   return { ...base, chain: sourceChain }
+}
+
+// Disable is local to the session's chain and owner-signed (no session
+// signers), so no cross-chain routing is needed regardless of chainMode.
+function createDisableTransaction(
+  chainMode: ChainMode,
+  { session }: { session: Session },
+) {
+  return {
+    chain: getExecutionChain(chainMode),
+    sponsored: true,
+    calls: [
+      experimental_disableSession(session, new Date(Date.now() + 60 * 60_000)),
+    ],
+  }
 }
 
 async function addEnableData(


### PR DESCRIPTION
Adds `experimental_disableSession` to the smart-sessions actions — disables a single enabled session via the emissary's `removeConfig` (RHI-4584). Item 5 of the SDK v2 cleanup.

- New action `experimental_disableSession(session, expires)` (`./actions/smart-sessions`), returning a `LazyCallInput` like `experimental_enableSession`.
- The account executes `removeConfig` itself, so the emissary skips the disable user-signature (`msg.sender == account`); the user authorizes it by signing the outer transaction — **no separate, blind session-digest signature**. Targets the no-allocator flow, matching how enable is used today.
- `expires` is required and accepted as a `Date` (converted to unix seconds at the boundary), per the v2 datetime convention.
- The `disableDigest` leaf is built from the current emissary nonce; the disable-specific EIP-712 wrapper (`MULTICHAIN_DISABLE`) is dead code in the deployed contract, so clear signing isn't possible there — but isn't needed for the account-executed path.

Verified end-to-end on Base Sepolia (sponsored): enable → disable (`isPermissionEnabled` → false) → re-enable, plus past-`expires` correctly rejected with state left intact. Unit test covers the `removeConfig` encoding + digest derivation; an integration spec (`ssx.itest.ts`) covers enable→disable on same/cross-chain accounts.

Closes [RHI-4584](https://linear.app/rhinestone/issue/RHI-4584)