### PR TITLE
feat(sdk): make expires optional in experimental_disableSession

### DIFF
--- a/.changeset/disable-session-optional-expires.md
+++ b/.changeset/disable-session-optional-expires.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Make `expires` optional in `experimental_disableSession`. Omitting it disables the session with no expiry (`maxUint256` sentinel), matching the enable paths, instead of forcing callers to invent a far-future `Date`.

--- a/src/actions/smart-sessions.ts
+++ b/src/actions/smart-sessions.ts
@@ -1,4 +1,4 @@
-import type { Hex } from 'viem'
+import { type Hex, maxUint256 } from 'viem'
 import {
   getModuleInstallationCalls,
   getModuleUninstallationCalls,
@@ -89,20 +89,20 @@ function experimental_enableSession(
  * the session is being disabled.
  *
  * @param session resolved session to disable
- * @param expires deadline after which this disable call is no longer valid;
- *   must be in the future
+ * @param expires optional deadline after which this disable call is no longer
+ *   valid; must be in the future. Omit for no expiry.
  * @returns Calls to disable the smart session
  */
 function experimental_disableSession(
   session: Session,
-  expires: Date,
+  expires?: Date,
 ): LazyCallInput {
   return {
     async resolve({ accountAddress, config }) {
       return getDisableSessionCall(
         accountAddress,
         session,
-        BigInt(Math.floor(expires.getTime() / 1000)),
+        expires ? BigInt(Math.floor(expires.getTime() / 1000)) : maxUint256,
         config.provider,
         config.useDevContracts,
       )


### PR DESCRIPTION
Makes `expires` optional in `experimental_disableSession`. Omitting it disables the session with no expiry (`maxUint256` sentinel), mirroring the enable paths, instead of forcing callers to pass a far-future `Date`.

Refines the still-unreleased disable API from #593 (this beta line).