### PR TITLE
refactor(sdk)!: trim ./smart-sessions to a curated public surface

### DIFF
--- a/.changeset/trim-smart-sessions-surface.md
+++ b/.changeset/trim-smart-sessions-surface.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': major
+---
+
+Trim the `@rhinestone/sdk/smart-sessions` subpath to a curated public surface. It now exports only `toSession`, `SMART_SESSION_EMISSARY_ADDRESS`, the policy address constants (`SPENDING_LIMITS_POLICY_ADDRESS`, `TIME_FRAME_POLICY_ADDRESS`, `SUDO_POLICY_ADDRESS`, `UNIVERSAL_ACTION_POLICY_ADDRESS`, `ARG_POLICY_ADDRESS`, `USAGE_LIMIT_POLICY_ADDRESS`, `VALUE_LIMIT_POLICY_ADDRESS`, `INTENT_EXECUTION_POLICY_ADDRESS`), and the `SessionDetails` and `ChainDigest` types. The remaining low-level helpers, constants, and types that the subpath previously re-exported are now internal. Use the account's `experimental_*` methods and the `@rhinestone/sdk/actions/smart-sessions` actions instead.

--- a/src/package.json
+++ b/src/package.json
@@ -52,8 +52,8 @@
       "import": "./dist/src/utils/index.js"
     },
     "./smart-sessions": {
-      "types": "./dist/src/modules/validators/smart-sessions.d.ts",
-      "import": "./dist/src/modules/validators/smart-sessions.js"
+      "types": "./dist/src/smart-sessions/index.d.ts",
+      "import": "./dist/src/smart-sessions/index.js"
     },
     "./jwt-server": {
       "types": "./dist/src/jwt-server/index.d.ts",

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -1,0 +1,35 @@
+// Curated public surface for the `@rhinestone/sdk/smart-sessions` subpath. The
+// validator module exports many low-level internals consumed only by `index.ts`
+// and the smart-sessions actions; this barrel re-exports just the building blocks
+// integrators need directly.
+
+import type {
+  ChainDigest,
+  SessionDetails,
+} from '../modules/validators/smart-sessions'
+import {
+  ARG_POLICY_ADDRESS,
+  INTENT_EXECUTION_POLICY_ADDRESS,
+  SMART_SESSION_EMISSARY_ADDRESS,
+  SPENDING_LIMITS_POLICY_ADDRESS,
+  SUDO_POLICY_ADDRESS,
+  TIME_FRAME_POLICY_ADDRESS,
+  toSession,
+  UNIVERSAL_ACTION_POLICY_ADDRESS,
+  USAGE_LIMIT_POLICY_ADDRESS,
+  VALUE_LIMIT_POLICY_ADDRESS,
+} from '../modules/validators/smart-sessions'
+
+export {
+  toSession,
+  SMART_SESSION_EMISSARY_ADDRESS,
+  SPENDING_LIMITS_POLICY_ADDRESS,
+  TIME_FRAME_POLICY_ADDRESS,
+  SUDO_POLICY_ADDRESS,
+  UNIVERSAL_ACTION_POLICY_ADDRESS,
+  ARG_POLICY_ADDRESS,
+  USAGE_LIMIT_POLICY_ADDRESS,
+  VALUE_LIMIT_POLICY_ADDRESS,
+  INTENT_EXECUTION_POLICY_ADDRESS,
+}
+export type { ChainDigest, SessionDetails }


### PR DESCRIPTION
The `./smart-sessions` subpath re-exported the entire validator module (35 symbols), most of them low-level internals only consumed by `index.ts` and the smart-sessions actions. This trims it to a curated public surface.

- New curated barrel `src/smart-sessions/index.ts` re-exports only `toSession`, `SMART_SESSION_EMISSARY_ADDRESS`, the 8 policy address constants, and the `SessionDetails` / `ChainDigest` types (12 total). The subpath is repointed at it.
- The raw validator module keeps its full export block, so internal cross-file imports are unchanged.
- Everything else previously on the subpath (`getSessionDetails`, `isSessionEnabled`, `signEnableSession`, `getEnableSessionCall`, `getSmartSessionValidator`, `getPermissionId`, `packSignature`, `buildMockSignature`, the permit2/policy helpers, the dev/fallback/dummy constants, and the internal types) is now internal. Use the account's `experimental_*` methods and `@rhinestone/sdk/actions/smart-sessions` instead.

Breaking → major changeset.

Closes [RHI-4590](https://linear.app/rhinestone/issue/RHI-4590)