### PR TITLE
Preserve unprocessable error details

### DIFF
--- a/.changeset/preserve-unprocessable-details.md
+++ b/.changeset/preserve-unprocessable-details.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Preserve unprocessable-content response details on `UnprocessableContentError` so callers can inspect structured orchestrator validation and planning context.

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -22,6 +22,7 @@ import {
   SessionChainRequiredError,
   SignerNotSupportedError,
 } from '../execution'
+import type { ErrorDetail } from '../orchestrator'
 import {
   ConflictError,
   ExternalServiceTimeoutError,
@@ -48,6 +49,8 @@ import {
   UnsupportedTokenError,
   ValidationError,
 } from '../orchestrator'
+
+export type { ErrorDetail }
 
 export {
   // Account

--- a/src/orchestrator/error.test.ts
+++ b/src/orchestrator/error.test.ts
@@ -7,6 +7,7 @@ import {
   KeyScopeDeniedError,
   parseErrorEnvelope,
   SimulationFailedError,
+  UnprocessableContentError,
 } from './error'
 
 describe('parseErrorEnvelope — KEY_SCOPE_DENIED', () => {
@@ -74,6 +75,94 @@ describe('parseErrorEnvelope — KEY_SCOPE_DENIED', () => {
     expect(err.scope).toBe('')
     expect(err.required).toBe('')
     expect(err.actual).toBe('')
+  })
+})
+
+describe('parseErrorEnvelope — UNPROCESSABLE_CONTENT', () => {
+  test('preserves structured details for callers', () => {
+    const err = parseErrorEnvelope(
+      {
+        code: 'UNPROCESSABLE_CONTENT',
+        message: 'No viable route found for this intent.',
+        traceId: 'trace-unprocessable',
+        details: [
+          {
+            message: 'No viable route found for this intent.',
+            context: {
+              code: 'NO_PLAN_AVAILABLE',
+              failureCodes: ['NO_ROUTE_SUPPORT', 'RELAY_FAILED'],
+              strategyFailures: [
+                {
+                  strategy: 'StandardPlanStrategy',
+                  code: 'NO_ROUTE_SUPPORT',
+                  message: 'no route support',
+                },
+                {
+                  strategy: 'RelayPlanStrategy',
+                  code: 'RELAY_FAILED',
+                  message: 'Relay quote exceeded 3000ms deadline',
+                },
+              ],
+            },
+          },
+        ],
+      },
+      422,
+    )
+
+    expect(err).toBeInstanceOf(UnprocessableContentError)
+    expect(err.code).toBe('UNPROCESSABLE_CONTENT')
+    expect(err.statusCode).toBe(422)
+    expect(err.traceId).toBe('trace-unprocessable')
+    expect((err as UnprocessableContentError).details).toEqual([
+      {
+        message: 'No viable route found for this intent.',
+        context: {
+          code: 'NO_PLAN_AVAILABLE',
+          failureCodes: ['NO_ROUTE_SUPPORT', 'RELAY_FAILED'],
+          strategyFailures: [
+            {
+              strategy: 'StandardPlanStrategy',
+              code: 'NO_ROUTE_SUPPORT',
+              message: 'no route support',
+            },
+            {
+              strategy: 'RelayPlanStrategy',
+              code: 'RELAY_FAILED',
+              message: 'Relay quote exceeded 3000ms deadline',
+            },
+          ],
+        },
+      },
+    ])
+  })
+
+  test('defaults details to an empty array when missing or malformed', () => {
+    const withoutDetails = parseErrorEnvelope(
+      {
+        code: 'UNPROCESSABLE_CONTENT',
+        message: 'unprocessable',
+        traceId: '',
+      },
+      422,
+    ) as UnprocessableContentError
+
+    const malformedDetails = parseErrorEnvelope(
+      {
+        code: 'UNPROCESSABLE_CONTENT',
+        message: 'unprocessable',
+        traceId: '',
+        details: [
+          { context: { code: 'NO_PLAN_AVAILABLE' } },
+          { message: 123, context: { code: 'NO_PLAN_AVAILABLE' } },
+          'not-an-object',
+        ],
+      },
+      422,
+    ) as UnprocessableContentError
+
+    expect(withoutDetails.details).toEqual([])
+    expect(malformedDetails.details).toEqual([])
   })
 })
 

--- a/src/orchestrator/error.ts
+++ b/src/orchestrator/error.ts
@@ -22,6 +22,11 @@ interface ValidationIssue {
   context?: Record<string, unknown>
 }
 
+interface ErrorDetail {
+  message: string
+  context?: Record<string, unknown>
+}
+
 interface BaseErrorParams {
   message: string
   traceId?: string
@@ -180,8 +185,11 @@ class ConflictError extends OrchestratorError {
 }
 
 class UnprocessableContentError extends OrchestratorError {
-  constructor(params: BaseErrorParams) {
+  readonly details: ErrorDetail[]
+
+  constructor(params: BaseErrorParams & { details?: ErrorDetail[] }) {
     super({ ...params, code: 'UNPROCESSABLE_CONTENT' })
+    this.details = params.details ?? []
   }
 }
 
@@ -299,6 +307,26 @@ function booleanValue(value: unknown): boolean | undefined {
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {
   return isRecord(value) ? value : undefined
+}
+
+function parseErrorDetails(details: unknown): ErrorDetail[] {
+  if (!Array.isArray(details)) {
+    return []
+  }
+
+  return details.flatMap((detail): ErrorDetail[] => {
+    if (!isRecord(detail) || typeof detail.message !== 'string') {
+      return []
+    }
+
+    const context = recordValue(detail.context)
+    return [
+      {
+        message: detail.message,
+        ...(context ? { context } : {}),
+      },
+    ]
+  })
 }
 
 const SIMULATION_ACTIONS = ['claim', 'fill'] as const
@@ -477,7 +505,10 @@ function parseErrorEnvelope(
     case 'CONFLICT':
       return new ConflictError(base)
     case 'UNPROCESSABLE_CONTENT':
-      return new UnprocessableContentError(base)
+      return new UnprocessableContentError({
+        ...base,
+        details: parseErrorDetails(envelope.details),
+      })
     case 'TOO_MANY_REQUESTS':
       return new RateLimitedError({ ...base, retryAfter })
     case 'SETTLEMENT_QUOTE_ERROR':
@@ -603,6 +634,7 @@ function isConnectionError(error: unknown): boolean {
 
 export type {
   ErrorCode,
+  ErrorDetail,
   ErrorEnvelope,
   SimulationAction,
   SimulationCall,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -10,6 +10,7 @@ import {
   solanaMainnet,
   tronMainnet,
 } from './destinations'
+import type { ErrorDetail } from './error'
 import {
   ConflictError,
   ExternalServiceTimeoutError,
@@ -106,6 +107,7 @@ export type {
   Cost,
   CostTokenEntry,
   DestinationChain,
+  ErrorDetail,
   NonEvmAddress,
   NonEvmChain,
   EstimatedFillTime,


### PR DESCRIPTION
Deposit-service needs the structured planning context returned by orchestrator 422 responses to classify no-route failures accurately, but SDK v2 currently drops envelope.details when constructing UnprocessableContentError. That leaves callers with only the generic top-level message.

This change adds an ErrorDetail type, stores parsed details on UnprocessableContentError, and wires parseErrorEnvelope to preserve details for UNPROCESSABLE_CONTENT responses. Malformed or missing details safely normalize to an empty array, preserving the existing behavior for callers that do not inspect details.

A changeset is included because this expands the public error surface, and tests cover preserved and malformed details.