### PR TITLE
feat(cross-chain-permits): export toCrossChainPermissionInput

### DIFF
--- a/.changeset/cross-chain-permission-input-converter.md
+++ b/.changeset/cross-chain-permission-input-converter.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Export `toCrossChainPermissionInput` from `@rhinestone/sdk/smart-sessions`, which converts a resolved `CrossChainPermit` (unix-seconds deadlines, `recipientIsAccount`) back into the `CrossChainPermissionInput` shape accepted by `SessionDefinition.crossChainPermits` (`Date` deadlines, `allowRecipientNotAccount`). Useful when a permit was persisted in resolved form and has to be re-supplied as session input.

--- a/src/modules/validators/cross-chain-permits.test.ts
+++ b/src/modules/validators/cross-chain-permits.test.ts
@@ -1,7 +1,10 @@
 import type { Address } from 'viem'
 import { arbitrum, mainnet } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
-import { resolveCrossChainPermission } from './cross-chain-permits'
+import {
+  resolveCrossChainPermission,
+  toCrossChainPermissionInput,
+} from './cross-chain-permits'
 
 // Concrete addresses skip the TokenSymbol registry path so these tests stay
 // independent of shared-configs registry contents.
@@ -178,5 +181,58 @@ describe('resolveCrossChainPermission', () => {
       validAfter: new Date(0),
     })
     expect(permit.validAfter).toBe(0n)
+  })
+})
+
+describe('toCrossChainPermissionInput', () => {
+  test('round-trips a resolved permit back to input that re-resolves identically', () => {
+    const resolved = resolveCrossChainPermission({
+      from: { chain: mainnet, token: TOKEN_A, maxAmount: 1000n },
+      to: { chain: arbitrum, token: TOKEN_B, recipient: RECIPIENT },
+      validAfter: new Date('2025-01-01T00:00:00Z'),
+      validUntil: new Date('2030-01-01T00:00:00Z'),
+      settlementLayers: ['ECO'],
+    })
+    expect(
+      resolveCrossChainPermission(toCrossChainPermissionInput(resolved)),
+    ).toEqual(resolved)
+  })
+
+  test('converts unix-seconds deadlines back to Date', () => {
+    const validUntil = 1_900_000_000n
+    expect(toCrossChainPermissionInput({ validUntil }).validUntil).toEqual(
+      new Date(Number(validUntil) * 1000),
+    )
+  })
+
+  test('converts fillDeadline windows to Date', () => {
+    expect(
+      toCrossChainPermissionInput({
+        fillDeadline: [{ chain: arbitrum, min: 1_000n, max: 2_000n }],
+      }).fillDeadline,
+    ).toEqual([
+      { chain: arbitrum, min: new Date(1_000_000), max: new Date(2_000_000) },
+    ])
+  })
+
+  test('maps recipientIsAccount to the inverse allowRecipientNotAccount', () => {
+    expect(
+      toCrossChainPermissionInput({ recipientIsAccount: true })
+        .allowRecipientNotAccount,
+    ).toBe(false)
+    expect(
+      toCrossChainPermissionInput({ recipientIsAccount: false })
+        .allowRecipientNotAccount,
+    ).toBe(true)
+    expect(
+      toCrossChainPermissionInput({}).allowRecipientNotAccount,
+    ).toBeUndefined()
+  })
+
+  test('passes settlementLayers through and leaves omitted deadlines undefined', () => {
+    const input = toCrossChainPermissionInput({ settlementLayers: ['ACROSS'] })
+    expect(input.settlementLayers).toEqual(['ACROSS'])
+    expect(input.validUntil).toBeUndefined()
+    expect(input.validAfter).toBeUndefined()
   })
 })

--- a/src/modules/validators/cross-chain-permits.ts
+++ b/src/modules/validators/cross-chain-permits.ts
@@ -98,4 +98,46 @@ function resolveCrossChainPermission(
   }
 }
 
-export { resolveCrossChainPermission }
+function unixSecondsToDate(seconds: bigint): Date {
+  // Inverse of dateToUnixSeconds: on-chain deadlines are unix-seconds; Date
+  // expects milliseconds.
+  return new Date(Number(seconds) * 1000)
+}
+
+/**
+ * Convert a resolved {@link CrossChainPermit} back into the
+ * {@link CrossChainPermissionInput} shape accepted by
+ * `SessionDefinition.crossChainPermits`.
+ *
+ * Useful when a permit was persisted in its resolved (unix-seconds) form and
+ * has to be re-supplied as session input: converts `bigint` deadlines to
+ * `Date` and maps `recipientIsAccount` to the inverse `allowRecipientNotAccount`.
+ */
+function toCrossChainPermissionInput(
+  permit: CrossChainPermit,
+): CrossChainPermissionInput {
+  return {
+    from: permit.from,
+    to: permit.to,
+    validUntil:
+      permit.validUntil !== undefined
+        ? unixSecondsToDate(permit.validUntil)
+        : undefined,
+    validAfter:
+      permit.validAfter !== undefined
+        ? unixSecondsToDate(permit.validAfter)
+        : undefined,
+    fillDeadline: permit.fillDeadline?.map(({ chain, min, max }) => ({
+      chain,
+      min: min !== undefined ? unixSecondsToDate(min) : undefined,
+      max: max !== undefined ? unixSecondsToDate(max) : undefined,
+    })),
+    allowRecipientNotAccount:
+      permit.recipientIsAccount !== undefined
+        ? !permit.recipientIsAccount
+        : undefined,
+    settlementLayers: permit.settlementLayers,
+  }
+}
+
+export { resolveCrossChainPermission, toCrossChainPermissionInput }

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -3,6 +3,7 @@
 // and the smart-sessions actions; this barrel re-exports just the building blocks
 // integrators need directly.
 
+import { toCrossChainPermissionInput } from '../modules/validators/cross-chain-permits'
 import type {
   ChainDigest,
   SessionDetails,
@@ -37,6 +38,7 @@ export {
   getSessionData,
   getSessionDetails,
   isSessionEnabled,
+  toCrossChainPermissionInput,
   SPENDING_LIMITS_POLICY_ADDRESS,
   TIME_FRAME_POLICY_ADDRESS,
   SUDO_POLICY_ADDRESS,


### PR DESCRIPTION
Adds `toCrossChainPermissionInput` — the inverse of the internal `resolveCrossChainPermission`.

It converts a **resolved** `CrossChainPermit` (unix-seconds `bigint` deadlines, `recipientIsAccount`) back into the **input** shape `CrossChainPermissionInput` (`Date` deadlines, `allowRecipientNotAccount`) accepted by `SessionDefinition.crossChainPermits`.

### Why
Integrators that persist a permit in its resolved form (e.g. in a session-key handle) and later re-supply it to `toSession` previously couldn't: since beta.30's datetime normalization, `toSession` takes only the input shape, and feeding a resolved permit fails at runtime (`dateToUnixSeconds` calls `.getTime()` on a `bigint`; `recipientIsAccount` is silently ignored). This is the canonical single converter for that round-trip.

Concretely this lets 1auth (passkey + `@rhinestone/1auth`) drop two duplicated local copies of the same mapping and import one shared definition.

### Surface
Exported from the **`@rhinestone/sdk/smart-sessions`** subpath, alongside `toSession` which consumes it (the cross-chain permit is a session-input concern). New unit tests cover round-trip equivalence, `bigint→Date`, the `recipientIsAccount` inversion, `fillDeadline`, and pass-through. `build`, `typecheck`, `test:types`, and `biome check` (2.1.0) all green.