### PR TITLE
[RHI-4560] feat: use canonical hypercore:mainnet CAIP-2 for HyperCore

### DIFF
--- a/.changeset/hypercore-caip2-mainnet.md
+++ b/.changeset/hypercore-caip2-mainnet.md
@@ -1,0 +1,12 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Use `hypercore:mainnet` as the canonical CAIP-2 id for the HyperCore destination instead of `eip155:1337` (RHI-4560), and source the CAIP-2 ↔ chain-id mapping from `@rhinestone/shared-configs`.
+
+The orchestrator (shared-configs ≥ 1.6.14) now emits `hypercore:mainnet` for HyperCore — `eip155:1337` was semantically wrong (1337 is the Hardhat/Ganache local chain id). Changes:
+
+- `hyperCoreMainnet.caip2` is `'hypercore:mainnet'`.
+- `caip2.ts` now delegates `toCaip2` / `fromCaip2` / `isNonEvmChainId` to the shared-configs registry instead of maintaining its own hardcoded namespace tables. This removes the SDK↔orchestrator drift risk (both now read the same source) and means new chains are a shared-configs registry entry, not a hand-maintained table in each repo. `fromCaip2` still accepts legacy `eip155:1337` for back-compat.
+
+HyperCore stays EVM-addressed: it's a `virtual` (`vmType: 'evm'`) registry entry, so `isNonEvmChainId(1337) === false` and its EVM token/recipient handling is unchanged. Bumps `@rhinestone/shared-configs` to 1.6.15.

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,9 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "^1.6.7",
+        "@rhinestone/shared-configs": "^1.6.15",
         "viem": "^2.40.1",
       },
       "devDependencies": {
@@ -26,9 +25,9 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "2.0.0-beta.28",
+      "version": "2.0.0-beta.33",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.6.7",
+        "@rhinestone/shared-configs": "1.6.15",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -179,7 +178,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.7", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-QV3ofrvc5kJpysk/g3mTE2WgMutmCdEu4kWNjMMbrDPVWe2QQDEiKpfi34YmFg8UoF6HULbmNUbhn/BniO0Xgw=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.15", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-hVVVRXUJktnss+aVyi+RlOqadIQ7VHvW0TrjVSFwswyZlpPgC+qj4ug57cfh5puB6n3Vmx3AkVR/j25HVqG7aA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "^1.6.7",
+    "@rhinestone/shared-configs": "^1.6.15",
     "viem": "^2.40.1"
   },
   "devDependencies": {

--- a/src/orchestrator/caip2.test.ts
+++ b/src/orchestrator/caip2.test.ts
@@ -22,6 +22,10 @@ describe('toCaip2', () => {
     expect(toCaip2(728126428)).toBe('tron:0x2b6653dc')
   })
 
+  test('encodes HyperCore virtual id to its canonical CAIP-2 (not eip155:1337)', () => {
+    expect(toCaip2(1337)).toBe('hypercore:mainnet')
+  })
+
   test('rejects negative or non-integer ids', () => {
     expect(() => toCaip2(-1)).toThrow()
     expect(() => toCaip2(1.5)).toThrow()
@@ -42,6 +46,14 @@ describe('fromCaip2', () => {
     expect(fromCaip2('tron:0x2b6653dc')).toBe(728126428)
   })
 
+  test('decodes canonical HyperCore CAIP-2 to virtual id 1337', () => {
+    expect(fromCaip2('hypercore:mainnet')).toBe(1337)
+  })
+
+  test('still decodes legacy eip155:1337 to 1337 (back-compat)', () => {
+    expect(fromCaip2('eip155:1337')).toBe(1337)
+  })
+
   test('rejects unknown namespaces', () => {
     expect(() => fromCaip2('cosmos:cosmoshub-4')).toThrow()
   })
@@ -52,7 +64,7 @@ describe('fromCaip2', () => {
 })
 
 describe('round-trip', () => {
-  test.each([1, 8453, 42161, 792703809, 728126428])(
+  test.each([1, 8453, 42161, 792703809, 728126428, 1337])(
     'id %d round-trips through CAIP-2',
     (id) => {
       expect(fromCaip2(toCaip2(id))).toBe(id)
@@ -65,14 +77,16 @@ describe('isCaip2 / isEvmCaip2', () => {
     expect(isCaip2('eip155:1')).toBe(true)
     expect(isCaip2('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')).toBe(true)
     expect(isCaip2('tron:0x2b6653dc')).toBe(true)
+    expect(isCaip2('hypercore:mainnet')).toBe(true)
     expect(isCaip2('cosmos:cosmoshub-4')).toBe(false)
     expect(isCaip2('not-a-caip2')).toBe(false)
   })
 
-  test('isEvmCaip2 only matches eip155', () => {
+  test('isEvmCaip2 only matches eip155 (not hypercore)', () => {
     expect(isEvmCaip2('eip155:1')).toBe(true)
     expect(isEvmCaip2('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')).toBe(false)
     expect(isEvmCaip2('tron:0x2b6653dc')).toBe(false)
+    expect(isEvmCaip2('hypercore:mainnet')).toBe(false)
   })
 })
 
@@ -85,5 +99,12 @@ describe('isNonEvmChainId', () => {
   test('rejects EVM chain ids', () => {
     expect(isNonEvmChainId(1)).toBe(false)
     expect(isNonEvmChainId(42161)).toBe(false)
+  })
+
+  test('treats HyperCore (1337) as EVM despite its non-eip155 namespace', () => {
+    // The decoupling invariant: hypercore:mainnet is a non-eip155 wire id, but
+    // HyperCore stays EVM-addressed, so isNonEvmChainId(1337) must be false
+    // (registry.ts / execution/utils.ts rely on this).
+    expect(isNonEvmChainId(1337)).toBe(false)
   })
 })

--- a/src/orchestrator/caip2.ts
+++ b/src/orchestrator/caip2.ts
@@ -1,64 +1,69 @@
-// CAIP-2 wire format. Mirrors the orchestrator's caip2.ts namespace registry
-// — Solana / Tron synthetic numeric ids round-trip through the same CAIP-2
-// strings the orchestrator emits, so the SDK and orchestrator agree on the
-// wire shape without needing the user to think about CAIP-2 themselves.
+// CAIP-2 wire format. The namespace ↔ numeric-id mapping is owned by
+// `@rhinestone/shared-configs` (the same source the orchestrator uses), so the
+// SDK and orchestrator can't drift on the wire shape — adding a chain is a
+// shared-configs registry entry, not a hand-maintained table in each repo.
+// HyperCore is a first-class `virtual` registry entry there: its canonical id
+// is `hypercore:mainnet` (EVM-settled, so `isNonEvmChainId(1337) === false`).
 //
 // Spec: https://chainagnostic.org/CAIPs/caip-2
+
+import {
+  chainIdFromCaip2,
+  getCaip2,
+  isNonEvmChainId as isNonEvmChainIdFromRegistry,
+} from '@rhinestone/shared-configs'
 
 type EvmCaip2ChainId = `eip155:${number}`
 type SolanaCaip2ChainId = `solana:${string}`
 type TronCaip2ChainId = `tron:${string}`
-type Caip2ChainId = EvmCaip2ChainId | SolanaCaip2ChainId | TronCaip2ChainId
+type HyperCoreCaip2ChainId = 'hypercore:mainnet'
+type Caip2ChainId =
+  | EvmCaip2ChainId
+  | SolanaCaip2ChainId
+  | TronCaip2ChainId
+  | HyperCoreCaip2ChainId
 
 const EIP155_CAIP2_REGEX = /^eip155:\d+$/
-const NON_EIP155_CAIP2_REGEX = /^(?:solana|tron):[-_a-zA-Z0-9]{1,32}$/
-
-// Synthetic numeric ids ↔ CAIP-2 strings for non-eip155 chains. Must match
-// the orchestrator's NON_EIP155_CAIP2_TO_ID exactly — these flow over the
-// wire and any drift would cause routing failures.
-const NON_EIP155_ID_TO_CAIP2: Record<number, Caip2ChainId> = {
-  792703809: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-  728126428: 'tron:0x2b6653dc',
-}
-const NON_EIP155_CAIP2_TO_ID: Record<string, number> = Object.fromEntries(
-  Object.entries(NON_EIP155_ID_TO_CAIP2).map(([id, caip2]) => [
-    caip2,
-    Number(id),
-  ]),
-)
 
 function toCaip2(chainId: number): Caip2ChainId {
   if (!Number.isInteger(chainId) || chainId < 0) {
     throw new Error(`Invalid chain id: ${chainId}`)
   }
-  const nonEvm = NON_EIP155_ID_TO_CAIP2[chainId]
-  if (nonEvm) return nonEvm
-  return `eip155:${chainId}`
+  // `getCaip2` returns the registry-declared caip2 (Solana/Tron/HyperCore) or
+  // the `eip155:<id>` fallback for plain EVM chains.
+  return getCaip2(chainId) as Caip2ChainId
 }
 
 function fromCaip2(chainId: string): number {
+  // eip155 references aren't registry-backed (they compose programmatically),
+  // so parse them numerically here. This also keeps accepting the legacy
+  // `eip155:1337` HyperCore id for back-compat.
   if (EIP155_CAIP2_REGEX.test(chainId)) {
     return Number(chainId.slice('eip155:'.length))
   }
-  if (NON_EIP155_CAIP2_REGEX.test(chainId)) {
-    const id = NON_EIP155_CAIP2_TO_ID[chainId]
-    if (id !== undefined) return id
-  }
+  const id = chainIdFromCaip2(chainId)
+  if (id !== undefined) return id
   throw new Error(`Invalid CAIP-2 chain id: ${chainId}`)
 }
 
 function isCaip2(chainId: string): chainId is Caip2ChainId {
   if (EIP155_CAIP2_REGEX.test(chainId)) return true
-  return chainId in NON_EIP155_CAIP2_TO_ID
+  return chainIdFromCaip2(chainId) !== undefined
 }
 
 function isEvmCaip2(chainId: string): chainId is EvmCaip2ChainId {
   return EIP155_CAIP2_REGEX.test(chainId)
 }
 
-/** True when a numeric chain id corresponds to a known non-eip155 namespace. */
+/**
+ * True when a numeric chain id is genuinely non-EVM (Solana / Tron). HyperCore
+ * (1337) is EVM-settled, so this is `false` for it even though its wire id is
+ * the non-eip155 `hypercore:mainnet` namespace — `registry.ts` /
+ * `execution/utils.ts` rely on HyperCore being EVM-classified here. Sourced
+ * from the shared-configs registry `vmType`.
+ */
 function isNonEvmChainId(chainId: number): boolean {
-  return chainId in NON_EIP155_ID_TO_CAIP2
+  return isNonEvmChainIdFromRegistry(chainId)
 }
 
 export type {
@@ -66,5 +71,6 @@ export type {
   EvmCaip2ChainId,
   SolanaCaip2ChainId,
   TronCaip2ChainId,
+  HyperCoreCaip2ChainId,
 }
 export { fromCaip2, isCaip2, isEvmCaip2, isNonEvmChainId, toCaip2 }

--- a/src/orchestrator/destinations.test.ts
+++ b/src/orchestrator/destinations.test.ts
@@ -38,8 +38,11 @@ describe('getChainId', () => {
 })
 
 describe('hyperCoreMainnet descriptor', () => {
-  test('is an EVM-settled virtual destination addressed by eip155:1337', () => {
+  test('is an EVM-settled virtual destination with the canonical hypercore:mainnet id', () => {
     expect(hyperCoreMainnet.kind).toBe('hypercore')
-    expect(hyperCoreMainnet.caip2).toBe('eip155:1337')
+    // Canonical CAIP-2 (RHI-4560) — no longer the wrong eip155:1337. Still
+    // resolves to the numeric virtual id 1337.
+    expect(hyperCoreMainnet.caip2).toBe('hypercore:mainnet')
+    expect(getChainId(hyperCoreMainnet)).toBe(1337)
   })
 })

--- a/src/orchestrator/destinations.ts
+++ b/src/orchestrator/destinations.ts
@@ -61,11 +61,15 @@ const tronMainnet: NonEvmChain = {
 // and Tron it settles on an EVM chain (HyperEVM, 999), but the deposit is
 // solver-mediated: the orchestrator builds the core-deposit executions and the
 // user signs no destination session, so it belongs with the descriptor-addressed
-// destinations rather than the standard EVM signing path. The CAIP-2 reference
-// is the virtual id; the orchestrator maps 1337 → 999 for settlement.
+// destinations rather than the standard EVM signing path. The canonical CAIP-2
+// id is `hypercore:mainnet` (the orchestrator emits this since shared-configs
+// 1.6.14 / RHI-4560; `eip155:1337` was wrong because 1337 is the
+// Hardhat/Ganache local chain id). It still resolves to the numeric virtual id
+// 1337, which the orchestrator maps to 999 for settlement; HyperCore stays
+// EVM-addressed (`isNonEvmChainId(1337) === false`).
 const hyperCoreMainnet: NonEvmChain = {
   name: 'HyperCore',
-  caip2: 'eip155:1337',
+  caip2: 'hypercore:mainnet',
   kind: 'hypercore',
   nativeCurrency: { name: 'Hyperliquid', symbol: 'HYPE', decimals: 18 },
 }

--- a/src/package.json
+++ b/src/package.json
@@ -75,7 +75,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.6.7",
+    "@rhinestone/shared-configs": "1.6.15",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
## What

SDK side of **RHI-4560**: adopt HyperCore's canonical CAIP-2 id `hypercore:mainnet` (replacing `eip155:1337`), and **source the CAIP-2 ↔ chain-id mapping from `@rhinestone/shared-configs`** instead of a hand-maintained table.

The orchestrator (shared-configs ≥ 1.6.14) now emits `hypercore:mainnet` — `eip155:1337` was semantically wrong (1337 is the Hardhat/Ganache local chain id).

## Approach: delegate, don't duplicate

`caip2.ts` previously kept its own hardcoded `NON_EIP155_*` namespace tables with a comment warning they *"must match the orchestrator's exactly — any drift would cause routing failures."* Rather than add HyperCore as a second hand-maintained table, this PR **deletes the hardcoded maps** and delegates to shared-configs:

- `toCaip2` → `getCaip2`, `fromCaip2` → eip155-numeric else `chainIdFromCaip2`, `isNonEvmChainId` → shared-configs `isNonEvmChainId`.
- HyperCore needs **zero special-casing** — it's a first-class `virtual` (`vmType: 'evm'`) registry entry upstream, so `getCaip2(1337) → hypercore:mainnet`, `chainIdFromCaip2('hypercore:mainnet') → 1337`, `isNonEvmChainId(1337) → false` all come from registry data.
- The SDK and orchestrator now read the **same source** → no wire drift; new chains are a shared-configs entry, not a table edit in each repo.
- `fromCaip2` still accepts legacy `eip155:1337` for back-compat.
- `Caip2ChainId` TS union gains `'hypercore:mainnet'` (SDK-public type, kept).

## Changes

- `destinations.ts` — `hyperCoreMainnet.caip2`: `'eip155:1337'` → `'hypercore:mainnet'`.
- `caip2.ts` — net deletion of the hardcoded maps; delegate to shared-configs.
- Bump `@rhinestone/shared-configs` `1.6.7 → 1.6.15`.
- Changeset (minor).

## Invariant

`isNonEvmChainId(1337)` stays **`false`** (HyperCore is EVM-settled) — `registry.ts` resolves its tokens via the EVM path and `execution/utils.ts` routes its recipients through the EVM/EOA passthrough; both have comments depending on this. The `kind`-based `isNonEvmChain` (solver-mediated routing) is untouched.

## Verification

- `caip2.test.ts` + `destinations.test.ts`: **29 pass** — the *same* tests pass against the delegated impl, proving behavior-equivalence (incl. dual-inbound `hypercore:mainnet`/`eip155:1337`, round-trip, `isNonEvmChainId(1337) === false`).
- Full suite: 441 pass; Solana/Tron now sourced from shared-configs with **no regressions** (1 pre-existing `index.test.ts`/`signIntent` failure on clean `release`, unrelated).
- `tsc --noEmit` + `biome check`: clean.
- **Verified end-to-end against orchestrator dev**: `hypercore:mainnet` routes byte-identically to `eip155:1337` (ACROSS → HyperEVM 999, CoreDepositWallet `depositFor`).

Closes RHI-4560

🤖 Generated with [Claude Code](https://claude.com/claude-code)