### PR TITLE
feat(orchestrator): use tron:mainnet as Tron's canonical CAIP-2

### DIFF
--- a/.changeset/tron-caip2-mainnet.md
+++ b/.changeset/tron-caip2-mainnet.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Use `tron:mainnet` as Tron's canonical CAIP-2 (was `tron:0x2b6653dc`).
+
+Updates the hardcoded `tronMainnet` destination descriptor and bumps `@rhinestone/shared-configs` to `^1.7.0`, so `toCaip2(728126428)` / `fromCaip2('tron:mainnet')` resolve via the registry. Hard cutover: `tron:0x2b6653dc` no longer resolves. Requires shared-configs ≥ 1.7.0.

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
       "name": "@rhinestone/sdk",
       "version": "2.0.0-beta.33",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.6.15",
+        "@rhinestone/shared-configs": "1.7.0",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -689,8 +689,6 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
-
-    "@rhinestone/sdk/@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.15", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-hVVVRXUJktnss+aVyi+RlOqadIQ7VHvW0TrjVSFwswyZlpPgC+qj4ug57cfh5puB6n3Vmx3AkVR/j25HVqG7aA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "^1.6.15",
+        "@rhinestone/shared-configs": "^1.7.0",
         "viem": "^2.40.1",
       },
       "devDependencies": {
@@ -178,7 +178,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.15", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-hVVVRXUJktnss+aVyi+RlOqadIQ7VHvW0TrjVSFwswyZlpPgC+qj4ug57cfh5puB6n3Vmx3AkVR/j25HVqG7aA=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.0", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-Jm3lIQyRs7lvIwuRadwwvAEY2rleJLadpm6amLPvRVzPkOY33+zqBG3Q+A0HroyN3Wt2SIAq8QLyGRs5pKSA8Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 
@@ -689,6 +689,8 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "@rhinestone/sdk/@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.6.15", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-hVVVRXUJktnss+aVyi+RlOqadIQ7VHvW0TrjVSFwswyZlpPgC+qj4ug57cfh5puB6n3Vmx3AkVR/j25HVqG7aA=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "^1.6.15",
+    "@rhinestone/shared-configs": "^1.7.0",
     "viem": "^2.40.1"
   },
   "devDependencies": {

--- a/src/orchestrator/caip2.test.ts
+++ b/src/orchestrator/caip2.test.ts
@@ -19,7 +19,7 @@ describe('toCaip2', () => {
   })
 
   test('encodes Tron synthetic id to its CAIP-2 string', () => {
-    expect(toCaip2(728126428)).toBe('tron:0x2b6653dc')
+    expect(toCaip2(728126428)).toBe('tron:mainnet')
   })
 
   test('encodes HyperCore virtual id to its canonical CAIP-2 (not eip155:1337)', () => {
@@ -43,7 +43,7 @@ describe('fromCaip2', () => {
   })
 
   test('decodes tron CAIP-2 to synthetic id', () => {
-    expect(fromCaip2('tron:0x2b6653dc')).toBe(728126428)
+    expect(fromCaip2('tron:mainnet')).toBe(728126428)
   })
 
   test('decodes canonical HyperCore CAIP-2 to virtual id 1337', () => {
@@ -76,7 +76,7 @@ describe('isCaip2 / isEvmCaip2', () => {
   test('isCaip2 accepts all supported namespaces', () => {
     expect(isCaip2('eip155:1')).toBe(true)
     expect(isCaip2('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')).toBe(true)
-    expect(isCaip2('tron:0x2b6653dc')).toBe(true)
+    expect(isCaip2('tron:mainnet')).toBe(true)
     expect(isCaip2('hypercore:mainnet')).toBe(true)
     expect(isCaip2('cosmos:cosmoshub-4')).toBe(false)
     expect(isCaip2('not-a-caip2')).toBe(false)
@@ -85,7 +85,7 @@ describe('isCaip2 / isEvmCaip2', () => {
   test('isEvmCaip2 only matches eip155 (not hypercore)', () => {
     expect(isEvmCaip2('eip155:1')).toBe(true)
     expect(isEvmCaip2('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')).toBe(false)
-    expect(isEvmCaip2('tron:0x2b6653dc')).toBe(false)
+    expect(isEvmCaip2('tron:mainnet')).toBe(false)
     expect(isEvmCaip2('hypercore:mainnet')).toBe(false)
   })
 })

--- a/src/orchestrator/destinations.ts
+++ b/src/orchestrator/destinations.ts
@@ -52,7 +52,7 @@ const solanaMainnet: NonEvmChain = {
 
 const tronMainnet: NonEvmChain = {
   name: 'Tron',
-  caip2: 'tron:0x2b6653dc',
+  caip2: 'tron:mainnet',
   kind: 'tvm',
   nativeCurrency: { name: 'Tron', symbol: 'TRX', decimals: 6 },
 }

--- a/src/package.json
+++ b/src/package.json
@@ -75,7 +75,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.6.15",
+    "@rhinestone/shared-configs": "1.7.0",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
> **Draft — blocked on [rhinestonewtf/yeet#195](https://github.com/rhinestonewtf/yeet/pull/195) publishing `@rhinestone/shared-configs@1.7.0`.** Mark ready once that's on npm and the lockfile resolves.

## What

- `tronMainnet` destination descriptor: `caip2` `tron:0x2b6653dc` → **`tron:mainnet`** (hardcoded literal — required).
- `caip2.test.ts`: `toCaip2`/`fromCaip2`/`isCaip2` Tron assertions updated (these derive from shared-configs).
- Bump `@rhinestone/shared-configs` floor to `^1.7.0` (the version that emits `tron:mainnet`).

## Why

Part of the org-wide standardization of Tron's CAIP-2 on `tron:mainnet` (the form deposit-service + dashboard already use; mirrors `hypercore:mainnet` from RHI-4560). Root change: yeet#195.

## Breaking — hard cutover

`fromCaip2('tron:0x2b6653dc')` / `isCaip2('tron:0x2b6653dc')` no longer resolve. No Tron traffic on the orchestrator in prod today, so no live intents affected.

## Verification

Overlaid a local `shared-configs@1.7.0` build (simulating the unpublished dep): **`caip2.test.ts` 23/23 pass**, **`tsc --noEmit` clean**. Full CI goes green once 1.7.0 is published.

## Release order

yeet#195 (publish 1.7.0) → **this** (bump dep, publish beta) → orchestrator + deposit-service.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>