### PR TITLE
fix(startale): derive EIP-712 domain for adopted accounts

### DIFF
--- a/.changeset/startale-adopted-eip712-domain.md
+++ b/.changeset/startale-adopted-eip712-domain.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Allow Startale accounts adopted via `initData` to sign intents: `getEip712Domain` no longer throws for existing accounts and derives the domain from `getAddress(config)`.

--- a/src/accounts/startale.ts
+++ b/src/accounts/startale.ts
@@ -20,10 +20,7 @@ import type {
   RhinestoneAccountConfig,
   StartaleAccount,
 } from '../types'
-import {
-  AccountConfigurationNotSupportedError,
-  Eip712DomainNotAvailableError,
-} from './error'
+import { AccountConfigurationNotSupportedError } from './error'
 import {
   getInstallData as getNexusInstallData,
   getSmartAccount as getNexusSmartAccount,
@@ -237,11 +234,9 @@ function getAddress(config: RhinestoneAccountConfig) {
 }
 
 function getEip712Domain(config: RhinestoneAccountConfig, chain: Chain) {
-  if (config.initData) {
-    throw new Eip712DomainNotAvailableError(
-      'Existing Startale accounts are not yet supported',
-    )
-  }
+  // Works for adopted accounts too: getAddress resolves the initData cases
+  // (returns initData.address, or recomputes the CREATE2 address from
+  // initData.factory/factoryData).
   return {
     name: 'Startale',
     version: STARTALE_VERSION,


### PR DESCRIPTION
Backport of #583 to the v2 line.

On `release`, `getEip712Domain` (`src/accounts/startale.ts`) still threw `Eip712DomainNotAvailableError` whenever `config.initData` was set, blocking K1-validated adopted Startale accounts from signing intents. It now derives the domain from `getAddress(config)` for adopted accounts too, matching v1.

Closes [RHI-4629](https://linear.app/rhinestone/issue/RHI-4629)