### PR TITLE
fix(startale): skip K1 default validator in setup()

### DIFF
--- a/.changeset/startale-setup-skip-default-validator.md
+++ b/.changeset/startale-setup-skip-default-validator.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `setup()` reverting on Startale K1 accounts: skip the built-in K1 default validator so only genuinely missing modules (e.g. the intent executor) are installed.

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -8,6 +8,7 @@ import {
   type HashTypedDataParameters,
   type Hex,
   hashTypedData,
+  isAddressEqual,
   type PublicClient,
   size,
   type TypedData,
@@ -99,6 +100,7 @@ import {
   getInstallData as getStartaleInstallData,
   getSmartAccount as getStartaleSmartAccount,
   packSignature as packStartaleSignature,
+  K1_DEFAULT_VALIDATOR_ADDRESS as STARTALE_K1_VALIDATOR_ADDRESS,
 } from './startale'
 import {
   createTransport,
@@ -710,7 +712,16 @@ async function setup(config: RhinestoneConfig, chain: Chain): Promise<boolean> {
     ...modules.executors,
     ...modules.fallbacks,
     ...modules.hooks,
-  ]
+  ].filter(
+    // Startale's K1 validator is the account's built-in default validator, set
+    // at deployment — it is never a regular 7579 module, so isModuleInstalled
+    // reports false and trying to install it reverts. Skip it.
+    (module) =>
+      !(
+        account.type === 'startale' &&
+        isAddressEqual(module.address, STARTALE_K1_VALIDATOR_ADDRESS)
+      ),
+  )
   // Check if the modules are already installed
   const installedResults = await publicClient.multicall({
     contracts: allModules.map((module) => ({


### PR DESCRIPTION
Backport of #584 to the v2 line.

On `release`, `setup()` (`src/accounts/index.ts`) still tried to install the Startale K1 default validator as a regular 7579 module, which reverts (`0xabc3af79`). The K1 validator is the account's built-in default validator (set at deployment), so `isModuleInstalled` reports false and installing it reverts. It's now skipped when gathering modules to install, matching v1.

Closes [RHI-4630](https://linear.app/rhinestone/issue/RHI-4630)