### PR TITLE
feat: custom module override for passkey & MFA validators

### DIFF
--- a/.changeset/validator-module-overrides.md
+++ b/.changeset/validator-module-overrides.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': major
+---
+
+Support custom module address overrides for the passkey and multi-factor validators via `owners.module`. Removed the inert `module` override from the ENS validator, whose address is fixed by the HCA account implementation.

--- a/src/accounts/signing/common.ts
+++ b/src/accounts/signing/common.ts
@@ -49,7 +49,7 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
         type: 'owner',
         kind: 'ecdsa',
         accounts: owners.owners.map((o) => o.account),
-        module: owners.module ?? ENS_HCA_MODULE,
+        module: ENS_HCA_MODULE,
       }
     }
     case 'passkey': {
@@ -79,7 +79,7 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
                 type: 'ecdsa',
                 id: index,
                 accounts: validator.owners.map((o) => o.account),
-                module: validator.module ?? ENS_HCA_MODULE,
+                module: ENS_HCA_MODULE,
               }
             }
             case 'passkey': {
@@ -97,6 +97,7 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
             }
           }
         }),
+        module: owners.module,
       }
     }
   }

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -1793,11 +1793,12 @@ function getValidator(
           pubKey: account.publicKey,
           authenticatorId: account.id,
         })),
+        withOwner.module,
       )
     }
     // Multi-factor
     if (withOwner.kind === 'multi-factor') {
-      return getMultiFactorValidator(1, withOwner.validators)
+      return getMultiFactorValidator(1, withOwner.validators, withOwner.module)
     }
   }
 

--- a/src/modules/validators/core.test.ts
+++ b/src/modules/validators/core.test.ts
@@ -73,6 +73,45 @@ describe('Validators Core', () => {
         '0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001580a9af0569ad3905b26a703201b358aa0904236642ebe79b22a19d00d3737637d46f725a5427ae45a9569259bf67e1e16b187d7b3ad1ed70138c4f0409677d10000000000000000000000000000000000000000000000000000000000000000',
       )
     })
+
+    const customModule = '0x00000000000000000000000000000000deadbeef'
+
+    test('ECDSA: custom module override', () => {
+      const validator = getValidator({
+        type: 'ecdsa',
+        accounts: [accountA],
+        module: customModule,
+      })
+      expect(validator.address).toEqual(customModule)
+    })
+
+    test('Passkey: custom module override', () => {
+      const validator = getValidator({
+        type: 'passkey',
+        accounts: [passkeyAccount],
+        module: customModule,
+      })
+      expect(validator.address).toEqual(customModule)
+    })
+
+    test('Multi-factor: default module', () => {
+      const validator = getValidator({
+        type: 'multi-factor',
+        validators: [{ type: 'ecdsa', accounts: [accountA] }],
+      })
+      expect(validator.address).toEqual(
+        '0xf6bdf42c9be18ceca5c06c42a43daf7fbbe7896b',
+      )
+    })
+
+    test('Multi-factor: custom module override', () => {
+      const validator = getValidator({
+        type: 'multi-factor',
+        validators: [{ type: 'ecdsa', accounts: [accountA] }],
+        module: customModule,
+      })
+      expect(validator.address).toEqual(customModule)
+    })
   })
 
   describe('Mock Signature', () => {
@@ -157,19 +196,6 @@ describe('Validators Core', () => {
                 owners: [{ account: accountA }],
               },
             ],
-          },
-        }),
-      ).toThrow(AccountConfigurationNotSupportedError)
-    })
-
-    test('HCA rejects a custom ENS owners.module', () => {
-      expect(() =>
-        getOwnerValidator({
-          account: { type: 'hca' },
-          owners: {
-            type: 'ens',
-            owners: [{ account: accountA }],
-            module: '0x00000000000000000000000000000000deadbeef',
           },
         }),
       ).toThrow(AccountConfigurationNotSupportedError)

--- a/src/modules/validators/core.ts
+++ b/src/modules/validators/core.ts
@@ -85,20 +85,6 @@ function getOwnerValidator(config: RhinestoneAccountConfig) {
       config.account?.type ?? 'nexus',
     )
   }
-  // HCA accounts use the ENS validator baked into the implementation; a custom
-  // owners.module would never be installed yet would drive signing/nonce
-  // selection, producing signatures for a validator the account does not have.
-  if (
-    config.account?.type === 'hca' &&
-    config.owners.type === 'ens' &&
-    config.owners.module &&
-    config.owners.module.toLowerCase() !== ENS_HCA_MODULE.toLowerCase()
-  ) {
-    throw new AccountConfigurationNotSupportedError(
-      'HCA accounts do not support a custom ENS owners.module',
-      'hca',
-    )
-  }
   return getValidator(config.owners)
 }
 
@@ -167,11 +153,12 @@ function getValidator(owners: OwnerSet) {
         owners.module,
       )
     case 'ens':
+      // ENS validation is baked into the HCA account implementation, so the
+      // module address is fixed (no override).
       return getENSValidator(
         owners.threshold ?? 1,
         owners.owners.map((o) => o.account.address),
         owners.owners.map((o) => o.expiration),
-        owners.module,
       )
     case 'passkey':
       return getWebAuthnValidator(
@@ -180,9 +167,14 @@ function getValidator(owners: OwnerSet) {
           pubKey: account.publicKey,
           authenticatorId: account.id,
         })),
+        owners.module,
       )
     case 'multi-factor': {
-      return getMultiFactorValidator(owners.threshold ?? 1, owners.validators)
+      return getMultiFactorValidator(
+        owners.threshold ?? 1,
+        owners.validators,
+        owners.module,
+      )
     }
   }
 }
@@ -214,7 +206,6 @@ function getENSValidator(
   threshold: number,
   owners: Address[],
   expirations: (Date | undefined)[],
-  address?: Address,
 ): Module {
   // format: (uint256 threshold, Owner[] owners)
   // where Owner is a tuple of (address addr, uint48 expiration)
@@ -252,10 +243,8 @@ function getENSValidator(
     [BigInt(threshold), ownersWithExpiration],
   )
 
-  const moduleAddress = address ?? ENS_HCA_MODULE
-
   return {
-    address: moduleAddress,
+    address: ENS_HCA_MODULE,
     initData,
     deInitData: '0x',
     additionalContext: '0x',
@@ -337,9 +326,10 @@ function getMultiFactorValidator(
     | WebauthnValidatorConfig
     | null
   )[],
+  address?: Address,
 ): Module {
   return {
-    address: MULTI_FACTOR_VALIDATOR_ADDRESS,
+    address: address ?? MULTI_FACTOR_VALIDATOR_ADDRESS,
     initData: encodePacked(
       ['uint8', 'bytes'],
       [

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,6 @@ interface ENSValidatorConfig {
   /** Each owner with an optional expiry. Omit `expiration` to never expire. */
   owners: { account: Account; expiration?: Date }[]
   threshold?: number
-  module?: Address
 }
 
 interface WebauthnValidatorConfig {


### PR DESCRIPTION
Backport of #571 to the v2 line.

On `release`, only the ECDSA (Ownable) validator honored the `owners.module` override — the passkey and multi-factor validators advertised the field but ignored it. This wires `owners.module` through both (signing + execution paths) and adds an `address?` param to `getMultiFactorValidator`.

Also removes the inert `module` override from the ENS validator (its address is fixed by the HCA account implementation) along with the now-redundant HCA guard, matching v1.

Breaking — removes `ENSValidatorConfig.module` from the public surface → major changeset.

Closes [RHI-4631](https://linear.app/rhinestone/issue/RHI-4631)