### PR TITLE
feat(hca): support custom factory via account config

### DIFF
--- a/.changeset/hca-custom-factory.md
+++ b/.changeset/hca-custom-factory.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Support a custom HCA factory via `account.factory`, which defines the deploy address and, through its implementation, the account's default validator.

--- a/src/accounts/hca.test.ts
+++ b/src/accounts/hca.test.ts
@@ -177,6 +177,19 @@ describe('Accounts: HCA', () => {
       })
       expect(result).toBeNull()
     })
+
+    test('custom factory overrides the deploy target', () => {
+      const customFactory: Address =
+        '0x00000000000000000000000000000000c0ffee00'
+      const result = getDeployArgs({
+        account: { type: 'hca', factory: customFactory },
+        owners: {
+          type: 'ens',
+          owners: [{ account: accountA }],
+        },
+      })
+      expect(result?.factory).toEqual(customFactory)
+    })
   })
 
   describe('Get Address', () => {
@@ -200,6 +213,22 @@ describe('Accounts: HCA', () => {
         },
       })
       expect(address).toEqual(address2)
+    })
+
+    test('Custom factory produces a different address', () => {
+      const owners = {
+        type: 'ens' as const,
+        owners: [{ account: accountA }],
+      }
+      const address = getAddress({ account: { type: 'hca' }, owners })
+      const customAddress = getAddress({
+        account: {
+          type: 'hca',
+          factory: '0x00000000000000000000000000000000c0ffee00',
+        },
+        owners,
+      })
+      expect(customAddress).not.toEqual(address)
     })
 
     test('Different primary owners produce different addresses', () => {

--- a/src/accounts/hca.ts
+++ b/src/accounts/hca.ts
@@ -58,6 +58,11 @@ function getDeployArgs(config: RhinestoneAccountConfig) {
     )
   }
 
+  const factory =
+    config.account?.type === 'hca' && config.account.factory
+      ? config.account.factory
+      : HCA_FACTORY_ADDRESS
+
   if (config.initData) {
     if (!('factory' in config.initData)) {
       return null
@@ -112,7 +117,7 @@ function getDeployArgs(config: RhinestoneAccountConfig) {
   })
 
   return {
-    factory: HCA_FACTORY_ADDRESS,
+    factory,
     factoryData,
     salt: zeroHash,
     implementation: HCA_IMPLEMENTATION_ADDRESS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,7 +563,23 @@ async function createAccountInternal(
   function getOwners(chain: Chain) {
     const accountType = getAccountProvider(config).type
     const account = getAddress()
-    return getOwnersInternal(accountType, account, chain, config.provider)
+    // For HCA, the module lives behind the factory (custom factories define
+    // their own). Resolve from the configured or initData factory so reads hit
+    // the right module.
+    const hcaFactory =
+      config.account?.type === 'hca'
+        ? (config.account.factory ??
+          (config.initData && 'factory' in config.initData
+            ? config.initData.factory
+            : undefined))
+        : undefined
+    return getOwnersInternal(
+      accountType,
+      account,
+      chain,
+      config.provider,
+      hcaFactory,
+    )
   }
 
   function getValidators(chain: Chain) {

--- a/src/modules/read.ts
+++ b/src/modules/read.ts
@@ -65,6 +65,7 @@ async function getOwners(
   account: Address,
   chain: Chain,
   provider?: ProviderConfig,
+  hcaFactory?: Address,
 ): Promise<{
   accounts: Address[]
   threshold: number
@@ -73,10 +74,28 @@ async function getOwners(
     chain,
     transport: createTransport(chain, provider),
   })
-  // HCA accounts hold owner state under the ENS HCA module, which is also
-  // OwnableValidator-based, so the getOwners/threshold reads are identical.
-  const moduleAddress =
-    accountType === 'hca' ? ENS_HCA_MODULE : OWNABLE_VALIDATOR_ADDRESS
+  // HCA accounts hold owner state under the HCA module (the factory's init-data
+  // parser), which is OwnableValidator-based, so the getOwners/threshold reads
+  // are identical. A custom factory defines its own module, so resolve it from
+  // the factory; otherwise fall back to the canonical module.
+  let moduleAddress: Address = OWNABLE_VALIDATOR_ADDRESS
+  if (accountType === 'hca') {
+    moduleAddress = hcaFactory
+      ? await publicClient.readContract({
+          abi: [
+            {
+              name: 'initDataParser',
+              type: 'function',
+              stateMutability: 'view',
+              inputs: [],
+              outputs: [{ name: '', type: 'address' }],
+            },
+          ],
+          functionName: 'initDataParser',
+          address: hcaFactory,
+        })
+      : ENS_HCA_MODULE
+  }
   const [ownerResult, thresholdResult] = await publicClient.multicall({
     contracts: [
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,10 @@ interface StartaleAccount {
 
 interface HcaAccount {
   type: 'hca'
+  // Custom HCA factory. Defines the CREATE3 deploy address and, via its
+  // implementation, the account's default validator (the HCA module).
+  // Defaults to the canonical HCA factory.
+  factory?: Address
 }
 
 interface EoaAccount {


### PR DESCRIPTION
Backport of #574 to the v2 line.

`release` locked HCA accounts to the canonical factory. This adds an optional `factory` on the `hca` account config, which defines the CREATE3 deploy address and, via the factory's `initDataParser`, the account's default validator (the HCA module). `getOwners` resolves the module from the configured or `initData` factory so reads hit the right module.

Non-breaking (optional field) → minor changeset.

Closes [RHI-4632](https://linear.app/rhinestone/issue/RHI-4632)