### PR TITLE
Remove the unused feeAsset option

### DIFF
--- a/.changeset/remove-fee-asset.md
+++ b/.changeset/remove-fee-asset.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': major
+---
+
+Remove the `feeAsset` transaction option. The orchestrator never honored it — the corresponding `feeToken` field was reserved with no effect — so choosing an ERC-20 fee asset was a no-op. Drop `feeAsset` from your `prepareTransaction` calls; it has no replacement until the feature actually ships.

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -31,7 +31,6 @@ import type {
   SourceCallInput,
   Sponsorship,
   TokenRequest,
-  TokenSymbol,
   UserOperationTransaction,
 } from '../types'
 import {
@@ -107,7 +106,6 @@ async function sendTransactionInternal(
     eip7702InitSignature?: Hex
     settlementLayers?: SettlementLayerFilter
     sourceAssets?: SourceAssetInput
-    feeAsset?: Address | TokenSymbol
     appFees?: AppFeeRate
   },
 ) {
@@ -136,7 +134,6 @@ async function sendTransactionInternal(
     options.eip7702InitSignature,
     options.settlementLayers,
     options.sourceAssets,
-    options.feeAsset,
     options.sourceCalls,
     options.appFees,
   )
@@ -189,7 +186,6 @@ async function sendTransactionAsIntent(
   eip7702InitSignature?: Hex,
   settlementLayers?: SettlementLayerFilter,
   sourceAssets?: SourceAssetInput,
-  feeAsset?: Address | TokenSymbol,
   sourceCalls?: Record<number, SourceCallInput[]>,
   appFees?: AppFeeRate,
 ) {
@@ -205,7 +201,6 @@ async function sendTransactionAsIntent(
     eip7702InitSignature,
     settlementLayers,
     sourceAssets,
-    feeAsset,
     undefined,
     undefined,
     signers,

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -197,7 +197,6 @@ describe('prepareTransactionAsIntent', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       auxiliaryFunds,
       undefined,
       undefined,
@@ -229,7 +228,6 @@ describe('prepareTransactionAsIntent', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
     )
 
     expect(mockCreateQuote).toHaveBeenCalledOnce()
@@ -252,7 +250,6 @@ describe('prepareTransactionAsIntent', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -292,7 +289,6 @@ describe('prepareTransactionAsIntent', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -339,7 +335,6 @@ describe('prepareTransactionAsIntent', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -502,7 +497,6 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       signers,
     )
 
@@ -547,7 +541,6 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       signers,
     )
 
@@ -578,7 +571,6 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -621,7 +613,6 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       signers,
     )
 
@@ -654,7 +645,6 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -717,7 +707,6 @@ describe('prepareTransactionAsIntent — preClaimExecutions', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       signers,
     )
 
@@ -769,7 +758,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       { [arbitrum.id]: [callA, callB] },
     )
 
@@ -791,7 +779,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -828,7 +815,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -882,7 +868,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       { [base.id]: [callA] },
     )
 
@@ -904,7 +889,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
         [{ address: zeroAddress, amount: 1n }],
         undefined,
         false,
-        undefined,
         undefined,
         undefined,
         undefined,
@@ -935,7 +919,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -985,7 +968,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       signers,
       { [base.id]: [callA] },
     )
@@ -1011,7 +993,6 @@ describe('prepareTransactionAsIntent — sourceCalls', () => {
       [{ address: zeroAddress, amount: 1n }],
       undefined,
       false,
-      undefined,
       undefined,
       undefined,
       undefined,

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -313,7 +313,6 @@ async function prepareTransaction(
     eip7702InitSignature,
     settlementLayers,
     sourceAssets,
-    feeAsset,
     auxiliaryFunds,
     appFees,
     account,
@@ -354,7 +353,6 @@ async function prepareTransaction(
     eip7702InitSignature,
     settlementLayers,
     sourceAssets,
-    feeAsset,
     auxiliaryFunds,
     account,
     signers,
@@ -822,7 +820,6 @@ function getTransactionParams(transaction: Transaction) {
   const gasLimit = transaction.gasLimit
   const settlementLayers = transaction.settlementLayers
   const sourceAssets = transaction.sourceAssets
-  const feeAsset = transaction.feeAsset
   const auxiliaryFunds = transaction.auxiliaryFunds
   const appFees = transaction.appFees
   const account = transaction.experimental_accountOverride
@@ -841,7 +838,6 @@ function getTransactionParams(transaction: Transaction) {
     gasLimit,
     settlementLayers,
     sourceAssets,
-    feeAsset,
     auxiliaryFunds,
     appFees,
     account,
@@ -992,7 +988,6 @@ async function prepareTransactionAsIntent(
   eip7702InitSignature: Hex | undefined,
   settlementLayers: SettlementLayerFilter | undefined,
   sourceAssets: SourceAssetInput | undefined,
-  feeAsset: Address | TokenSymbol | undefined,
   auxiliaryFunds: AuxiliaryFunds | undefined,
   account:
     | {
@@ -1197,7 +1192,6 @@ async function prepareTransactionAsIntent(
     destinationGasUnits: gasLimit,
     accountAccessList,
     options: {
-      feeToken: feeAsset,
       sponsorSettings: sponsored
         ? typeof sponsored === 'object'
           ? {

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -124,7 +124,6 @@ type AuxiliaryFunds = {
 }
 
 interface IntentOptions {
-  feeToken?: Address | SupportedTokenSymbol
   appFees?: AppFeeRate
   sponsorSettings?: SponsorSettings
   settlementLayers?: SettlementLayerFilter

--- a/src/types.ts
+++ b/src/types.ts
@@ -822,7 +822,6 @@ interface BaseTransaction {
   sponsored?: Sponsorship
   eip7702InitSignature?: Hex
   sourceAssets?: SourceAssetInput
-  feeAsset?: Address | TokenSymbol
   appFees?: AppFeeRate
   settlementLayers?: SettlementLayerFilter
   auxiliaryFunds?: AuxiliaryFunds


### PR DESCRIPTION
`feeAsset` on `prepareTransaction` mapped to `options.feeToken` and was sent to the orchestrator, but blanc marks `feeToken` *"Reserved for future use. No effect today."* and reads it nowhere — so choosing an ERC-20 fee asset has always been a no-op.

This removes the option and all its plumbing (the public field, the internal threading, and the `options.feeToken` mapping). Pure removal — no behavior changes, since the orchestrator ignored it. Changeset marks it a breaking change.

Companion: docs page removed ([RHI-4649](https://linear.app/rhinestone/issue/RHI-4649) / docs#153); orchestrator drops the reserved field ([RHI-4651](https://linear.app/rhinestone/issue/RHI-4651)).

Closes [RHI-4650](https://linear.app/rhinestone/issue/RHI-4650)