### PR TITLE
fix(app-fee): drop top-level appFee leg from quote routes

### DIFF
--- a/.changeset/single-app-fee.md
+++ b/.changeset/single-app-fee.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': major
+---
+
+Remove the top-level `appFee` leg from quote routes. The orchestrator now charges the whole-intent app fee in a single token, so the concrete leg lives in signed metadata rather than on the route response. `Quote.appFee` and the `AppFee` type are removed; the app fee is available as `quote.cost.fees.breakdown.app.usd`. Requesting an app fee via `options.appFees` (type `AppFeeRate`) is unchanged.

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ import type {
   WrapRequired,
 } from './orchestrator'
 
-export type { AppFee, AppFeeRate } from './orchestrator'
+export type { AppFeeRate } from './orchestrator'
 
 import { hyperCoreMainnet, solanaMainnet, tronMainnet } from './orchestrator'
 import type {

--- a/src/orchestrator/client.test.ts
+++ b/src/orchestrator/client.test.ts
@@ -98,7 +98,7 @@ describe('Orchestrator trace IDs', () => {
     })
   })
 
-  it('decodes app fee legs and app fee breakdown', async () => {
+  it('decodes app fee breakdown', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
@@ -110,15 +110,6 @@ describe('Orchestrator trace IDs', () => {
               estimatedFillTime: { seconds: 3 },
               settlementLayer: 'ACROSS',
               signData: { origin: [], destination: null },
-              appFee: [
-                {
-                  feeBps: 100,
-                  baseAmount: '1000000',
-                  amount: '10000',
-                  chainId: 'eip155:42161',
-                  tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-                },
-              ],
               cost: {
                 input: [],
                 output: [],
@@ -153,16 +144,8 @@ describe('Orchestrator trace IDs', () => {
       options: {},
     } as any)
 
-    expect(result.routes[0].appFee).toEqual([
-      {
-        feeBps: 100,
-        baseAmount: 1000000n,
-        amount: 10000n,
-        chainId: 42161,
-        tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-      },
-    ])
     expect(result.routes[0].cost.fees.breakdown.app).toEqual({ usd: 0.01 })
+    expect('appFee' in result.routes[0]).toBe(false)
   })
 
   it('preserves traceId on split responses', async () => {

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -9,7 +9,6 @@ import {
 } from './error'
 import type {
   AccountAccessList,
-  AppFee,
   ApprovalRequired,
   AuxiliaryFunds,
   BridgeFill,
@@ -365,23 +364,11 @@ function decodeQuote(route: WireRoute): Quote {
     settlementLayer: route.settlementLayer,
     signData: route.signData as unknown as SignData,
     cost: decodeCost(route.cost),
-    appFee: decodeAppFee(route.appFee),
     tokenRequirements: route.tokenRequirements
       ? decodeTokenRequirements(route.tokenRequirements)
       : undefined,
     bridgeFill: decodeBridgeFill(route.bridgeFill),
   }
-}
-
-function decodeAppFee(appFee: WireRoute['appFee']): AppFee[] | undefined {
-  if (!appFee) return undefined
-  return appFee.map((fee) => ({
-    feeBps: fee.feeBps,
-    baseAmount: BigInt(fee.baseAmount),
-    amount: BigInt(fee.amount),
-    chainId: parseChainId(fee.chainId),
-    tokenAddress: fee.tokenAddress as Address,
-  }))
 }
 
 function decodeBridgeFill(

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -44,7 +44,6 @@ import {
   isTokenAddressSupported,
 } from './registry'
 import type {
-  AppFee,
   AppFeeRate,
   ApprovalRequired,
   AuxiliaryFunds,
@@ -103,7 +102,6 @@ function getOrchestrator(
 
 export type {
   ApprovalRequired,
-  AppFee,
   AppFeeRate,
   AuxiliaryFunds,
   BridgeFill,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -135,13 +135,6 @@ interface AppFeeRate {
   feeBps: number
 }
 
-interface AppFee extends AppFeeRate {
-  baseAmount: bigint
-  amount: bigint
-  chainId: number
-  tokenAddress: Address
-}
-
 interface SponsorSettings {
   gas: boolean
   bridgeFees: boolean
@@ -238,7 +231,6 @@ interface Quote {
   settlementLayer: SettlementLayer
   signData: SignData
   cost: Cost
-  appFee?: AppFee[]
   tokenRequirements?: TokenRequirements
   bridgeFill?: BridgeFill
 }
@@ -409,7 +401,6 @@ export type {
   Account,
   AccountType,
   AccountWithContext,
-  AppFee,
   AppFeeRate,
   AuxiliaryFunds,
   TokenConfig,

--- a/src/orchestrator/wire.ts
+++ b/src/orchestrator/wire.ts
@@ -26,7 +26,6 @@ export type WireRoute = WireQuoteResponse['routes'][number]
 export type WireCost = WireRoute['cost']
 export type WireCostInputEntry = WireCost['input'][number]
 export type WireCostOutputEntry = WireCost['output'][number]
-export type WireAppFee = NonNullable<WireRoute['appFee']>[number]
 export type WireBridgeFill = NonNullable<WireRoute['bridgeFill']>
 export type WireTokenRequirements = NonNullable<WireRoute['tokenRequirements']>
 


### PR DESCRIPTION
## Problem

The orchestrator now charges the whole-intent app fee in a **single token** (one on-chain carve per intent), so it no longer emits per-segment app-fee legs on the quote route response. The concrete fee leg lives in signed metadata; the route response carries the fee only as the aggregate USD figure in the cost breakdown.

This SDK still decodes a top-level `route.appFee` **array** (`decodeAppFee`, `Quote.appFee`, `WireAppFee`), which no longer exists on the wire. Left as-is, integrators reading `quote.appFee` break at runtime once the orchestrator ships.

Depends on orchestrator #1691.

## Change

- Remove `Quote.appFee`, the `AppFee` type and its public re-exports, `WireAppFee`, and `decodeAppFee`.
- The app fee remains available as `quote.cost.fees.breakdown.app.usd`.
- Requesting an app fee via `options.appFees` (type `AppFeeRate`) is unchanged.
- `wire.gen.ts` is generated from the orchestrator OpenAPI spec and regenerates in CI once #1691's spec ships — not hand-edited here.

## Breaking change

`Quote.appFee` and the exported `AppFee` type are removed. `major` changeset included. Consumers that read per-token app-fee legs off the quote should use the `breakdown.app` USD figure instead.

## Verification

- `client.test.ts` asserts `cost.fees.breakdown.app` decodes and no `appFee` field is surfaced on the route.
- typecheck clean, biome clean, unit tests green.