### PR TITLE
ci: auto-regenerate SDK reference on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,15 @@ jobs:
           bun run generate:wire
           git diff --exit-code src/orchestrator/wire.gen.ts
 
+      # Fail if a public export drifts from the curated reference manifest.
+      # Renders to a throwaway dir; the docs.json patch no-ops on a missing path.
+      - name: Verify SDK reference coverage
+        env:
+          SDK_REF_OUT: ${{ runner.temp }}/sdk-reference
+          SDK_REF_DOCS_JSON: ${{ runner.temp }}/docs.json
+          SDK_REF_CHECK: "1"
+        run: bun run generate:reference
+
       - name: Build
         run: bun run build
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,3 +98,66 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label ship
+
+      # Regenerate the SDK reference and open/update a PR in the docs repo, but
+      # only when a real publish happened (not when the Release PR is merely
+      # opened/updated). Gated to the v2 line — flip `release` to `main` when v2
+      # graduates. v1 publishes are intentionally excluded so they can't clobber
+      # the v2 reference the docs site tracks.
+      - name: Mint docs-repo token
+        if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
+        id: docs-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: docs
+
+      - name: Checkout docs repo
+        if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
+        uses: "actions/checkout@v4"
+        with:
+          repository: ${{ github.repository_owner }}/docs
+          ref: main
+          token: ${{ steps.docs-token.outputs.token }}
+          path: docs-repo
+
+      - name: Regenerate SDK reference into the docs checkout
+        if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
+        env:
+          SDK_REF_OUT: ${{ github.workspace }}/docs-repo/sdk-reference
+          SDK_REF_DOCS_JSON: ${{ github.workspace }}/docs-repo/docs.json
+        run: bun run generate:reference
+
+      - name: Open or update docs PR
+        if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
+        env:
+          DOCS_TOKEN: ${{ steps.docs-token.outputs.token }}
+          GH_TOKEN: ${{ steps.docs-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          BRANCH="update/sdk-reference"
+          cd docs-repo
+          git checkout -b "$BRANCH"
+          git add sdk-reference docs.json
+          if git diff --cached --quiet; then
+            echo "SDK reference unchanged; nothing to open."
+            exit 0
+          fi
+          git config user.name "rhinestone-automations[bot]"
+          git config user.email "rhinestone-automations[bot]@users.noreply.github.com"
+          git commit -m "chore(sdk-reference): sync from ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+          git push --force "https://x-access-token:${DOCS_TOKEN}@github.com/${GITHUB_REPOSITORY_OWNER}/docs.git" "$BRANCH"
+          BODY="Regenerated SDK reference from ${GITHUB_REPOSITORY}@${GITHUB_SHA}."
+          EXISTING_PR=$(gh pr list --repo "${GITHUB_REPOSITORY_OWNER}/docs" --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" --repo "${GITHUB_REPOSITORY_OWNER}/docs" --body "$BODY"
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY_OWNER}/docs" \
+              --base main \
+              --head "$BRANCH" \
+              --title "Sync SDK reference" \
+              --body "$BODY"
+          fi

--- a/scripts/reference/generate.ts
+++ b/scripts/reference/generate.ts
@@ -27,6 +27,15 @@ const OUT_DIR =
   process.env.SDK_REF_OUT ?? resolve(HERE, '../../../docs/sdk-reference')
 const NAV_BASE = 'sdk-reference'
 
+// When set, the render exits non-zero on any coverage problem (an unresolved
+// manifest symbol or a public export missing from the manifest) instead of
+// just warning. Used by CI to block reference drift at PR time.
+const CHECK = process.env.SDK_REF_CHECK === '1'
+
+// Manifest symbols that could not be resolved in the TypeDoc model, collected
+// during render so CHECK mode can fail on them.
+const unresolved: string[] = []
+
 // ---------------------------------------------------------------------------
 // TypeDoc JSON traversal
 // ---------------------------------------------------------------------------
@@ -385,6 +394,7 @@ function renderPage(entry: SymbolEntry): string | null {
   const node = resolveNode(entry)
   if (!node) {
     console.error(`! could not resolve ${entry.source}#${entry.symbol}`)
+    unresolved.push(`${entry.source}#${entry.symbol}`)
     return null
   }
   const sigs = signaturesOf(node, entry)
@@ -668,7 +678,7 @@ const UNDOCUMENTED_OK = new Set<string>([
 // already documents, but are themselves missing from it. Scoped this way so
 // out-of-scope modules (jwt-server, errors, types, the standalone
 // /smart-sessions module) are never flagged.
-function warnMissingCoverage() {
+function warnMissingCoverage(): string[] {
   const documented = new Set(nameToPage.keys())
   const containers = new Set<string>()
   const modules = new Set<string>()
@@ -712,6 +722,7 @@ function warnMissingCoverage() {
       '  Add them to manifest.ts, or to UNDOCUMENTED_OK in generate.ts if intentional.',
     )
   }
+  return missing
 }
 
 function main() {
@@ -719,9 +730,16 @@ function main() {
 
   const navPages = build(manifest as Node[], [NAV_BASE])
   patchDocsJson(navPages)
-  warnMissingCoverage()
+  const missing = warnMissingCoverage()
 
   console.info(`Generated ${countPages(navPages)} pages under ${OUT_DIR}`)
+
+  if (CHECK && (unresolved.length || missing.length)) {
+    console.error(
+      `\n! reference coverage check failed: ${unresolved.length} unresolved symbol(s), ${missing.length} undocumented export(s).`,
+    )
+    process.exit(1)
+  }
 }
 
 function countPages(pages: (string | NavGroup)[]): number {


### PR DESCRIPTION
Closes the drift gap where the docs site's SDK Reference is regenerated by hand.

- On a real v2 publish (`release` branch + changesets `published == 'true'`), regenerate the reference into the `docs` repo and open/update a `update/sdk-reference` PR there, via the `rhinestone-automations` app. Mirrors the orchestrator → openapi flow.
- v1 publishes and no-op Release-PR pushes are intentionally excluded so they can't clobber the v2 reference. Flip `release` → `main` when v2 graduates.
- New `SDK_REF_CHECK` mode in the generator fails on unresolved manifest symbols or public exports missing from the manifest; wired into PR CI so drift is blocked before merge.

Requires the `rhinestone-automations` app to have `docs` in its selected repos (app already requests `contents:write` + `pull_requests:write`).

Closes [RHI-4571](https://linear.app/rhinestone/issue/RHI-4571)