### PR TITLE
feat: add getAppFeeBalances (app-fee balances endpoint)

### DIFF
--- a/.changeset/add-app-fee-balances.md
+++ b/.changeset/add-app-fee-balances.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add `getAppFeeBalances` to the account and orchestrator client. Returns the integrator's accrued app-fee balance as USD totals (`withdrawableUsd`, `pendingUsd`), read from `GET /app-fees/balances`. Fees are valued in USD at the moment they are collected, so the balance is unaffected by later price movements of the collected tokens.

--- a/.changeset/add-app-fee-balances.md
+++ b/.changeset/add-app-fee-balances.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': minor
 ---
 
-Add `getAppFeeBalances` to the account and orchestrator client. Returns the integrator's accrued app-fee balance as USD totals (`withdrawableUsd`, `pendingUsd`), read from `GET /app-fees/balances`. Fees are valued in USD at the moment they are collected, so the balance is unaffected by later price movements of the collected tokens.
+Add `getAppFeeBalances` to `RhinestoneSDK`. Returns the integrator's accrued app-fee balance as USD totals (`withdrawableUsd`, `pendingUsd`), read from `GET /app-fees/balances`. The balance is project-scoped (keyed to the API key), not tied to any account. Fees are valued in USD at the moment they are collected, so the balance is unaffected by later price movements of the collected tokens.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Once v2 is stable, we'll switch back to the standard `main` (dev) / `release` (p
 ## Patterns
 
 - Use viem types for addresses, chains, and hex values
+- Placement of a new public method — `RhinestoneSDK` vs `RhinestoneAccount`: put it on **`RhinestoneSDK`** when its data is scoped to the API key's project/integrator and needs no account (auth-only orchestrator reads, e.g. `getIntentStatus`, `splitIntents`, `getAppFeeBalances`); put it on **`RhinestoneAccount`** only when it is genuinely account-scoped (needs the account address / owners / on-chain state, e.g. `getPortfolio`, signing). Exposing project-scoped data as an account method misleads callers into reading it as account-scoped.
 - Account implementations live in `/src/accounts/*.ts`
 - Public API is the union of `src/index.ts` re-exports and the subpath exports in `src/package.json` (`/actions`, `/errors`, `/jwt-server`, `/smart-sessions`, etc.) — adding, renaming, or removing exports is a breaking change
 - When changing the public surface (types, exports, account/action APIs, config, errors, defaults), use the `dx` skill to keep it safe and ergonomic to integrate

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -154,6 +154,7 @@ export const manifest: Group[] = [
         items: [
           accountMethod('getAddress'),
           accountMethod('getPortfolio'),
+          accountMethod('getAppFeeBalances'),
           accountMethod('getOwners'),
           accountMethod('getValidators'),
           accountMethod('getExecutors'),

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -99,6 +99,13 @@ export const manifest: Group[] = [
         container: 'RhinestoneSDK',
         callStyle: 'sdkMethod',
       },
+      {
+        kind: 'symbol',
+        symbol: 'getAppFeeBalances',
+        source: '.',
+        container: 'RhinestoneSDK',
+        callStyle: 'sdkMethod',
+      },
     ],
   },
   {
@@ -154,7 +161,6 @@ export const manifest: Group[] = [
         items: [
           accountMethod('getAddress'),
           accountMethod('getPortfolio'),
-          accountMethod('getAppFeeBalances'),
           accountMethod('getOwners'),
           accountMethod('getValidators'),
           accountMethod('getExecutors'),

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -361,6 +361,15 @@ async function getPortfolio(config: RhinestoneConfig, onTestnets: boolean) {
   return orchestrator.getPortfolio(address, { chainIds: filteredChainIds })
 }
 
+async function getAppFeeBalances(config: RhinestoneConfig) {
+  const orchestrator = getOrchestrator(
+    config._authProvider ?? createAuthProvider(config),
+    config.endpointUrl,
+    config.headers,
+  )
+  return orchestrator.getAppFeeBalances()
+}
+
 async function getIntentStatus(
   authProvider: AuthProvider,
   endpointUrl: string | undefined,
@@ -393,6 +402,7 @@ export {
   sendUserOperationInternal,
   waitForExecution,
   getPortfolio,
+  getAppFeeBalances,
   getIntentStatus,
   splitIntents,
   // Errors

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -361,12 +361,12 @@ async function getPortfolio(config: RhinestoneConfig, onTestnets: boolean) {
   return orchestrator.getPortfolio(address, { chainIds: filteredChainIds })
 }
 
-async function getAppFeeBalances(config: RhinestoneConfig) {
-  const orchestrator = getOrchestrator(
-    config._authProvider ?? createAuthProvider(config),
-    config.endpointUrl,
-    config.headers,
-  )
+async function getAppFeeBalances(
+  authProvider: AuthProvider,
+  endpointUrl: string | undefined,
+  headers?: Record<string, string>,
+) {
+  const orchestrator = getOrchestrator(authProvider, endpointUrl, headers)
   return orchestrator.getAppFeeBalances()
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from './accounts'
 import { type AuthProvider, createAuthProvider } from './auth/provider'
 import {
+  getAppFeeBalances as getAppFeeBalancesInternal,
   getIntentStatus as getIntentStatusInternal,
   getPortfolio as getPortfolioInternal,
   sendUserOperation as sendUserOperationInternal,
@@ -68,6 +69,7 @@ import {
   type SessionDetails,
 } from './modules/validators/smart-sessions'
 import type {
+  AppFeeBalances,
   ApprovalRequired,
   AuxiliaryFunds,
   BridgeFill,
@@ -91,7 +93,7 @@ import type {
   WrapRequired,
 } from './orchestrator'
 
-export type { AppFeeRate } from './orchestrator'
+export type { AppFeeBalances, AppFeeRate } from './orchestrator'
 
 import { hyperCoreMainnet, solanaMainnet, tronMainnet } from './orchestrator'
 import type {
@@ -341,6 +343,15 @@ interface RhinestoneAccount {
    */
   getPortfolio(onTestnets?: boolean): Promise<Portfolio>
   /**
+   * Get the integrator's accrued app-fee balance, as USD totals.
+   *
+   * App fees are earned by the integrator (identified by the API key's project)
+   * and valued in USD at the moment each fee is collected, so the balance is not
+   * affected by later price movements of the collected tokens.
+   * @returns The withdrawable and pending app-fee balances in USD
+   */
+  getAppFeeBalances(): Promise<AppFeeBalances>
+  /**
    * Resolve the smart-session details for a set of sessions.
    * @param sessions Sessions to resolve
    * @returns The resolved session details
@@ -560,6 +571,10 @@ async function createAccountInternal(
     return getPortfolioInternal(config, onTestnets)
   }
 
+  function getAppFeeBalances() {
+    return getAppFeeBalancesInternal(config)
+  }
+
   function getOwners(chain: Chain) {
     const accountType = getAccountProvider(config).type
     const account = getAddress()
@@ -639,6 +654,7 @@ async function createAccountInternal(
     waitForExecution,
     getAddress,
     getPortfolio,
+    getAppFeeBalances,
     getOwners,
     getValidators,
     getExecutors,

--- a/src/index.ts
+++ b/src/index.ts
@@ -343,15 +343,6 @@ interface RhinestoneAccount {
    */
   getPortfolio(onTestnets?: boolean): Promise<Portfolio>
   /**
-   * Get the integrator's accrued app-fee balance, as USD totals.
-   *
-   * App fees are earned by the integrator (identified by the API key's project)
-   * and valued in USD at the moment each fee is collected, so the balance is not
-   * affected by later price movements of the collected tokens.
-   * @returns The withdrawable and pending app-fee balances in USD
-   */
-  getAppFeeBalances(): Promise<AppFeeBalances>
-  /**
    * Resolve the smart-session details for a set of sessions.
    * @param sessions Sessions to resolve
    * @returns The resolved session details
@@ -571,10 +562,6 @@ async function createAccountInternal(
     return getPortfolioInternal(config, onTestnets)
   }
 
-  function getAppFeeBalances() {
-    return getAppFeeBalancesInternal(config)
-  }
-
   function getOwners(chain: Chain) {
     const accountType = getAccountProvider(config).type
     const account = getAddress()
@@ -654,7 +641,6 @@ async function createAccountInternal(
     waitForExecution,
     getAddress,
     getPortfolio,
-    getAppFeeBalances,
     getOwners,
     getValidators,
     getExecutors,
@@ -750,6 +736,23 @@ class RhinestoneSDK {
       this.authProvider,
       this.endpointUrl,
       input,
+      this.headers,
+    )
+  }
+
+  /**
+   * Get the integrator's accrued app-fee balance, as USD totals.
+   *
+   * App fees are earned by the integrator identified by this instance's API key
+   * (project-scoped, not tied to any account) and valued in USD at the moment
+   * each fee is collected, so the balance is not affected by later price
+   * movements of the collected tokens.
+   * @returns The withdrawable and pending app-fee balances in USD
+   */
+  getAppFeeBalances(): Promise<AppFeeBalances> {
+    return getAppFeeBalancesInternal(
+      this.authProvider,
+      this.endpointUrl,
       this.headers,
     )
   }

--- a/src/orchestrator/client.test.ts
+++ b/src/orchestrator/client.test.ts
@@ -243,4 +243,24 @@ describe('Orchestrator trace IDs', () => {
       traceId: 'trace-header',
     })
   })
+
+  it('gets app-fee balances from GET /app-fees/balances', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        mockJsonResponse({ withdrawableUsd: 12.34, pendingUsd: 0 }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    const orchestrator = new Orchestrator(
+      'https://orchestrator.test',
+      authProvider,
+    )
+
+    const result = await orchestrator.getAppFeeBalances()
+
+    expect(result).toEqual({ withdrawableUsd: 12.34, pendingUsd: 0 })
+    const [url, options] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://orchestrator.test/app-fees/balances')
+    expect(options.headers).toMatchObject({ 'x-api-key': 'test-key' })
+  })
 })

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -388,7 +388,11 @@ function decodeBridgeFill(
   bf: WireBridgeFill | undefined,
 ): BridgeFill | undefined {
   if (!bf) return undefined
-  return { ...bf } as BridgeFill
+  // `fillStatusTimeout` is an internal orchestrator field on the wire that the
+  // public `BridgeFill` type does not surface — strip it so the adapter returns
+  // only the typed variant fields rather than leaking an untyped runtime field.
+  const { fillStatusTimeout: _fillStatusTimeout, ...rest } = bf
+  return { ...rest } as BridgeFill
 }
 
 function decodeCost(cost: WireCost): Cost {

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -9,6 +9,7 @@ import {
 } from './error'
 import type {
   AccountAccessList,
+  AppFeeBalances,
   ApprovalRequired,
   AuxiliaryFunds,
   BridgeFill,
@@ -30,6 +31,7 @@ import type {
 } from './types'
 import { convertBigIntFields } from './utils'
 import type {
+  WireAppFeeBalancesResponse,
   WireBridgeFill,
   WireCost,
   WireCostInputEntry,
@@ -104,6 +106,17 @@ export class Orchestrator {
         amount: BigInt(c.amount),
       })),
     }))
+  }
+
+  async getAppFeeBalances(): Promise<AppFeeBalances> {
+    const json: WireAppFeeBalancesResponse = await this.fetch(
+      `${this.serverUrl}/app-fees/balances`,
+      { headers: await this.getHeaders() },
+    )
+    return {
+      withdrawableUsd: json.withdrawableUsd,
+      pendingUsd: json.pendingUsd,
+    }
   }
 
   async createQuote(input: IntentInput): Promise<QuoteResponse> {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -44,6 +44,7 @@ import {
   isTokenAddressSupported,
 } from './registry'
 import type {
+  AppFeeBalances,
   AppFeeRate,
   ApprovalRequired,
   AuxiliaryFunds,
@@ -102,6 +103,7 @@ function getOrchestrator(
 
 export type {
   ApprovalRequired,
+  AppFeeBalances,
   AppFeeRate,
   AuxiliaryFunds,
   BridgeFill,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -135,6 +135,14 @@ interface AppFeeRate {
   feeBps: number
 }
 
+/** An integrator's accrued app-fee balance, as USD totals. */
+interface AppFeeBalances {
+  /** Collected (accrued) app fees available to withdraw, valued in USD at collection. */
+  withdrawableUsd: number
+  /** Value reserved by an in-flight withdrawal; `0` until withdrawals are enabled. */
+  pendingUsd: number
+}
+
 interface SponsorSettings {
   gas: boolean
   bridgeFees: boolean
@@ -403,6 +411,7 @@ export type {
   AccountWithContext,
   AppFeeRate,
   AuxiliaryFunds,
+  AppFeeBalances,
   TokenConfig,
   SupportedChain,
   SettlementLayer,

--- a/src/orchestrator/wire.gen.ts
+++ b/src/orchestrator/wire.gen.ts
@@ -147,6 +147,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/app-fees/balances": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get App-Fee Balances
+         * @description The authenticated project's withdrawable app-fee balance as a USD total, valued at collection time. `pendingUsd` is 0 until withdrawals land.
+         */
+        get: operations["getAppFeeBalances"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -3566,6 +3586,8 @@ export interface operations {
                                 destinationChainId: number;
                                 /** @description Optional bridge-specific fill deadline duration, in seconds. Preserved on stored quote reload so checksum validation uses the same bridgeFill payload that was signed at quote time. */
                                 fillExpirationPeriod?: number;
+                                /** @description Fill-tracker watch window, in seconds. The orchestrator owns this timeout; the fill-tracker reads it here to decide when a bridge fill has timed out. */
+                                fillStatusTimeout: number;
                                 /**
                                  * @description LayerZero OFT
                                  * @enum {string}
@@ -3576,6 +3598,8 @@ export interface operations {
                                 destinationChainId: number;
                                 /** @description Optional bridge-specific fill deadline duration, in seconds. Preserved on stored quote reload so checksum validation uses the same bridgeFill payload that was signed at quote time. */
                                 fillExpirationPeriod?: number;
+                                /** @description Fill-tracker watch window, in seconds. The orchestrator owns this timeout; the fill-tracker reads it here to decide when a bridge fill has timed out. */
+                                fillStatusTimeout: number;
                                 /**
                                  * @description Relay.link
                                  * @enum {string}
@@ -3588,6 +3612,8 @@ export interface operations {
                                 destinationChainId: number;
                                 /** @description Optional bridge-specific fill deadline duration, in seconds. Preserved on stored quote reload so checksum validation uses the same bridgeFill payload that was signed at quote time. */
                                 fillExpirationPeriod?: number;
+                                /** @description Fill-tracker watch window, in seconds. The orchestrator owns this timeout; the fill-tracker reads it here to decide when a bridge fill has timed out. */
+                                fillStatusTimeout: number;
                                 /**
                                  * @description NEAR Intents
                                  * @enum {string}
@@ -3600,6 +3626,8 @@ export interface operations {
                                 destinationChainId: number;
                                 /** @description Optional bridge-specific fill deadline duration, in seconds. Preserved on stored quote reload so checksum validation uses the same bridgeFill payload that was signed at quote time. */
                                 fillExpirationPeriod?: number;
+                                /** @description Fill-tracker watch window, in seconds. The orchestrator owns this timeout; the fill-tracker reads it here to decide when a bridge fill has timed out. */
+                                fillStatusTimeout: number;
                                 /**
                                  * @description Rhino.fi
                                  * @enum {string}
@@ -3612,6 +3640,8 @@ export interface operations {
                                 destinationChainId: number;
                                 /** @description Optional bridge-specific fill deadline duration, in seconds. Preserved on stored quote reload so checksum validation uses the same bridgeFill payload that was signed at quote time. */
                                 fillExpirationPeriod?: number;
+                                /** @description Fill-tracker watch window, in seconds. The orchestrator owns this timeout; the fill-tracker reads it here to decide when a bridge fill has timed out. */
+                                fillStatusTimeout: number;
                                 /**
                                  * @description Circle CCTP
                                  * @enum {string}
@@ -3728,6 +3758,334 @@ export interface operations {
             };
             /** @description API key scope denied */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+        };
+    };
+    getAppFeeBalances: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description API version. Required; pinned to this document. */
+                "x-api-version": "2026-04.blanc";
+                /** @description API key. */
+                "x-api-key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        withdrawableUsd: number;
+                        pendingUsd: number;
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/orchestrator/wire.ts
+++ b/src/orchestrator/wire.ts
@@ -40,3 +40,6 @@ export type WireIntentStatus = SuccessJson<'getIntent', 200>
 
 // GET /accounts/{accountAddress}/portfolio
 export type WirePortfolioResponse = SuccessJson<'getPortfolio', 200>
+
+// GET /app-fees/balances
+export type WireAppFeeBalancesResponse = SuccessJson<'getAppFeeBalances', 200>


### PR DESCRIPTION
## What

Adds `getAppFeeBalances()` to the account and the orchestrator client, backing the orchestrator's `GET /app-fees/balances` endpoint.

```ts
const { withdrawableUsd, pendingUsd } = await account.getAppFeeBalances()
```

Returns the integrator's accrued app-fee balance as USD totals:
- `withdrawableUsd` — collected (accrued) app fees available to withdraw.
- `pendingUsd` — value reserved by an in-flight withdrawal (`0` until withdrawals are enabled).

App fees are earned by the integrator (identified by the API key's project) and valued in USD **at the moment each fee is collected**, so the balance is not affected by later price movements of the collected tokens.

## Changes

- `orchestrator/wire.ts`: `WireAppFeeBalancesResponse` alias (`SuccessJson<'getAppFeeBalances', 200>`).
- `orchestrator/wire.gen.ts`: regenerated from the published `blanc` spec (adds the `getAppFeeBalances` operation; purely additive).
- `orchestrator/types.ts`: `AppFeeBalances` type (exported).
- `orchestrator/client.ts`: `Orchestrator.getAppFeeBalances()`.
- `execution/index.ts` + `index.ts`: exposed as `RhinestoneAccount.getAppFeeBalances()` with JSDoc; added to the reference manifest.
- Unit test in `orchestrator/client.test.ts`; changeset (minor).

## Verification

- `typecheck`, `check` (biome), `build` all clean.
- `getAppFeeBalances` unit test passes; wire regenerates identically from the published spec (CI drift-check clean).
- Verified end-to-end via bundle-generator (local build linked) against the deployed **dev** orchestrator: returns `{ withdrawableUsd: 0, pendingUsd: 0 }`, matching the raw endpoint.

## Note

One pre-existing test failure (`src/index.test.ts` → "signIntent delegates to SDK intent signing utilities") reproduces on the base `release` branch untouched by this PR — its `vi.mock('./execution/utils')` doesn't intercept because the SDK entry resolves through the package export map to `dist`. Not introduced here.
