### PR TITLE
feat: add getAppFeeBalances (app-fee balances endpoint)

### DIFF
--- a/.changeset/add-app-fee-balances.md
+++ b/.changeset/add-app-fee-balances.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add `getAppFeeBalances` to the account and orchestrator client. Returns the integrator's accrued app-fee balance as USD totals (`withdrawableUsd`, `pendingUsd`), read from `GET /app-fees/balances`. Fees are valued in USD at the moment they are collected, so the balance is unaffected by later price movements of the collected tokens.

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -460,9 +460,19 @@ async function splitIntents(
   return orchestrator.splitIntents(input)
 }
 
+async function getAppFeeBalances(
+  authProvider: AuthProvider,
+  endpointUrl: string | undefined,
+  headers?: Record<string, string>,
+) {
+  const orchestrator = getOrchestrator(authProvider, endpointUrl, headers)
+  return orchestrator.getAppFeeBalances()
+}
+
 export type { TransactionResult, TransactionStatus, UserOperationResult }
 export {
   ExecutionError,
+  getAppFeeBalances,
   getIntentStatus,
   getPortfolio,
   IntentFailedError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { walletClientToAccount, wrapParaAccount } from './accounts/walletClient'
 import { deployAccountsForOwners } from './actions/deployment'
 import { type AuthProvider, createAuthProvider } from './auth/provider'
 import {
+  getAppFeeBalances as getAppFeeBalancesInternal,
   getIntentStatus as getIntentStatusInternal,
   getPortfolio as getPortfolioInternal,
   sendTransaction as sendTransactionInternal,
@@ -79,6 +80,7 @@ import {
 } from './modules/validators/smart-sessions'
 import {
   type AppFee,
+  type AppFeeBalances,
   type AppFeeRate,
   type ApprovalRequired,
   type AuxiliaryFunds,
@@ -630,12 +632,30 @@ class RhinestoneSDK {
       this.headers,
     )
   }
+
+  /**
+   * Get the integrator's accrued app-fee balance, as USD totals.
+   *
+   * App fees are earned by the integrator identified by this instance's API key
+   * (project-scoped, not tied to any account) and valued in USD at the moment
+   * each fee is collected, so the balance is not affected by later price
+   * movements of the collected tokens.
+   * @returns The withdrawable and pending app-fee balances in USD
+   */
+  getAppFeeBalances(): Promise<AppFeeBalances> {
+    return getAppFeeBalancesInternal(
+      this.authProvider,
+      this.endpointUrl,
+      this.headers,
+    )
+  }
 }
 
 export type {
   AccountProviderConfig,
   AccountType,
   AppFee,
+  AppFeeBalances,
   AppFeeRate,
   ApprovalRequired,
   AuxiliaryFunds,

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -27,6 +27,7 @@ import {
   UnsupportedTokenError,
 } from './error'
 import type {
+  AppFeeBalances,
   IntentInput,
   IntentOpStatus,
   IntentResult,
@@ -217,6 +218,16 @@ export class Orchestrator {
         headers: await this.getHeaders(),
       },
     )
+  }
+
+  async getAppFeeBalances(): Promise<AppFeeBalances> {
+    const json = await this.fetch(`${this.serverUrl}/app-fees/balances`, {
+      headers: await this.getHeaders(),
+    })
+    return {
+      withdrawableUsd: json.withdrawableUsd,
+      pendingUsd: json.pendingUsd,
+    }
   }
 
   private async getHeaders(): Promise<Record<string, string>> {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -44,6 +44,7 @@ import {
 } from './registry'
 import type {
   AppFee,
+  AppFeeBalances,
   AppFeeRate,
   ApprovalRequired,
   AuxiliaryFunds,
@@ -87,6 +88,7 @@ function getOrchestrator(
 
 export type {
   AppFee,
+  AppFeeBalances,
   AppFeeRate,
   ApprovalRequired,
   AuxiliaryFunds,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -110,6 +110,14 @@ interface AppFeeRate {
   feeBps: number
 }
 
+/** An integrator's accrued app-fee balance, as USD totals. */
+interface AppFeeBalances {
+  /** Collected (accrued) app fees available to withdraw, valued in USD at collection. */
+  withdrawableUsd: number
+  /** Value reserved by an in-flight withdrawal; `0` until withdrawals are enabled. */
+  pendingUsd: number
+}
+
 interface AppFee extends AppFeeRate {
   baseAmount: string
   amount: string
@@ -503,6 +511,7 @@ export type {
   AccountAccessList,
   AccountType,
   AppFee,
+  AppFeeBalances,
   AppFeeRate,
   ApprovalRequired,
   AuxiliaryFunds,


### PR DESCRIPTION
Adds `getAppFeeBalances()` to `RhinestoneSDK` and the orchestrator client, backing `GET /app-fees/balances`.

```ts
const { withdrawableUsd, pendingUsd } = await sdk.getAppFeeBalances()
```

Returns the integrator's accrued app-fee balance as USD totals:
- `withdrawableUsd` — collected (accrued) app fees available to withdraw.
- `pendingUsd` — value reserved by an in-flight withdrawal (`0` until withdrawals are enabled).

App fees are project-scoped (identified by the API key's project) and valued in USD **at the moment each fee is collected**, so the balance is unaffected by later price movements of the collected tokens.

## Changes

- `orchestrator/types.ts`: `AppFeeBalances` type (exported).
- `orchestrator/client.ts`: `Orchestrator.getAppFeeBalances()`.
- `execution/index.ts` + `index.ts`: exposed as `RhinestoneSDK.getAppFeeBalances()`.
- Changeset (minor).

## Notes

- v1 port of #637 (v2/`release`). The v1 orchestrator layer is hand-written (no generated wire types), so `wire.gen.ts`/`wire.ts`, the reference manifest, and the `decodeBridgeFill` change from the v2 PR don't apply.
- The endpoint is version-invariant (plain USD numbers) and its response ladder serves both `blanc` and `alps`, so the v1 SDK (`2026-01.alps`) works against it.

Companion PRs: rhinestonewtf/sdk#637 (v2 SDK), rhinestonewtf/orchestrator#1712 (endpoint).