### PR TITLE
ci: pin npm to v11 in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Use OIDC-capable npm
-        run: sudo npm install -g npm@latest
+        run: sudo npm install -g npm@11
 
       - name: Install the npm dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
- The release workflow installs `npm@latest` for OIDC trusted publishing. `npm@latest` (v12+) ships a broken provenance path that fails publish with `Cannot find module 'sigstore'` ([failing run](https://github.com/rhinestonewtf/sdk/actions/runs/29034892651/job/86177182315)).
- Pin to `npm@11`, the known-good version, until upstream is fixed.