### PR TITLE
feat: add Robinhood Chain (4663) to the 2.0-beta line (shared-configs 1.7.8)

### DIFF
--- a/.changeset/robinhood-chain.md
+++ b/.changeset/robinhood-chain.md
@@ -1,0 +1,8 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Bump @rhinestone/shared-configs to 1.7.8 to add Robinhood Chain (4663). Raise the
+`viem` peer floor to ^2.55.0 — shared-configs 1.7.8's generated networks import
+`robinhood` from `viem/chains`, which was added in viem 2.55.0; on older viem the
+package crashes at module load.

--- a/bun.lock
+++ b/bun.lock
@@ -3,8 +3,8 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "^1.7.0",
-        "viem": "^2.40.1",
+        "@rhinestone/shared-configs": "^1.7.8",
+        "viem": "^2.55.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.1.0",
@@ -26,15 +26,15 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.38",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.7.0",
+        "@rhinestone/shared-configs": "1.7.8",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
         "express": ">=4",
         "jose": ">=5.0.0",
-        "viem": "^2.38.0",
+        "viem": "^2.55.0",
       },
       "optionalPeers": [
         "express",
@@ -189,7 +189,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.0", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.40.1" } }, "sha512-Jm3lIQyRs7lvIwuRadwwvAEY2rleJLadpm6amLPvRVzPkOY33+zqBG3Q+A0HroyN3Wt2SIAq8QLyGRs5pKSA8Q=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.8", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.55.0" } }, "sha512-Es4zeRf+rqd5JMmY3mLyJ+3BiDhIriIPqA7pZfirksTnX1ad3rfHxFuSZJCGadCPy1lOKhhP0vOT2Bbpunz/7Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 
@@ -535,7 +535,7 @@
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
-    "ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
+    "ox": ["ox@0.14.30", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
@@ -691,7 +691,7 @@
 
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 
-    "viem": ["viem@2.45.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.11.3", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-iVA9qrAgRdtpWa80lCZ6Jri6XzmLOwwA1wagX2HnKejKeliFLpON0KOdyfqvcy+gUpBVP59LBxP2aKiL3aj8fg=="],
+    "viem": ["viem@2.55.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.30", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-5XWSTCTmNvHCeT38Fsp31uofmOZFJdj4nOUH+H2Vh/hzsx9M7r+KgL3fSYUZeVn4H0UyQxjwPFqEaV4M0CI1tA=="],
 
     "vite": ["vite@6.3.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw=="],
 
@@ -707,7 +707,7 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "^1.7.0",
-    "viem": "^2.40.1"
+    "@rhinestone/shared-configs": "^1.7.8",
+    "viem": "^2.55.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.0",

--- a/src/package.json
+++ b/src/package.json
@@ -75,11 +75,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.7.0",
+    "@rhinestone/shared-configs": "1.7.8",
     "solady": "^0.1.26"
   },
   "peerDependencies": {
-    "viem": "^2.38.0",
+    "viem": "^2.55.0",
     "jose": ">=5.0.0",
     "express": ">=4"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,16 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // Deps: with commonjs "node" resolution, tsc ignores ox's exports map and
+    // resolves ox/* to its raw .ts source (skipLibCheck can't skip it). ox>=0.14
+    // (pulled in by viem 2.55, required for Robinhood in viem/chains) ships a
+    // tempo/ module whose source fails strict tsc. Redirect ox to its bundled
+    // .d.ts. Reached transitively via shared-configs -> viem/chains.
+    "baseUrl": ".",
+    "paths": {
+      "ox": ["./node_modules/ox/_types/index.d.ts"],
+      "ox/*": ["./node_modules/ox/_types/*"]
+    },
     // Output
     "rootDir": ".",
     "outDir": "./src/dist",


### PR DESCRIPTION
## What

Ports the Robinhood Chain (4663) enablement onto the **`release`** (2.0-beta) line so it reaches consumers that track the beta channel — notably **deposit-service-processor** (currently pinned `@rhinestone/sdk@2.0.0-beta.33`, which bundles shared-configs 1.6.7 and rejects chain 4663 with `Unsupported chain 4663`).

Robinhood support in the SDK is **purely a config bump** (no SDK source changes) — the chain registry comes from bundled shared-configs. This mirrors #644 which landed the same bump on `main`.

## Changes
- `@rhinestone/shared-configs` `1.7.0 → 1.7.8` (adds Robinhood Chain 4663) in both the root and published (`src`) manifests.
- `viem` floor `→ ^2.55.0` (peer + root dep): shared-configs 1.7.8's generated networks import `robinhood` from `viem/chains`, added in viem 2.55.0 — older viem crashes at module load.
- `tsconfig.json`: `ox → _types` paths redirect (viem 2.55 pulls `ox ≥0.14` whose `tempo/` source fails strict `tsc` under commonjs `node` resolution). Same fix as #644.
- changeset (patch) → cuts `2.0.0-beta.39`.

## Verification (on `release`)
- `tsc` build + `typecheck`: **0 errors**
- `biome check`: clean
- `test:unit`: **447 pass / 4 todo**. The single failure (`RhinestoneSDK.createAccount > signIntent delegates…`) is **pre-existing on `release` HEAD** — reproduced on a clean baseline checkout (viem 2.45, before this change) with identical 447/1 counts. Not introduced here.

## Release flow
Merging this triggers the changesets beta action → opens the "Version Packages (beta)" PR → merging that publishes **`@rhinestone/sdk@2.0.0-beta.39`** bundling shared-configs 1.7.8. The deposit-processor then bumps `beta.33 → beta.39` (verified: processor typechecks clean against the beta line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)