### PR TITLE
fix(smart-sessions): whitelist IntentExecutor as claim arbiter for non-arbiter settlement layers

### DIFF
--- a/src/modules/validators/policies/claim/arbiters.ts
+++ b/src/modules/validators/policies/claim/arbiters.ts
@@ -21,6 +21,16 @@ const SETTLEMENT_LAYER_CONTRACT_KEYS: Record<
 }
 
 /**
+ * Every settlement layer without a dedicated arbiter — CCTP, RELAY, RHINO,
+ * OFT, and any future layer — settles through the IntentExecutor, so it acts
+ * as the Permit2 claim arbiter for those routes. It's included in the "all
+ * layers" default and used as the fallback for any layer not present in
+ * {@link SETTLEMENT_LAYER_CONTRACT_KEYS}, so a newly-added settlement layer
+ * never silently fails the on-chain arbiter check.
+ */
+const FALLBACK_CONTRACT_KEYS: readonly string[] = ['intentExecutor']
+
+/**
  * Collects every distinct arbiter address that any chain in the registry
  * has deployed for the given settlement layers. The resulting whitelist
  * is what the Permit2 claim policy enforces on-chain — a session signed
@@ -42,15 +52,22 @@ export function getArbitersForSettlementLayers(
   layers: readonly CrossChainSettlementLayer[] | undefined,
   useDevContracts?: boolean,
 ): Address[] | undefined {
-  const effectiveLayers: readonly CrossChainSettlementLayer[] =
-    !layers || layers.length === 0
-      ? (Object.keys(
-          SETTLEMENT_LAYER_CONTRACT_KEYS,
-        ) as CrossChainSettlementLayer[])
-      : layers
-
   const registry = useDevContracts ? contractAddressesDev : contractAddresses
-  const keys = effectiveLayers.flatMap((l) => SETTLEMENT_LAYER_CONTRACT_KEYS[l])
+
+  // Unknown/empty ⇒ permission every mechanism: all dedicated arbiters PLUS
+  // the IntentExecutor (the universal settler). Named layers resolve to their
+  // dedicated arbiter, falling back to the IntentExecutor when they have none.
+  const layerKeys = SETTLEMENT_LAYER_CONTRACT_KEYS as Record<
+    string,
+    readonly string[] | undefined
+  >
+  const keys =
+    !layers || layers.length === 0
+      ? [
+          ...Object.values(SETTLEMENT_LAYER_CONTRACT_KEYS).flat(),
+          ...FALLBACK_CONTRACT_KEYS,
+        ]
+      : layers.flatMap((l) => layerKeys[l] ?? FALLBACK_CONTRACT_KEYS)
   const seen = new Set<string>()
   const addresses: Address[] = []
 


### PR DESCRIPTION
## Problem

Every **cross-chain** smart-session intent that settles via **CCTP / RELAY / RHINO / OFT** fails simulation with `InvalidSignature` (surfaced as `HashMismatch` deep in the emissary). Same-chain works; only cross-chain via those layers breaks. Reproduced on Arb→Base (CCTP) and robinhood→Base (RELAY).

## Root cause

`getArbitersForSettlementLayers` builds the session's Permit2 claim-policy **arbiter whitelist**. Its map only covers arbiter-based layers:

```ts
SAME_CHAIN → samechainArbiter
ECO        → ecoArbiter
ACROSS     → across7579Arbiter, acrossMulticallArbiter
```

But **CCTP / RELAY / RHINO / OFT settle through the `IntentExecutor`**, not a dedicated arbiter. A session is created before its route is known, so `settlementLayers` is `undefined` → the resolver expands to the union of the three arbiter-based layers → the whitelist **excludes the IntentExecutor**. On-chain, the Permit2 claim policy (`validateArbiter`, where the arbiter *is* the Permit2 spender) then rejects the IntentExecutor and the claim fails.

Traced on dev: the reverting arbiter is the IntentExecutor `0xbf9b5b91…` (dev `intentExecutor`), rejected because it isn't in the session whitelist.

This regressed relative to beta.11, which had no per-layer arbiter restriction (empty whitelist ⇒ the on-chain `FIELD_ARBITER` check was never enabled), so all cross-chain routes validated.

## Fix

Include the `IntentExecutor` in the "all layers" default, and fall back to it for any settlement layer without a dedicated arbiter — so current and future IntentExecutor-settled layers are always permissioned, while `SAME_CHAIN`/`ECO`/`ACROSS` keep their dedicated arbiters unchanged.

Validated against a locally-patched beta.39:

| `settlementLayers` | includes IntentExecutor? |
|---|---|
| `undefined` (all) | ✅ (+ all dedicated arbiters) |
| `['CCTP']` / `['RELAY']` / `['RHINO']` / `['OFT']` | ✅ |
| `['SAME_CHAIN']` / `['ECO']` / `['ACROSS']` | ❌ (dedicated arbiters, unchanged) |
| any future/unmapped layer | ✅ (fallback) |

Type-clean (`tsc --noEmit`) and biome-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)