### PR TITLE
fix: reject duplicate session permissions for the same (target, selector)

### DIFF
--- a/.changeset/reject-duplicate-session-permissions.md
+++ b/.changeset/reject-duplicate-session-permissions.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Reject duplicate session permissions for the same function on the same contract at session build time. Previously they were silently accepted, but on-chain they share one action config, so the later entry's policies overwrote the earlier ones and calls permitted by the earlier entry failed with `InvalidSignature()` at execution.
+Reject duplicate session permissions for the same function on the same contract at session build time. Previously they were silently accepted and collided on-chain, so only the last entry's policies took effect and calls permitted by earlier entries failed at execution.

--- a/.changeset/reject-duplicate-session-permissions.md
+++ b/.changeset/reject-duplicate-session-permissions.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Reject duplicate session permissions for the same function on the same contract at session build time. Previously they were silently accepted, but on-chain they share one action config, so the later entry's policies overwrote the earlier ones and calls permitted by the earlier entry failed with `InvalidSignature()` at execution.

--- a/src/modules/validators/permissions.test.ts
+++ b/src/modules/validators/permissions.test.ts
@@ -472,6 +472,72 @@ describe('resolvePermissions', () => {
     expect(actions[1].target).toBe(dai)
   })
 
+  test('throws on duplicate (target, function) across permission entries', () => {
+    const recipientB: Address = '0x2222222222222222222222222222222222222222'
+
+    expect(() =>
+      resolvePermissions([
+        {
+          abi: erc20Abi,
+          address: USDC,
+          functions: {
+            transfer: {
+              params: { recipient: { condition: 'equal', value: RECIPIENT } },
+            },
+          },
+        },
+        {
+          abi: erc20Abi,
+          address: USDC,
+          functions: {
+            transfer: {
+              params: { recipient: { condition: 'equal', value: recipientB } },
+            },
+          },
+        },
+      ]),
+    ).toThrow(
+      new RegExp(`Duplicate permission for function "transfer".*on ${USDC}`),
+    )
+  })
+
+  test('duplicate detection is case-insensitive on the target address', () => {
+    expect(() =>
+      resolvePermissions([
+        {
+          abi: erc20Abi,
+          address: USDC,
+          functions: { transfer: {} },
+        },
+        {
+          abi: erc20Abi,
+          address: USDC.toLowerCase() as Address,
+          functions: { transfer: {} },
+        },
+      ]),
+    ).toThrow(/Duplicate permission/)
+  })
+
+  test('same function on different contracts is allowed', () => {
+    const dai: Address = '0x3333333333333333333333333333333333333333'
+
+    const actions = resolvePermissions([
+      { abi: erc20Abi, address: USDC, functions: { transfer: {} } },
+      { abi: erc20Abi, address: dai, functions: { transfer: {} } },
+    ])
+
+    expect(actions).toHaveLength(2)
+  })
+
+  test('different functions on the same contract are allowed', () => {
+    const actions = resolvePermissions([
+      { abi: erc20Abi, address: USDC, functions: { transfer: {} } },
+      { abi: erc20Abi, address: USDC, functions: { approve: {} } },
+    ])
+
+    expect(actions).toHaveLength(2)
+  })
+
   test('Session.permissions feeds into getSessionData without errors', () => {
     const session = toSession({
       chain: base,

--- a/src/modules/validators/permissions.ts
+++ b/src/modules/validators/permissions.ts
@@ -349,10 +349,48 @@ function resolvePermission(permission: Permission): ScopedAction[] {
   return actions
 }
 
+// Error-path only: recover the function name behind a selector for the
+// duplicate-permission message.
+function findFunctionName(
+  permission: Permission,
+  selector: Hex,
+): string | undefined {
+  return Object.keys(permission.functions).find((name) => {
+    const entry = (permission.abi as readonly AbiParameter[]).find(
+      (e): e is AbiFunction =>
+        (e as { type: string }).type === 'function' &&
+        (e as { name: string }).name === name,
+    )
+    return entry !== undefined && toFunctionSelector(entry) === selector
+  })
+}
+
 function resolvePermissions(
   permissions: readonly Permission[],
 ): ScopedAction[] {
-  return permissions.flatMap(resolvePermission)
+  // On-chain, actions are keyed by keccak(target, selector): two permission
+  // entries for the same function on the same contract share one actionId,
+  // and the later entry's `initializeWithMultiplexer` silently overwrites the
+  // earlier one's policy config. Reject at build time instead of letting the
+  // collision surface as an opaque InvalidSignature() at execution.
+  const seen = new Set<string>()
+  return permissions.flatMap((permission) => {
+    const actions = resolvePermission(permission)
+    for (const action of actions) {
+      const key = `${action.target.toLowerCase()}:${action.selector.toLowerCase()}`
+      if (seen.has(key)) {
+        const fnName = findFunctionName(permission, action.selector)
+        throw new Error(
+          `Duplicate permission for function "${fnName}" (selector ${action.selector}) ` +
+            `on ${action.target}: permission entries for the same function on the same ` +
+            "contract share one on-chain action, so the later entry's policies would " +
+            'silently overwrite the earlier ones. Merge them into a single entry.',
+        )
+      }
+      seen.add(key)
+    }
+    return actions
+  })
 }
 
 export { resolvePermissions, resolvePermission }


### PR DESCRIPTION
- `resolvePermissions` now throws at session build time when two permission entries configure the same function on the same contract. On-chain, such entries share one `actionId`, so the later entry's `initializeWithMultiplexer` silently overwrites the earlier one's policy config — calls permitted by the earlier entry then fail with an opaque `InvalidSignature()` at execution.
- The SDK-injected actions (wrapped-token deposit, intent-execution fallback, dummy preclaimop) are appended after the check and intentionally exempt.
- Adds unit tests (duplicate across entries, case-insensitive target match, allowed same-fn/different-contract and different-fn/same-contract) and a patch changeset.

**Out of scope:** a user permission overlapping an injected action (e.g. the wrapped token's `deposit()`) does not hit the overwrite path — the injected action's sudo policy is a different policy contract, so both attach to the actionId and AND-compose on-chain; the user's limits remain enforced. The residual effect is that such a permission also gates the SDK's automatic native-token wrapping (an availability limitation, arguably intended), which is a known limitation and deliberately not guarded here.

Closes [RHI-4786](https://linear.app/rhinestone/issue/RHI-4786)

🤖 Generated with [Claude Code](https://claude.com/claude-code)