### PR TITLE
feat: add independent multisig signing

### DIFF
--- a/.changeset/independent-multisig-signing.md
+++ b/.changeset/independent-multisig-signing.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add independent multisig signing. Pass an `owner` to `signTransaction` to create a serializable owner signature, then combine owner signatures with `assembleTransaction` before submission. Supports ECDSA, passkey, and multi-factor owner sets.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,9 @@ the relayer market; the SDK signs and submits.
 2. `getTransactionMessages(...)` — typed-data messages to sign (optional; for
    headless signing).
 3. `signTransaction(...)` — signs the origin/destination/target-execution typed
-   data with the account's validator.
+   data with the account's validator. Multisig owners can instead call
+   `signTransaction(prepared, { owner })` independently and combine their
+   contributions with `assembleTransaction(...)`.
 4. `submitTransaction(...)` — posts the signed intent; returns a
    `TransactionResult` (an intent id).
 5. `waitForExecution(result)` — polls the orchestrator until the intent reaches

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -130,6 +130,7 @@ export const manifest: Group[] = [
           accountMethod('prepareTransaction'),
           accountMethod('getTransactionMessages'),
           accountMethod('signTransaction'),
+          accountMethod('assembleTransaction'),
           accountMethod('signAuthorizations'),
           accountMethod('signIntent'),
           accountMethod('submitTransaction'),

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -1,4 +1,5 @@
 import {
+  type Account,
   type Address,
   type Chain,
   concat,
@@ -14,6 +15,7 @@ import {
   type TypedData,
   zeroAddress,
 } from 'viem'
+import type { WebAuthnAccount } from 'viem/account-abstraction'
 import {
   sendTransactionInternal,
   sendUserOperationInternal,
@@ -489,7 +491,43 @@ function checkAddress(config: RhinestoneConfig) {
   return initData.address.toLowerCase() === getAddress(config).toLowerCase()
 }
 
-// Signs and packs a signature to be EIP-1271 compatible
+async function packAccountSignature(
+  config: RhinestoneConfig,
+  signature: Hex,
+  validator: ValidatorConfig,
+  transformSignature: (signature: Hex) => Hex = (signature) => signature,
+): Promise<Hex> {
+  const account = getAccountProvider(config)
+  switch (account.type) {
+    case 'safe': {
+      return packSafeSignature(signature, validator, transformSignature)
+    }
+    case 'nexus': {
+      const defaultValidatorAddress = getNexusDefaultValidatorAddress(
+        account.version,
+      )
+      return packNexusSignature(
+        signature,
+        validator,
+        transformSignature,
+        defaultValidatorAddress,
+      )
+    }
+    case 'kernel': {
+      return packKernelSignature(signature, validator, transformSignature)
+    }
+    case 'startale': {
+      return packStartaleSignature(signature, validator, transformSignature)
+    }
+    case 'hca': {
+      return packHcaSignature(signature, validator, transformSignature)
+    }
+    default: {
+      throw new Error(`Unsupported account type: ${(account as any).type}`)
+    }
+  }
+}
+
 async function getEip1271Signature(
   config: RhinestoneConfig,
   signers: InternalSignerSet | undefined,
@@ -503,43 +541,18 @@ async function getEip1271Signature(
   }
 
   signers = signers ?? convertOwnerSetToSignerSet(config.owners!)
-  const signFn = (hash: Hex) =>
-    signMessage(signers, chain, address, hash, false)
   const account = getAccountProvider(config)
   const address = getAddress(config)
-  switch (account.type) {
-    case 'safe': {
-      const signature = await signFn(hash)
-      return packSafeSignature(signature, validator, transformSignature)
-    }
-    case 'nexus': {
-      const signature = await signFn(hash)
-      const defaultValidatorAddress = getNexusDefaultValidatorAddress(
-        account.version,
-      )
-      return packNexusSignature(
-        signature,
-        validator,
-        transformSignature,
-        defaultValidatorAddress,
-      )
-    }
-    case 'kernel': {
-      const signature = await signFn(wrapKernelMessageHash(hash, address))
-      return packKernelSignature(signature, validator, transformSignature)
-    }
-    case 'startale': {
-      const signature = await signFn(hash)
-      return packStartaleSignature(signature, validator, transformSignature)
-    }
-    case 'hca': {
-      const signature = await signFn(hash)
-      return packHcaSignature(signature, validator, transformSignature)
-    }
-    default: {
-      throw new Error(`Unsupported account type: ${(account as any).type}`)
-    }
-  }
+  const signedHash =
+    account.type === 'kernel' ? wrapKernelMessageHash(hash, address) : hash
+  const signature = await signMessage(
+    signers,
+    chain,
+    address,
+    signedHash,
+    false,
+  )
+  return packAccountSignature(config, signature, validator, transformSignature)
 }
 
 // Signs and packs a signature to be used by the emissary validator
@@ -580,48 +593,100 @@ async function getTypedDataPackedSignature<
 
   const address = getAddress(config)
   signers = signers ?? convertOwnerSetToSignerSet(config.owners!)
-  const signFn = (
-    parameters: HashTypedDataParameters<typedData, primaryType>,
-  ) => signTypedData(signers, chain, address, parameters)
   const account = getAccountProvider(config)
-  switch (account.type) {
-    case 'safe': {
-      const signature = await signFn(parameters)
-      return packSafeSignature(signature, validator, transformSignature)
-    }
-    case 'nexus': {
-      const signature = await signFn(parameters)
-      const defaultValidatorAddress = getNexusDefaultValidatorAddress(
-        account.version,
-      )
-      return packNexusSignature(
-        signature,
-        validator,
-        transformSignature,
-        defaultValidatorAddress,
-      )
-    }
-    case 'kernel': {
-      const address = getAddress(config)
-      const signMessageFn = (hash: Hex) =>
-        signMessage(signers, chain, address, hash, false)
-      const signature = await signMessageFn(
-        wrapKernelMessageHash(hashTypedData(parameters), address),
-      )
-      return packKernelSignature(signature, validator, transformSignature)
-    }
-    case 'startale': {
-      const signature = await signFn(parameters)
-      return packStartaleSignature(signature, validator, transformSignature)
-    }
-    case 'hca': {
-      const signature = await signFn(parameters)
-      return packHcaSignature(signature, validator, transformSignature)
-    }
-    default: {
-      throw new Error(`Unsupported account type: ${(account as any).type}`)
-    }
+  const signature =
+    account.type === 'kernel'
+      ? await signMessage(
+          signers,
+          chain,
+          address,
+          wrapKernelMessageHash(hashTypedData(parameters), address),
+          false,
+        )
+      : await signTypedData(signers, chain, address, parameters)
+  return packAccountSignature(config, signature, validator, transformSignature)
+}
+
+async function getOwnerEcdsaSignature<
+  typedData extends TypedData | Record<string, unknown> = TypedData,
+  primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
+>(
+  config: RhinestoneConfig,
+  chain: Chain,
+  parameters: HashTypedDataParameters<typedData, primaryType>,
+  owner: Account,
+  module: Address | undefined,
+  validatorSupportsEip712: boolean,
+): Promise<Hex> {
+  if (config.account?.type === 'eoa') {
+    throw new EoaSigningNotSupportedError('packed signatures')
   }
+  const address = getAddress(config)
+  const signers: SignerSet = {
+    type: 'owner',
+    kind: 'ecdsa',
+    accounts: [owner],
+    module,
+  }
+  const accountProvider = getAccountProvider(config)
+  if (accountProvider.type === 'kernel') {
+    return signMessage(
+      signers,
+      chain,
+      address,
+      wrapKernelMessageHash(hashTypedData(parameters), address),
+      false,
+    )
+  }
+  if (!validatorSupportsEip712) {
+    return signMessage(
+      signers,
+      chain,
+      address,
+      hashTypedData(parameters),
+      false,
+    )
+  }
+  return signTypedData(signers, chain, address, parameters)
+}
+
+async function getOwnerPasskeySignature<
+  typedData extends TypedData | Record<string, unknown> = TypedData,
+  primaryType extends keyof typedData | 'EIP712Domain' = keyof typedData,
+>(
+  config: RhinestoneConfig,
+  parameters: HashTypedDataParameters<typedData, primaryType>,
+  owner: WebAuthnAccount,
+  validatorSupportsEip712: boolean,
+): Promise<{
+  webauthn: {
+    authenticatorData: Hex
+    clientDataJSON: string
+    challengeIndex?: number | undefined
+    typeIndex?: number | undefined
+    userVerificationRequired?: boolean | undefined
+  }
+  signature: Hex
+}> {
+  if (config.account?.type === 'eoa') {
+    throw new EoaSigningNotSupportedError('packed signatures')
+  }
+  const address = getAddress(config)
+  const accountProvider = getAccountProvider(config)
+  if (accountProvider.type === 'kernel') {
+    const { webauthn, signature } = await owner.sign({
+      hash: wrapKernelMessageHash(hashTypedData(parameters), address),
+    })
+    return { webauthn, signature }
+  }
+  if (!validatorSupportsEip712) {
+    const { webauthn, signature } = await owner.sign({
+      hash: hashTypedData(parameters),
+    })
+    return { webauthn, signature }
+  }
+  const { webauthn, signature } = await owner.signTypedData(parameters)
+  return { webauthn, signature }
 }
 
 async function isDeployed(config: RhinestoneConfig, chain: Chain) {
@@ -970,7 +1035,10 @@ export {
   getSmartAccount,
   getEip1271Signature,
   getEmissarySignature,
+  getOwnerEcdsaSignature,
+  getOwnerPasskeySignature,
   getTypedDataPackedSignature,
+  packAccountSignature,
   // Errors
   isAccountError,
   AccountError,

--- a/src/accounts/signing/common.ts
+++ b/src/accounts/signing/common.ts
@@ -146,7 +146,23 @@ async function signWithMultiFactorAuth<T>(
     }),
   )
 
-  const data = encodeAbiParameters(
+  return packMultiFactorOwnerSignatures(
+    signers.validators.map((validator, index) => ({
+      id: validator.id,
+      validatorAddress: getValidator(validator).address,
+      signature: signatures[index],
+    })),
+  )
+}
+
+function packMultiFactorOwnerSignatures(
+  entries: {
+    id: number | Hex
+    validatorAddress: Address
+    signature: Hex
+  }[],
+): Hex {
+  return encodeAbiParameters(
     [
       {
         components: [
@@ -162,21 +178,46 @@ async function signWithMultiFactorAuth<T>(
       },
     ],
     [
-      signers.validators.map((validator, index) => {
-        const validatorModule = getValidator(validator)
-        return {
-          packedValidatorAndId: concat([
-            pad(toHex(validator.id), {
-              size: 12,
-            }),
-            validatorModule.address,
-          ]),
-          data: signatures[index],
-        }
-      }),
+      entries.map((entry) => ({
+        packedValidatorAndId: concat([
+          pad(toHex(entry.id), {
+            size: 12,
+          }),
+          entry.validatorAddress,
+        ]),
+        data: entry.signature,
+      })),
     ],
   )
-  return data
+}
+
+function packPasskeyOwnerSignatures(
+  chain: Chain,
+  address: Address,
+  publicKeys: Hex[],
+  signatures: { webauthn: WebAuthnSignMetadata; signature: Hex }[],
+  module?: Address,
+): Hex {
+  const usePrecompile = isRip7212SupportedNetwork(chain)
+  const credIds = publicKeys.map((publicKey) => {
+    const { x, y } = parsePublicKey(publicKey)
+    return generateCredentialId(x, y, address)
+  })
+  const webAuthns = signatures.map((signature) => {
+    const { r, s } = parseSignature(signature.signature)
+    return {
+      authenticatorData: signature.webauthn.authenticatorData,
+      clientDataJSON: signature.webauthn.clientDataJSON,
+      challengeIndex: BigInt(signature.webauthn.challengeIndex ?? 0),
+      typeIndex: BigInt(signature.webauthn.typeIndex ?? 0),
+      r,
+      s,
+    }
+  })
+  if (module?.toLowerCase() === WEBAUTHN_V0_VALIDATOR_ADDRESS) {
+    return packPasskeySignatureV0(webAuthns[0], usePrecompile)
+  }
+  return packPasskeySignature(credIds, usePrecompile, webAuthns)
 }
 
 async function signWithSession(
@@ -273,27 +314,13 @@ async function signWithOwners<T>(
           signingFunctions.signPasskey(account, params),
         ),
       )
-      const usePrecompile = isRip7212SupportedNetwork(chain)
-      const credIds = signers.accounts.map((account) => {
-        const publicKey = account.publicKey
-        const { x, y } = parsePublicKey(publicKey)
-        return generateCredentialId(x, y, address)
-      })
-      const webAuthns = signatures.map((signature) => {
-        const { r, s } = parseSignature(signature.signature)
-        return {
-          authenticatorData: signature.webauthn.authenticatorData,
-          clientDataJSON: signature.webauthn.clientDataJSON,
-          challengeIndex: BigInt(signature.webauthn.challengeIndex ?? 0),
-          typeIndex: BigInt(signature.webauthn.typeIndex ?? 0),
-          r,
-          s,
-        }
-      })
-      if (signers.module?.toLowerCase() === WEBAUTHN_V0_VALIDATOR_ADDRESS) {
-        return packPasskeySignatureV0(webAuthns[0], usePrecompile)
-      }
-      return packPasskeySignature(credIds, usePrecompile, webAuthns)
+      return packPasskeyOwnerSignatures(
+        chain,
+        address,
+        signers.accounts.map((account) => account.publicKey),
+        signatures,
+        signers.module,
+      )
     }
     case 'multi-factor': {
       return signWithMultiFactorAuth(
@@ -313,6 +340,8 @@ async function signWithOwners<T>(
 
 export {
   convertOwnerSetToSignerSet,
+  packMultiFactorOwnerSignatures,
+  packPasskeyOwnerSignatures,
   signWithMultiFactorAuth,
   signWithSession,
   signWithOwners,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -18,11 +18,16 @@ import {
 import {
   Eip7702InitSignatureRequiredError,
   ExecutionError,
+  IndependentSigningNotSupportedError,
+  InsufficientOwnerSignaturesError,
   IntentFailedError,
+  InvalidOwnerSigningOptionsError,
   InvalidSourceCallsError,
   isExecutionError,
+  MismatchedOwnerSignaturesError,
   OrderPathRequiredForIntentsError,
   QuoteNotInPreparedTransactionError,
+  UnknownOwnerError,
 } from '../execution'
 import type { ErrorDetail } from '../orchestrator'
 import {
@@ -75,10 +80,15 @@ export {
   isExecutionError,
   ExecutionError,
   Eip7702InitSignatureRequiredError,
+  IndependentSigningNotSupportedError,
+  InsufficientOwnerSignaturesError,
   IntentFailedError,
+  InvalidOwnerSigningOptionsError,
   InvalidSourceCallsError,
+  MismatchedOwnerSignaturesError,
   OrderPathRequiredForIntentsError,
   QuoteNotInPreparedTransactionError,
+  UnknownOwnerError,
   // Orchestrator
   isOrchestratorError,
   isRetryable,

--- a/src/execution/error.ts
+++ b/src/execution/error.ts
@@ -106,6 +106,92 @@ class Eip7702InitSignatureRequiredError extends ExecutionError {
   }
 }
 
+class UnknownOwnerError extends ExecutionError {
+  constructor(params?: {
+    context?: { signer?: string; publicKey?: string; validatorId?: number }
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        'The provided owner is not part of the account owner set. Pass an account that matches one of the configured `owners` (for multi-factor owner sets, also pass the matching `validatorId`).',
+      ...params,
+    })
+  }
+}
+
+class MismatchedOwnerSignaturesError extends ExecutionError {
+  constructor(params?: {
+    message?: string
+    context?: any
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        params?.message ??
+        'Owner signatures are inconsistent and cannot be assembled. All owners must sign the same prepared transaction and quote using `signTransaction` with the `owner` option.',
+      ...params,
+    })
+  }
+}
+
+class InsufficientOwnerSignaturesError extends ExecutionError {
+  constructor(params?: {
+    required?: number
+    provided?: number
+    validatorId?: number
+    context?: any
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        params?.required !== undefined
+          ? params?.validatorId !== undefined
+            ? `Not enough owner signatures to meet the threshold of validator ${params.validatorId}: ${params.provided ?? 0} of ${params.required} required. Collect the missing owner signatures before calling \`assembleTransaction\`.`
+            : `Not enough owner signatures to meet the account threshold: ${params.provided ?? 0} of ${params.required} required. Collect the missing owner signatures before calling \`assembleTransaction\`.`
+          : 'Not enough owner signatures to meet the account threshold. Collect the missing owner signatures before calling `assembleTransaction`.',
+      context: {
+        required: params?.required,
+        provided: params?.provided,
+        validatorId: params?.validatorId,
+        ...params?.context,
+      },
+      errorType: params?.errorType,
+      traceId: params?.traceId,
+    })
+  }
+}
+
+class InvalidOwnerSigningOptionsError extends ExecutionError {
+  constructor(params?: {
+    context?: any
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        'Invalid per-owner signing options. Pass `validatorId` only for multi-factor accounts, where it must identify the factor containing `owner`.',
+      ...params,
+    })
+  }
+}
+
+class IndependentSigningNotSupportedError extends ExecutionError {
+  constructor(params?: {
+    context?: any
+    errorType?: string
+    traceId?: string
+  }) {
+    super({
+      message:
+        'Independent owner signing is only supported for smart accounts using ECDSA, passkey, or multi-factor owners. EOA accounts, smart sessions, and K1/ERC-7739 validators must use the standard `signTransaction` flow.',
+      ...params,
+    })
+  }
+}
+
 function isExecutionError(error: Error): error is ExecutionError {
   return error instanceof ExecutionError
 }
@@ -114,8 +200,13 @@ export {
   isExecutionError,
   ExecutionError,
   Eip7702InitSignatureRequiredError,
+  IndependentSigningNotSupportedError,
+  InsufficientOwnerSignaturesError,
+  InvalidOwnerSigningOptionsError,
   InvalidSourceCallsError,
+  MismatchedOwnerSignaturesError,
   OrderPathRequiredForIntentsError,
   QuoteNotInPreparedTransactionError,
   IntentFailedError,
+  UnknownOwnerError,
 }

--- a/src/execution/error.ts
+++ b/src/execution/error.ts
@@ -1,3 +1,5 @@
+import type { Hex } from 'viem'
+
 class ExecutionError extends Error {
   private readonly _message: string
   private readonly _context: any
@@ -108,7 +110,11 @@ class Eip7702InitSignatureRequiredError extends ExecutionError {
 
 class UnknownOwnerError extends ExecutionError {
   constructor(params?: {
-    context?: { signer?: string; publicKey?: string; validatorId?: number }
+    context?: {
+      signer?: string
+      publicKey?: string
+      validatorId?: number | Hex
+    }
     errorType?: string
     traceId?: string
   }) {
@@ -140,7 +146,7 @@ class InsufficientOwnerSignaturesError extends ExecutionError {
   constructor(params?: {
     required?: number
     provided?: number
-    validatorId?: number
+    validatorId?: number | Hex
     context?: any
     errorType?: string
     traceId?: string

--- a/src/execution/independent-signing.test.ts
+++ b/src/execution/independent-signing.test.ts
@@ -1,0 +1,478 @@
+import {
+  concat,
+  type Hex,
+  hashMessage,
+  hashTypedData,
+  type TypedDataDefinition,
+} from 'viem'
+import {
+  toWebAuthnAccount,
+  type WebAuthnAccount,
+} from 'viem/account-abstraction'
+import { privateKeyToAccount } from 'viem/accounts'
+import { arbitrum, base } from 'viem/chains'
+import { describe, expect, test } from 'vitest'
+import { accountA, accountB, accountC } from '../../test/consts'
+import type { Quote, SignData } from '../orchestrator'
+import type {
+  AccountProviderConfig,
+  MultiFactorValidatorConfig,
+  OwnerSet,
+  RhinestoneConfig,
+} from '../types'
+import {
+  IndependentSigningNotSupportedError,
+  InsufficientOwnerSignaturesError,
+  InvalidOwnerSigningOptionsError,
+  MismatchedOwnerSignaturesError,
+  UnknownOwnerError,
+} from './error'
+import {
+  assembleTransaction,
+  type OwnerSignature,
+  type PreparedTransactionData,
+  signTransaction,
+} from './utils'
+
+const ACCOUNT_ADDRESS = '0x1111111111111111111111111111111111111111'
+const OWNABLE_V0_VALIDATOR_ADDRESS =
+  '0x2483da3a338895199e5e538530213157e931bf06'
+const OWNABLE_BETA_VALIDATOR_ADDRESS =
+  '0x0000000000e9e6e96bcaa3c113187cdb7e38aed9'
+const WEBAUTHN_V0_VALIDATOR_ADDRESS =
+  '0x0000000000578c4cb0e472a5462da43c495c3f33'
+const K1_VALIDATOR_ADDRESS = '0x00000072f286204bb934ed49d8969e86f7dec7b1'
+
+const message = (chainId: number, value: bigint): TypedDataDefinition => ({
+  domain: {
+    name: 'Independent signing test',
+    version: '1',
+    chainId,
+    verifyingContract: ACCOUNT_ADDRESS,
+  },
+  types: {
+    Test: [{ name: 'value', type: 'uint256' }],
+  },
+  primaryType: 'Test',
+  message: { value },
+})
+
+const signData: SignData = {
+  origin: [message(base.id, 1n), message(arbitrum.id, 2n)],
+  destination: message(arbitrum.id, 3n),
+}
+
+function makeQuote(intentId: string, data: SignData = signData): Quote {
+  return { intentId, signData: data } as Quote
+}
+
+function makePrepared(
+  options: {
+    quotes?: Quote[]
+    transaction?: PreparedTransactionData['transaction']
+  } = {},
+): PreparedTransactionData {
+  const quotes = options.quotes ?? [makeQuote('intent-a')]
+  return {
+    quotes: { traceId: 'trace', best: quotes[0], all: quotes },
+    intentInput: { test: true },
+    transaction: options.transaction ?? { chain: base },
+  }
+}
+
+function makeConfig(
+  account: AccountProviderConfig['type'],
+  owners: OwnerSet,
+): RhinestoneConfig {
+  return {
+    account: { type: account } as AccountProviderConfig,
+    owners,
+    ...(account === 'kernel' || account === 'hca'
+      ? {}
+      : { initData: { address: ACCOUNT_ADDRESS as Hex } }),
+  }
+}
+
+function makePasskey(seed: string): WebAuthnAccount {
+  const hashSeed = privateKeyToAccount(
+    `0x${seed.padStart(64, seed)}` as Hex,
+  ).address.slice(2)
+  const publicKey = `0x${hashSeed.padEnd(128, hashSeed)}` as Hex
+  const account = toWebAuthnAccount({
+    credential: { id: `credential-${seed}`, publicKey },
+  })
+  const signHash = async (hash: Hex) => ({
+    signature: concat([hash, hash]),
+    webauthn: {
+      authenticatorData: `0x${'ab'.repeat(37)}` as Hex,
+      clientDataJSON: JSON.stringify({ type: 'webauthn.get', challenge: hash }),
+      challengeIndex: 23,
+      typeIndex: 1,
+      userVerificationRequired: false,
+    },
+    raw: {},
+  })
+  account.sign = ({ hash }) => signHash(hash)
+  account.signMessage = ({ message }) => signHash(hashMessage(message))
+  account.signTypedData = (parameters) =>
+    signHash(hashTypedData(parameters as TypedDataDefinition))
+  return account
+}
+
+const passkeyA = makePasskey('1')
+const passkeyB = makePasskey('2')
+
+const accountTypes = ['safe', 'nexus', 'kernel', 'startale'] as const
+
+function signingOptions(owners: OwnerSet) {
+  switch (owners.type) {
+    case 'ecdsa':
+      return owners.accounts.map((owner) => ({ owner }))
+    case 'ens':
+      return owners.owners.map(({ account: owner }) => ({ owner }))
+    case 'passkey':
+      return owners.accounts.map((owner) => ({ owner }))
+    case 'multi-factor':
+      return owners.validators.flatMap((validator, validatorId) => {
+        const accounts =
+          validator.type === 'ens'
+            ? validator.owners.map(({ account }) => account)
+            : validator.accounts
+        return accounts.map((owner) => ({ owner, validatorId }))
+      })
+  }
+}
+
+async function expectGoldenEquivalence(
+  config: RhinestoneConfig,
+  prepared = makePrepared(),
+) {
+  const full = await signTransaction(config, prepared)
+  const partials: OwnerSignature[] = []
+  for (const options of signingOptions(config.owners as OwnerSet)) {
+    partials.push(await signTransaction(config, prepared, options))
+  }
+  expect(JSON.parse(JSON.stringify(partials))).toEqual(partials)
+  const assembled = await assembleTransaction(
+    config,
+    prepared,
+    partials.reverse(),
+  )
+  expect(assembled).toEqual(full)
+}
+
+describe.each(accountTypes)('independent signing: %s', (accountType) => {
+  test('assembles ECDSA signatures byte-for-byte', async () => {
+    await expectGoldenEquivalence(
+      makeConfig(accountType, {
+        type: 'ecdsa',
+        accounts: [accountA, accountB],
+        threshold: 2,
+      }),
+    )
+  })
+
+  test('assembles passkey signatures byte-for-byte', async () => {
+    await expectGoldenEquivalence(
+      makeConfig(accountType, {
+        type: 'passkey',
+        accounts: [passkeyA, passkeyB],
+        threshold: 2,
+      }),
+    )
+  })
+
+  test('assembles multi-factor signatures byte-for-byte', async () => {
+    await expectGoldenEquivalence(
+      makeConfig(accountType, {
+        type: 'multi-factor',
+        validators: [
+          {
+            type: 'ecdsa',
+            accounts: [accountA, accountB],
+            threshold: 2,
+          },
+          { type: 'passkey', accounts: [passkeyA] },
+        ],
+        threshold: 2,
+      }),
+    )
+  })
+})
+
+test('assembles HCA ENS signatures byte-for-byte', async () => {
+  await expectGoldenEquivalence(
+    makeConfig('hca', {
+      type: 'ens',
+      owners: [{ account: accountA }, { account: accountB }],
+      threshold: 2,
+    }),
+  )
+})
+
+describe('independent signing transformations', () => {
+  test.each([
+    ['safe', OWNABLE_V0_VALIDATOR_ADDRESS],
+    ['safe', OWNABLE_BETA_VALIDATOR_ADDRESS],
+    ['kernel', OWNABLE_V0_VALIDATOR_ADDRESS],
+    ['kernel', OWNABLE_BETA_VALIDATOR_ADDRESS],
+  ] as const)(
+    'matches legacy Ownable signing for %s with %s',
+    async (accountType, module) => {
+      await expectGoldenEquivalence(
+        makeConfig(accountType, {
+          type: 'ecdsa',
+          accounts: [accountA, accountB],
+          threshold: 2,
+          module,
+        }),
+      )
+    },
+  )
+
+  test.each(['safe', 'kernel'] as const)(
+    'matches legacy WebAuthn signing for %s',
+    async (accountType) => {
+      await expectGoldenEquivalence(
+        makeConfig(accountType, {
+          type: 'passkey',
+          accounts: [passkeyA],
+          module: WEBAUTHN_V0_VALIDATOR_ADDRESS,
+        }),
+      )
+    },
+  )
+})
+
+describe('independent signing validation', () => {
+  const owners: OwnerSet = {
+    type: 'ecdsa',
+    accounts: [accountA, accountB],
+    threshold: 2,
+  }
+  const config = makeConfig('safe', owners)
+
+  test('assembles a threshold subset in configured owner order', async () => {
+    const subsetConfig = makeConfig('safe', {
+      type: 'ecdsa',
+      accounts: [accountA, accountB, accountC],
+      threshold: 2,
+    })
+    const prepared = makePrepared({
+      transaction: {
+        chain: base,
+        signers: {
+          type: 'owner',
+          kind: 'ecdsa',
+          accounts: [accountA, accountC],
+        },
+      },
+    })
+    const full = await signTransaction(subsetConfig, prepared)
+    const signatureA = await signTransaction(subsetConfig, prepared, {
+      owner: accountA,
+    })
+    const signatureC = await signTransaction(subsetConfig, prepared, {
+      owner: accountC,
+    })
+    await expect(
+      assembleTransaction(subsetConfig, prepared, [signatureC, signatureA]),
+    ).resolves.toEqual(full)
+  })
+
+  test('omits unsigned multi-factor validators', async () => {
+    const multiFactorConfig = makeConfig('safe', {
+      type: 'multi-factor',
+      validators: [
+        { type: 'ecdsa', accounts: [accountA] },
+        { type: 'passkey', accounts: [passkeyA] },
+        { type: 'ecdsa', accounts: [accountC] },
+      ],
+      threshold: 2,
+    })
+    const prepared = makePrepared({
+      transaction: {
+        chain: base,
+        signers: {
+          type: 'owner',
+          kind: 'multi-factor',
+          validators: [
+            { type: 'ecdsa', id: 0, accounts: [accountA] },
+            { type: 'ecdsa', id: 2, accounts: [accountC] },
+          ],
+        },
+      },
+    })
+    const full = await signTransaction(multiFactorConfig, prepared)
+    const factorA = await signTransaction(multiFactorConfig, prepared, {
+      owner: accountA,
+      validatorId: 0,
+    })
+    const factorC = await signTransaction(multiFactorConfig, prepared, {
+      owner: accountC,
+      validatorId: 2,
+    })
+    await expect(
+      assembleTransaction(multiFactorConfig, prepared, [factorC, factorA]),
+    ).resolves.toEqual(full)
+  })
+
+  test('rejects an owner outside the configured owner set', async () => {
+    await expect(
+      signTransaction(config, makePrepared(), { owner: accountC }),
+    ).rejects.toBeInstanceOf(UnknownOwnerError)
+  })
+
+  test('rejects signatures from different quotes', async () => {
+    const prepared = makePrepared({
+      quotes: [makeQuote('intent-a'), makeQuote('intent-b')],
+    })
+    const signatureA = await signTransaction(config, prepared, {
+      owner: accountA,
+      intentId: 'intent-a',
+    })
+    const signatureB = await signTransaction(config, prepared, {
+      owner: accountB,
+      intentId: 'intent-b',
+    })
+    await expect(
+      assembleTransaction(config, prepared, [signatureA, signatureB]),
+    ).rejects.toBeInstanceOf(MismatchedOwnerSignaturesError)
+  })
+
+  test('does not count duplicate owner signatures toward the threshold', async () => {
+    const prepared = makePrepared()
+    const signature = await signTransaction(config, prepared, {
+      owner: accountA,
+    })
+    await expect(
+      assembleTransaction(config, prepared, [signature, signature]),
+    ).rejects.toBeInstanceOf(InsufficientOwnerSignaturesError)
+  })
+
+  test('rejects a partial with the wrong origin count', async () => {
+    const prepared = makePrepared()
+    const signature = await signTransaction(config, prepared, {
+      owner: accountA,
+    })
+    if (signature.kind === 'multi-factor') throw new Error('unexpected kind')
+    signature.origin.pop()
+    await expect(
+      assembleTransaction(config, prepared, [signature]),
+    ).rejects.toBeInstanceOf(MismatchedOwnerSignaturesError)
+  })
+
+  test('requires a validator id for multi-factor signing', async () => {
+    const multiFactorConfig = makeConfig('safe', {
+      type: 'multi-factor',
+      validators: [{ type: 'ecdsa', accounts: [accountA] }],
+    })
+    await expect(
+      signTransaction(multiFactorConfig, makePrepared(), { owner: accountA }),
+    ).rejects.toBeInstanceOf(InvalidOwnerSigningOptionsError)
+  })
+
+  test('requires enough complete multi-factor validators', async () => {
+    const multiFactorOwners: MultiFactorValidatorConfig = {
+      type: 'multi-factor',
+      validators: [
+        {
+          type: 'ecdsa',
+          accounts: [accountA, accountB],
+          threshold: 2,
+        },
+        { type: 'passkey', accounts: [passkeyA] },
+      ],
+      threshold: 2,
+    }
+    const multiFactorConfig = makeConfig('safe', multiFactorOwners)
+    const prepared = makePrepared()
+    const factorA = await signTransaction(multiFactorConfig, prepared, {
+      owner: accountA,
+      validatorId: 0,
+    })
+    const factorB = await signTransaction(multiFactorConfig, prepared, {
+      owner: accountB,
+      validatorId: 0,
+    })
+    await expect(
+      assembleTransaction(multiFactorConfig, prepared, [factorA, factorB]),
+    ).rejects.toBeInstanceOf(InsufficientOwnerSignaturesError)
+  })
+
+  test('requires each included factor to meet its own threshold', async () => {
+    const multiFactorConfig = makeConfig('safe', {
+      type: 'multi-factor',
+      validators: [
+        {
+          type: 'ecdsa',
+          accounts: [accountA, accountB],
+          threshold: 2,
+        },
+        { type: 'passkey', accounts: [passkeyA] },
+      ],
+      threshold: 2,
+    })
+    const prepared = makePrepared()
+    const ecdsa = await signTransaction(multiFactorConfig, prepared, {
+      owner: accountA,
+      validatorId: 0,
+    })
+    const passkey = await signTransaction(multiFactorConfig, prepared, {
+      owner: passkeyA,
+      validatorId: 1,
+    })
+    await expect(
+      assembleTransaction(multiFactorConfig, prepared, [ecdsa, passkey]),
+    ).rejects.toMatchObject({ context: { validatorId: 0 } })
+  })
+
+  test('rejects smart-session transactions', async () => {
+    const prepared = makePrepared({
+      transaction: {
+        chain: base,
+        signers: {
+          type: 'experimental_session',
+          session: {} as never,
+        },
+      },
+    })
+    await expect(
+      signTransaction(config, prepared, { owner: accountA }),
+    ).rejects.toBeInstanceOf(IndependentSigningNotSupportedError)
+  })
+
+  test('rejects transactions routed through a different validator', async () => {
+    const prepared = makePrepared({
+      transaction: {
+        chain: base,
+        signers: {
+          type: 'owner',
+          kind: 'passkey',
+          accounts: [passkeyA],
+        },
+      },
+    })
+    await expect(
+      signTransaction(config, prepared, { owner: accountA }),
+    ).rejects.toBeInstanceOf(IndependentSigningNotSupportedError)
+  })
+
+  test('rejects EOA accounts', async () => {
+    const eoaConfig = makeConfig('eoa', owners)
+    await expect(
+      signTransaction(eoaConfig, makePrepared(), { owner: accountA }),
+    ).rejects.toBeInstanceOf(IndependentSigningNotSupportedError)
+  })
+
+  test('rejects K1/ERC-7739 validators', async () => {
+    const k1Config = makeConfig('startale', {
+      type: 'ecdsa',
+      accounts: [accountA],
+      module: K1_VALIDATOR_ADDRESS,
+    })
+    await expect(
+      signTransaction(k1Config, makePrepared(), { owner: accountA }),
+    ).rejects.toBeInstanceOf(IndependentSigningNotSupportedError)
+  })
+})

--- a/src/execution/independent-signing.test.ts
+++ b/src/execution/independent-signing.test.ts
@@ -19,6 +19,7 @@ import type {
   MultiFactorValidatorConfig,
   OwnerSet,
   RhinestoneConfig,
+  SignerSet,
 } from '../types'
 import {
   IndependentSigningNotSupportedError,
@@ -124,7 +125,7 @@ const passkeyB = makePasskey('2')
 
 const accountTypes = ['safe', 'nexus', 'kernel', 'startale'] as const
 
-function signingOptions(owners: OwnerSet) {
+function signingOptions(owners: OwnerSet, signers?: SignerSet) {
   switch (owners.type) {
     case 'ecdsa':
       return owners.accounts.map((owner) => ({ owner }))
@@ -132,7 +133,12 @@ function signingOptions(owners: OwnerSet) {
       return owners.owners.map(({ account: owner }) => ({ owner }))
     case 'passkey':
       return owners.accounts.map((owner) => ({ owner }))
-    case 'multi-factor':
+    case 'multi-factor': {
+      if (signers?.type === 'owner' && signers.kind === 'multi-factor') {
+        return signers.validators.flatMap(({ accounts, id: validatorId }) =>
+          accounts.map((owner) => ({ owner, validatorId })),
+        )
+      }
       return owners.validators.flatMap((validator, validatorId) => {
         const accounts =
           validator.type === 'ens'
@@ -140,6 +146,7 @@ function signingOptions(owners: OwnerSet) {
             : validator.accounts
         return accounts.map((owner) => ({ owner, validatorId }))
       })
+    }
   }
 }
 
@@ -149,7 +156,10 @@ async function expectGoldenEquivalence(
 ) {
   const full = await signTransaction(config, prepared)
   const partials: OwnerSignature[] = []
-  for (const options of signingOptions(config.owners as OwnerSet)) {
+  for (const options of signingOptions(
+    config.owners as OwnerSet,
+    prepared.transaction.signers,
+  )) {
     partials.push(await signTransaction(config, prepared, options))
   }
   expect(JSON.parse(JSON.stringify(partials))).toEqual(partials)
@@ -315,6 +325,32 @@ describe('independent signing validation', () => {
     await expect(
       assembleTransaction(multiFactorConfig, prepared, [factorC, factorA]),
     ).resolves.toEqual(full)
+  })
+
+  test('uses custom numeric and hex multi-factor validator ids', async () => {
+    const multiFactorConfig = makeConfig('safe', {
+      type: 'multi-factor',
+      validators: [
+        { type: 'ecdsa', accounts: [accountA] },
+        { type: 'passkey', accounts: [passkeyA] },
+      ],
+      threshold: 2,
+    })
+    const prepared = makePrepared({
+      transaction: {
+        chain: base,
+        signers: {
+          type: 'owner',
+          kind: 'multi-factor',
+          validators: [
+            { type: 'ecdsa', id: 42, accounts: [accountA] },
+            { type: 'passkey', id: '0x1234', accounts: [passkeyA] },
+          ],
+        },
+      },
+    })
+
+    await expectGoldenEquivalence(multiFactorConfig, prepared)
   })
 
   test('rejects an owner outside the configured owner set', async () => {

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -36,11 +36,16 @@ import type {
 import {
   Eip7702InitSignatureRequiredError,
   ExecutionError,
+  IndependentSigningNotSupportedError,
+  InsufficientOwnerSignaturesError,
   IntentFailedError,
+  InvalidOwnerSigningOptionsError,
   InvalidSourceCallsError,
   isExecutionError,
+  MismatchedOwnerSignaturesError,
   OrderPathRequiredForIntentsError,
   QuoteNotInPreparedTransactionError,
+  UnknownOwnerError,
 } from './error'
 import type { TransactionResult, UserOperationResult } from './utils'
 import {
@@ -409,9 +414,14 @@ export {
   isExecutionError,
   ExecutionError,
   Eip7702InitSignatureRequiredError,
+  IndependentSigningNotSupportedError,
+  InsufficientOwnerSignaturesError,
   IntentFailedError,
+  InvalidOwnerSigningOptionsError,
   InvalidSourceCallsError,
+  MismatchedOwnerSignaturesError,
   OrderPathRequiredForIntentsError,
   QuoteNotInPreparedTransactionError,
+  UnknownOwnerError,
 }
 export type { TransactionStatus, TransactionResult, UserOperationResult }

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -16,6 +16,7 @@ import {
   isAddress,
   keccak256,
   type PublicClient,
+  pad,
   publicActions,
   type SignableMessage,
   type SignedAuthorization,
@@ -130,6 +131,7 @@ import type {
   CallInput,
   ENSValidatorConfig,
   ExactInputConfig,
+  MultiFactorValidatorConfig,
   NonEvmTokenRequest,
   OwnableValidatorConfig,
   OwnerSet,
@@ -302,8 +304,8 @@ interface QuoteSelection {
 interface SignAsOwnerOptions {
   /** Account that contributes this signature. Must belong to the configured owner set. */
   owner: Account | WebAuthnAccount
-  /** Multi-factor validator index containing `owner`. Required only for multi-factor accounts. */
-  validatorId?: number
+  /** Multi-factor validator ID containing `owner`. Required only for multi-factor accounts. */
+  validatorId?: number | Hex
   /** Quote to sign. Defaults to `preparedTransaction.quotes.best`. */
   intentId?: string
 }
@@ -336,7 +338,7 @@ type OwnerSignature =
   | {
       intentId: string
       kind: 'multi-factor'
-      validatorId: number
+      validatorId: number | Hex
       signature: OwnerSignatureData
     }
 
@@ -544,7 +546,7 @@ type AtomicOwnerSet =
 function assertIndependentSigningSupported(
   config: RhinestoneConfig,
   preparedTransaction: PreparedTransactionData,
-): { owners: OwnerSet; validator: Module } {
+): { owners: OwnerSet; signers: SignerSet | undefined; validator: Module } {
   if (config.account?.type === 'eoa') {
     throw new IndependentSigningNotSupportedError({
       context: { reason: 'eoa-account' },
@@ -579,24 +581,70 @@ function assertIndependentSigningSupported(
       context: { reason: 'missing-owner-set' },
     })
   }
-  return { owners: config.owners, validator }
+  return { owners: config.owners, signers, validator }
+}
+
+interface MultiFactorOwnerFactor {
+  id: number | Hex
+  owners: AtomicOwnerSet
+}
+
+function getValidatorIdKey(id: number | Hex): Hex | undefined {
+  if (typeof id === 'number' && (!Number.isSafeInteger(id) || id < 0)) {
+    return undefined
+  }
+  try {
+    return pad(toHex(id), { size: 12 }).toLowerCase() as Hex
+  } catch {
+    return undefined
+  }
+}
+
+function getMultiFactorOwnerFactors(
+  owners: MultiFactorValidatorConfig,
+  signers: SignerSet | undefined,
+): MultiFactorOwnerFactor[] {
+  if (signers?.type === 'owner' && signers.kind === 'multi-factor') {
+    return signers.validators.map((factor) => {
+      switch (factor.type) {
+        case 'ecdsa':
+          return {
+            id: factor.id,
+            owners: {
+              type: 'ecdsa',
+              accounts: factor.accounts,
+              threshold: factor.accounts.length,
+            },
+          }
+        case 'passkey':
+          return {
+            id: factor.id,
+            owners: {
+              type: 'passkey',
+              accounts: factor.accounts,
+              threshold: factor.accounts.length,
+            },
+          }
+      }
+    })
+  }
+  return owners.validators.map((factor, id) => ({ id, owners: factor }))
 }
 
 function resolveAtomicOwnerSet(
   owners: OwnerSet,
-  validatorId: number | undefined,
-): AtomicOwnerSet | undefined {
+  validatorId: number | Hex | undefined,
+  signers: SignerSet | undefined,
+): MultiFactorOwnerFactor | undefined {
   if (owners.type !== 'multi-factor') {
-    return validatorId === undefined ? owners : undefined
+    return validatorId === undefined ? { id: 0, owners } : undefined
   }
-  if (
-    validatorId === undefined ||
-    !Number.isInteger(validatorId) ||
-    validatorId < 0
-  ) {
-    return undefined
-  }
-  return owners.validators[validatorId]
+  if (validatorId === undefined) return undefined
+  const key = getValidatorIdKey(validatorId)
+  if (!key) return undefined
+  return getMultiFactorOwnerFactors(owners, signers).find(
+    (factor) => getValidatorIdKey(factor.id) === key,
+  )
 }
 
 function getAtomicOwnerAccounts(
@@ -649,16 +697,17 @@ async function signTransactionAsOwner(
   preparedTransaction: PreparedTransactionData,
   options: SignAsOwnerOptions,
 ): Promise<OwnerSignature> {
-  const { owners } = assertIndependentSigningSupported(
+  const { owners, signers } = assertIndependentSigningSupported(
     config,
     preparedTransaction,
   )
-  const atomicOwners = resolveAtomicOwnerSet(owners, options.validatorId)
-  if (!atomicOwners) {
+  const factor = resolveAtomicOwnerSet(owners, options.validatorId, signers)
+  if (!factor) {
     throw new InvalidOwnerSigningOptionsError({
       context: { validatorId: options.validatorId },
     })
   }
+  const atomicOwners = factor.owners
   if (!isOwnerMember(atomicOwners, options.owner)) {
     throw new UnknownOwnerError({
       context: {
@@ -733,7 +782,7 @@ async function signTransactionAsOwner(
     ? {
         intentId: quote.intentId,
         kind: 'multi-factor',
-        validatorId: options.validatorId as number,
+        validatorId: factor.id,
         signature,
       }
     : { intentId: quote.intentId, ...signature }
@@ -743,7 +792,7 @@ function orderAtomicOwnerSignatures(
   owners: AtomicOwnerSet,
   signatures: OwnerSignatureData[],
   originCount: number,
-  validatorId?: number,
+  validatorId?: number | Hex,
 ): OwnerSignatureData[] {
   const expectedKind = owners.type === 'passkey' ? 'passkey' : 'ecdsa'
   const byIdentity = new Map<string, OwnerSignatureData>()
@@ -838,7 +887,7 @@ async function assembleTransaction(
   preparedTransaction: PreparedTransactionData,
   signatures: OwnerSignature[],
 ): Promise<SignedTransactionData> {
-  const { owners, validator } = assertIndependentSigningSupported(
+  const { owners, signers, validator } = assertIndependentSigningSupported(
     config,
     preparedTransaction,
   )
@@ -866,45 +915,54 @@ async function assembleTransaction(
   let directSignatures: OwnerSignatureData[] | undefined
   let factorSignatures:
     | {
-        id: number
+        id: number | Hex
         owners: AtomicOwnerSet
         signatures: OwnerSignatureData[]
       }[]
     | undefined
 
   if (owners.type === 'multi-factor') {
-    const grouped = new Map<number, OwnerSignatureData[]>()
+    const factors = getMultiFactorOwnerFactors(owners, signers)
+    const factorsById = new Map(
+      factors.flatMap((factor) => {
+        const key = getValidatorIdKey(factor.id)
+        return key ? [[key, factor] as const] : []
+      }),
+    )
+    const grouped = new Map<Hex, OwnerSignatureData[]>()
     for (const signature of signatures) {
       if (signature.kind !== 'multi-factor') {
         throw new MismatchedOwnerSignaturesError({
           context: { expectedKind: 'multi-factor' },
         })
       }
-      const atomicOwners = resolveAtomicOwnerSet(owners, signature.validatorId)
-      if (!atomicOwners) {
+      const key = getValidatorIdKey(signature.validatorId)
+      if (!key || !factorsById.has(key)) {
         throw new MismatchedOwnerSignaturesError({
           context: { validatorId: signature.validatorId },
         })
       }
-      const current = grouped.get(signature.validatorId) ?? []
+      const current = grouped.get(key) ?? []
       current.push(signature.signature)
-      grouped.set(signature.validatorId, current)
+      grouped.set(key, current)
     }
-    factorSignatures = [...grouped.entries()]
-      .sort(([a], [b]) => a - b)
-      .map(([id, groupedSignatures]) => {
-        const atomicOwners = owners.validators[id]
-        return {
-          id,
-          owners: atomicOwners,
+    factorSignatures = factors.flatMap((factor) => {
+      const key = getValidatorIdKey(factor.id)
+      const groupedSignatures = key ? grouped.get(key) : undefined
+      if (!groupedSignatures) return []
+      return [
+        {
+          id: factor.id,
+          owners: factor.owners,
           signatures: orderAtomicOwnerSignatures(
-            atomicOwners,
+            factor.owners,
             groupedSignatures,
             origin.length,
-            id,
+            factor.id,
           ),
-        }
-      })
+        },
+      ]
+    })
     const required = owners.threshold ?? 1
     if (factorSignatures.length < required) {
       throw new InsufficientOwnerSignaturesError({

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -1,4 +1,5 @@
 import {
+  type Account,
   type Address,
   type Chain,
   concat,
@@ -29,6 +30,7 @@ import {
   entryPoint07Address,
   getUserOperationHash,
   type UserOperation,
+  type WebAuthnAccount,
 } from 'viem/account-abstraction'
 import { wrapTypedDataSignature } from 'viem/experimental/erc7739'
 import {
@@ -42,12 +44,19 @@ import {
   getEip7702InitCall,
   getEmissarySignature,
   getInitCode,
+  getOwnerEcdsaSignature,
+  getOwnerPasskeySignature,
   getSmartAccount,
   getTypedDataPackedSignature,
   is7702,
+  packAccountSignature,
   toErc6492Signature,
 } from '../accounts'
-import { convertOwnerSetToSignerSet } from '../accounts/signing/common'
+import {
+  convertOwnerSetToSignerSet,
+  packMultiFactorOwnerSignatures,
+  packPasskeyOwnerSignatures,
+} from '../accounts/signing/common'
 import { K1_DEFAULT_VALIDATOR_ADDRESS } from '../accounts/startale'
 import {
   createTransport,
@@ -67,6 +76,7 @@ import {
 } from '../modules/validators'
 import {
   getMultiFactorValidator,
+  getValidator as getValidatorModule,
   getWebAuthnValidator,
   supportsEip712,
 } from '../modules/validators/core'
@@ -118,8 +128,11 @@ import type {
   Call,
   CalldataInput,
   CallInput,
+  ENSValidatorConfig,
   ExactInputConfig,
   NonEvmTokenRequest,
+  OwnableValidatorConfig,
+  OwnerSet,
   RhinestoneAccountConfig,
   RhinestoneConfig,
   Session,
@@ -134,11 +147,17 @@ import type {
   TokenSymbol,
   Transaction,
   UserOperationTransaction,
+  WebauthnValidatorConfig,
 } from '../types'
 import {
   Eip7702InitSignatureRequiredError,
+  IndependentSigningNotSupportedError,
+  InsufficientOwnerSignaturesError,
+  InvalidOwnerSigningOptionsError,
   InvalidSourceCallsError,
+  MismatchedOwnerSignaturesError,
   QuoteNotInPreparedTransactionError,
+  UnknownOwnerError,
 } from './error'
 
 type InternalSignerSet =
@@ -279,6 +298,47 @@ interface PreparedTransactionData {
 interface QuoteSelection {
   intentId: string
 }
+
+interface SignAsOwnerOptions {
+  /** Account that contributes this signature. Must belong to the configured owner set. */
+  owner: Account | WebAuthnAccount
+  /** Multi-factor validator index containing `owner`. Required only for multi-factor accounts. */
+  validatorId?: number
+  /** Quote to sign. Defaults to `preparedTransaction.quotes.best`. */
+  intentId?: string
+}
+
+interface OwnerPasskeySignature {
+  webauthn: {
+    authenticatorData: Hex
+    challengeIndex?: number
+    clientDataJSON: string
+    typeIndex?: number
+    userVerificationRequired?: boolean
+  }
+  signature: Hex
+}
+
+type OwnerSignatureData =
+  | {
+      kind: 'ecdsa'
+      signer: Address
+      origin: Hex[]
+    }
+  | {
+      kind: 'passkey'
+      publicKey: Hex
+      origin: OwnerPasskeySignature[]
+    }
+
+type OwnerSignature =
+  | ({ intentId: string } & OwnerSignatureData)
+  | {
+      intentId: string
+      kind: 'multi-factor'
+      validatorId: number
+      signature: OwnerSignatureData
+    }
 
 interface PreparedUserOperationData {
   userOperation: UserOperation
@@ -426,11 +486,25 @@ function getTransactionMessages(
   return getIntentMessages(quote.signData)
 }
 
-async function signTransaction(
+function signTransaction(
+  config: RhinestoneConfig,
+  preparedTransaction: PreparedTransactionData,
+  options: SignAsOwnerOptions,
+): Promise<OwnerSignature>
+function signTransaction(
   config: RhinestoneConfig,
   preparedTransaction: PreparedTransactionData,
   options?: QuoteSelection,
-): Promise<SignedTransactionData> {
+): Promise<SignedTransactionData>
+async function signTransaction(
+  config: RhinestoneConfig,
+  preparedTransaction: PreparedTransactionData,
+  options?: QuoteSelection | SignAsOwnerOptions,
+): Promise<SignedTransactionData | OwnerSignature> {
+  if (options && 'owner' in options) {
+    return signTransactionAsOwner(config, preparedTransaction, options)
+  }
+
   const { signers } = getTransactionParams(preparedTransaction.transaction)
   const quote = resolveQuote(preparedTransaction.quotes, options)
   const targetChain =
@@ -459,6 +533,438 @@ async function signTransaction(
     originSignatures,
     destinationSignature,
     targetExecutionSignature,
+  }
+}
+
+type AtomicOwnerSet =
+  | OwnableValidatorConfig
+  | ENSValidatorConfig
+  | WebauthnValidatorConfig
+
+function assertIndependentSigningSupported(
+  config: RhinestoneConfig,
+  preparedTransaction: PreparedTransactionData,
+): { owners: OwnerSet; validator: Module } {
+  if (config.account?.type === 'eoa') {
+    throw new IndependentSigningNotSupportedError({
+      context: { reason: 'eoa-account' },
+    })
+  }
+  const { signers } = getTransactionParams(preparedTransaction.transaction)
+  if (signers?.type === 'experimental_session') {
+    throw new IndependentSigningNotSupportedError({
+      context: { reason: 'smart-session' },
+    })
+  }
+  const validator = getOwnerValidator(config)
+  const selectedValidator = getValidator(config, signers)
+  if (
+    !selectedValidator ||
+    selectedValidator.address.toLowerCase() !== validator.address.toLowerCase()
+  ) {
+    throw new IndependentSigningNotSupportedError({
+      context: { reason: 'non-owner-validator' },
+    })
+  }
+  if (
+    validator.address.toLowerCase() ===
+    K1_DEFAULT_VALIDATOR_ADDRESS.toLowerCase()
+  ) {
+    throw new IndependentSigningNotSupportedError({
+      context: { reason: 'erc7739-validator' },
+    })
+  }
+  if (!config.owners) {
+    throw new IndependentSigningNotSupportedError({
+      context: { reason: 'missing-owner-set' },
+    })
+  }
+  return { owners: config.owners, validator }
+}
+
+function resolveAtomicOwnerSet(
+  owners: OwnerSet,
+  validatorId: number | undefined,
+): AtomicOwnerSet | undefined {
+  if (owners.type !== 'multi-factor') {
+    return validatorId === undefined ? owners : undefined
+  }
+  if (
+    validatorId === undefined ||
+    !Number.isInteger(validatorId) ||
+    validatorId < 0
+  ) {
+    return undefined
+  }
+  return owners.validators[validatorId]
+}
+
+function getAtomicOwnerAccounts(
+  owners: AtomicOwnerSet,
+): (Account | WebAuthnAccount)[] {
+  switch (owners.type) {
+    case 'ecdsa':
+    case 'passkey':
+      return owners.accounts
+    case 'ens':
+      return owners.owners.map(({ account }) => account)
+  }
+}
+
+function getAtomicOwnerThreshold(owners: AtomicOwnerSet): number {
+  return owners.threshold ?? 1
+}
+
+function isWebAuthnAccount(
+  account: Account | WebAuthnAccount,
+): account is WebAuthnAccount {
+  return account.type === 'webAuthn'
+}
+
+function getAccountIdentity(account: Account | WebAuthnAccount): string {
+  return isWebAuthnAccount(account)
+    ? account.publicKey.toLowerCase()
+    : account.address.toLowerCase()
+}
+
+function getAtomicSignatureIdentity(signature: OwnerSignatureData): string {
+  return signature.kind === 'passkey'
+    ? signature.publicKey.toLowerCase()
+    : signature.signer.toLowerCase()
+}
+
+function isOwnerMember(
+  owners: AtomicOwnerSet,
+  account: Account | WebAuthnAccount,
+): boolean {
+  if ((owners.type === 'passkey') !== isWebAuthnAccount(account)) return false
+  const identity = getAccountIdentity(account)
+  return getAtomicOwnerAccounts(owners).some(
+    (configured) => getAccountIdentity(configured) === identity,
+  )
+}
+
+async function signTransactionAsOwner(
+  config: RhinestoneConfig,
+  preparedTransaction: PreparedTransactionData,
+  options: SignAsOwnerOptions,
+): Promise<OwnerSignature> {
+  const { owners } = assertIndependentSigningSupported(
+    config,
+    preparedTransaction,
+  )
+  const atomicOwners = resolveAtomicOwnerSet(owners, options.validatorId)
+  if (!atomicOwners) {
+    throw new InvalidOwnerSigningOptionsError({
+      context: { validatorId: options.validatorId },
+    })
+  }
+  if (!isOwnerMember(atomicOwners, options.owner)) {
+    throw new UnknownOwnerError({
+      context: {
+        ...(isWebAuthnAccount(options.owner)
+          ? { publicKey: options.owner.publicKey }
+          : { signer: options.owner.address }),
+        validatorId: options.validatorId,
+      },
+    })
+  }
+
+  const quote = resolveQuote(
+    preparedTransaction.quotes,
+    options.intentId === undefined ? undefined : { intentId: options.intentId },
+  )
+  const { origin } = getIntentMessages(quote.signData)
+  const atomicSigners = convertOwnerSetToSignerSet(atomicOwners)
+  if (atomicSigners.type !== 'owner' || atomicSigners.kind === 'multi-factor') {
+    throw new IndependentSigningNotSupportedError()
+  }
+  const validatorSupportsEip712 = supportsEip712(
+    getValidatorModule(atomicOwners),
+  )
+
+  let signature: OwnerSignatureData
+  if (atomicSigners.kind === 'ecdsa' && !isWebAuthnAccount(options.owner)) {
+    const signatures: Hex[] = []
+    for (const typedData of origin) {
+      signatures.push(
+        await getOwnerEcdsaSignature(
+          config,
+          getChainById(typedData.domain?.chainId as number),
+          typedData,
+          options.owner,
+          atomicSigners.module,
+          validatorSupportsEip712,
+        ),
+      )
+    }
+    signature = {
+      kind: 'ecdsa',
+      signer: options.owner.address,
+      origin: signatures,
+    }
+  } else if (
+    atomicSigners.kind === 'passkey' &&
+    isWebAuthnAccount(options.owner)
+  ) {
+    const signatures: OwnerPasskeySignature[] = []
+    for (const typedData of origin) {
+      signatures.push(
+        await getOwnerPasskeySignature(
+          config,
+          typedData,
+          options.owner,
+          validatorSupportsEip712,
+        ),
+      )
+    }
+    signature = {
+      kind: 'passkey',
+      publicKey: options.owner.publicKey,
+      origin: signatures,
+    }
+  } else {
+    throw new UnknownOwnerError({
+      context: { validatorId: options.validatorId },
+    })
+  }
+
+  return owners.type === 'multi-factor'
+    ? {
+        intentId: quote.intentId,
+        kind: 'multi-factor',
+        validatorId: options.validatorId as number,
+        signature,
+      }
+    : { intentId: quote.intentId, ...signature }
+}
+
+function orderAtomicOwnerSignatures(
+  owners: AtomicOwnerSet,
+  signatures: OwnerSignatureData[],
+  originCount: number,
+  validatorId?: number,
+): OwnerSignatureData[] {
+  const expectedKind = owners.type === 'passkey' ? 'passkey' : 'ecdsa'
+  const byIdentity = new Map<string, OwnerSignatureData>()
+  const configuredIdentities = new Set(
+    getAtomicOwnerAccounts(owners).map(getAccountIdentity),
+  )
+
+  for (const signature of signatures) {
+    if (
+      signature.kind !== expectedKind ||
+      signature.origin.length !== originCount
+    ) {
+      throw new MismatchedOwnerSignaturesError({
+        context: {
+          expectedKind,
+          expectedOriginCount: originCount,
+          validatorId,
+        },
+      })
+    }
+    const identity = getAtomicSignatureIdentity(signature)
+    if (!configuredIdentities.has(identity)) {
+      throw new UnknownOwnerError({
+        context: {
+          ...(signature.kind === 'passkey'
+            ? { publicKey: signature.publicKey }
+            : { signer: signature.signer }),
+          validatorId,
+        },
+      })
+    }
+    if (!byIdentity.has(identity)) byIdentity.set(identity, signature)
+  }
+
+  const ordered = [...configuredIdentities].flatMap((identity) => {
+    const signature = byIdentity.get(identity)
+    return signature ? [signature] : []
+  })
+  const required = getAtomicOwnerThreshold(owners)
+  if (ordered.length < required) {
+    throw new InsufficientOwnerSignaturesError({
+      required,
+      provided: ordered.length,
+      validatorId,
+    })
+  }
+  return ordered
+}
+
+function packAtomicOwnerSignatures(
+  owners: AtomicOwnerSet,
+  signatures: OwnerSignatureData[],
+  originIndex: number,
+  chain: Chain,
+  accountAddress: Address,
+): Hex {
+  const signers = convertOwnerSetToSignerSet(owners)
+  if (
+    owners.type === 'passkey' &&
+    signers.type === 'owner' &&
+    signers.kind === 'passkey'
+  ) {
+    const passkeySignatures = signatures.map((signature) => {
+      if (signature.kind !== 'passkey') {
+        throw new MismatchedOwnerSignaturesError()
+      }
+      return {
+        publicKey: signature.publicKey,
+        signature: signature.origin[originIndex],
+      }
+    })
+    return packPasskeyOwnerSignatures(
+      chain,
+      accountAddress,
+      passkeySignatures.map(({ publicKey }) => publicKey),
+      passkeySignatures.map(({ signature }) => signature),
+      signers.module,
+    )
+  }
+  return concat(
+    signatures.map((signature) => {
+      if (signature.kind !== 'ecdsa') {
+        throw new MismatchedOwnerSignaturesError()
+      }
+      return signature.origin[originIndex]
+    }),
+  )
+}
+
+async function assembleTransaction(
+  config: RhinestoneConfig,
+  preparedTransaction: PreparedTransactionData,
+  signatures: OwnerSignature[],
+): Promise<SignedTransactionData> {
+  const { owners, validator } = assertIndependentSigningSupported(
+    config,
+    preparedTransaction,
+  )
+  if (signatures.length === 0) {
+    throw new InsufficientOwnerSignaturesError({
+      required: owners.threshold ?? 1,
+      provided: 0,
+    })
+  }
+
+  const intentIds = [...new Set(signatures.map(({ intentId }) => intentId))]
+  if (intentIds.length !== 1) {
+    throw new MismatchedOwnerSignaturesError({ context: { intentIds } })
+  }
+  const quote = resolveQuote(preparedTransaction.quotes, {
+    intentId: intentIds[0],
+  })
+  const { origin } = getIntentMessages(quote.signData)
+  const accountAddress = getAddress(config)
+  const validatorConfig: ValidatorConfig = {
+    address: validator.address,
+    isRoot: true,
+  }
+
+  let directSignatures: OwnerSignatureData[] | undefined
+  let factorSignatures:
+    | {
+        id: number
+        owners: AtomicOwnerSet
+        signatures: OwnerSignatureData[]
+      }[]
+    | undefined
+
+  if (owners.type === 'multi-factor') {
+    const grouped = new Map<number, OwnerSignatureData[]>()
+    for (const signature of signatures) {
+      if (signature.kind !== 'multi-factor') {
+        throw new MismatchedOwnerSignaturesError({
+          context: { expectedKind: 'multi-factor' },
+        })
+      }
+      const atomicOwners = resolveAtomicOwnerSet(owners, signature.validatorId)
+      if (!atomicOwners) {
+        throw new MismatchedOwnerSignaturesError({
+          context: { validatorId: signature.validatorId },
+        })
+      }
+      const current = grouped.get(signature.validatorId) ?? []
+      current.push(signature.signature)
+      grouped.set(signature.validatorId, current)
+    }
+    factorSignatures = [...grouped.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([id, groupedSignatures]) => {
+        const atomicOwners = owners.validators[id]
+        return {
+          id,
+          owners: atomicOwners,
+          signatures: orderAtomicOwnerSignatures(
+            atomicOwners,
+            groupedSignatures,
+            origin.length,
+            id,
+          ),
+        }
+      })
+    const required = owners.threshold ?? 1
+    if (factorSignatures.length < required) {
+      throw new InsufficientOwnerSignaturesError({
+        required,
+        provided: factorSignatures.length,
+      })
+    }
+  } else {
+    directSignatures = orderAtomicOwnerSignatures(
+      owners,
+      signatures.map((signature) => {
+        if (signature.kind === 'multi-factor') {
+          throw new MismatchedOwnerSignaturesError({
+            context: { expectedKind: owners.type },
+          })
+        }
+        const { intentId: _, ...atomicSignature } = signature
+        return atomicSignature
+      }),
+      origin.length,
+    )
+  }
+
+  const originSignatures: Hex[] = []
+  for (const [originIndex, typedData] of origin.entries()) {
+    const chain = getChainById(typedData.domain?.chainId as number)
+    const validatorSignature = factorSignatures
+      ? packMultiFactorOwnerSignatures(
+          factorSignatures.map((factor) => ({
+            id: factor.id,
+            validatorAddress: getValidatorModule(factor.owners).address,
+            signature: packAtomicOwnerSignatures(
+              factor.owners,
+              factor.signatures,
+              originIndex,
+              chain,
+              accountAddress,
+            ),
+          })),
+        )
+      : packAtomicOwnerSignatures(
+          owners as AtomicOwnerSet,
+          directSignatures as OwnerSignatureData[],
+          originIndex,
+          chain,
+          accountAddress,
+        )
+    originSignatures.push(
+      await packAccountSignature(config, validatorSignature, validatorConfig),
+    )
+  }
+
+  return {
+    quote,
+    quotes: preparedTransaction.quotes,
+    intentInput: preparedTransaction.intentInput,
+    transaction: preparedTransaction.transaction,
+    originSignatures,
+    destinationSignature: originSignatures.at(-1) ?? '0x',
+    targetExecutionSignature: undefined,
   }
 }
 
@@ -2112,6 +2618,7 @@ export {
   prepareTransaction,
   getTransactionMessages,
   signTransaction,
+  assembleTransaction,
   signAuthorizations,
   signAuthorizationsInternal,
   signMessage,
@@ -2139,7 +2646,11 @@ export type {
   PreparedQuotes,
   PreparedTransactionData,
   PreparedUserOperationData,
+  OwnerPasskeySignature,
+  OwnerSignature,
+  OwnerSignatureData,
   QuoteSelection,
+  SignAsOwnerOptions,
   SignedTransactionData,
   SignedUserOperationData,
   UserOperationResult,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,17 +4,26 @@ import { accountA } from '../test/consts'
 import type { SignData } from './orchestrator'
 import type { SessionSignerSet } from './types'
 
-const { mockGetTargetExecutionSignature, mockSignIntent } = vi.hoisted(() => ({
+const {
+  mockAssembleTransaction,
+  mockGetTargetExecutionSignature,
+  mockSignIntent,
+  mockSignTransaction,
+} = vi.hoisted(() => ({
+  mockAssembleTransaction: vi.fn(),
   mockGetTargetExecutionSignature: vi.fn(),
   mockSignIntent: vi.fn(),
+  mockSignTransaction: vi.fn(),
 }))
 
 vi.mock('./execution/utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./execution/utils')>()
   return {
     ...actual,
+    assembleTransaction: mockAssembleTransaction,
     getTargetExecutionSignature: mockGetTargetExecutionSignature,
     signIntent: mockSignIntent,
+    signTransaction: mockSignTransaction,
   }
 })
 
@@ -22,8 +31,10 @@ const { RhinestoneSDK } = await import('.')
 
 describe('RhinestoneSDK.createAccount', () => {
   beforeEach(() => {
+    mockAssembleTransaction.mockReset()
     mockGetTargetExecutionSignature.mockReset()
     mockSignIntent.mockReset()
+    mockSignTransaction.mockReset()
   })
 
   test('signIntent delegates to SDK intent signing utilities', async () => {
@@ -74,5 +85,38 @@ describe('RhinestoneSDK.createAccount', () => {
       destinationSignature: '0x22',
       targetExecutionSignature: '0x33',
     })
+  })
+
+  test('independent signing and assembly delegate to execution utilities', async () => {
+    const config = {
+      owners: { type: 'ecdsa' as const, accounts: [accountA], threshold: 1 },
+    }
+    const prepared = { quotes: {} } as never
+    const ownerSignature = { intentId: 'intent', kind: 'ecdsa' } as never
+    const signedTransaction = { quote: {} } as never
+    mockSignTransaction.mockResolvedValue(ownerSignature)
+    mockAssembleTransaction.mockResolvedValue(signedTransaction)
+
+    const sdk = new RhinestoneSDK({
+      auth: { mode: 'apiKey', apiKey: 'test' },
+    })
+    const account = await sdk.createAccount(config)
+
+    await expect(
+      account.signTransaction(prepared, { owner: accountA }),
+    ).resolves.toBe(ownerSignature)
+    await expect(
+      account.assembleTransaction(prepared, [ownerSignature]),
+    ).resolves.toBe(signedTransaction)
+    expect(mockSignTransaction).toHaveBeenCalledWith(
+      expect.objectContaining(config),
+      prepared,
+      { owner: accountA },
+    )
+    expect(mockAssembleTransaction).toHaveBeenCalledWith(
+      expect.objectContaining(config),
+      prepared,
+      [ownerSignature],
+    )
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,7 +213,7 @@ interface RhinestoneAccount {
    * Sign a prepared transaction as one configured owner. The returned signature
    * can be serialized and shared with the party coordinating submission.
    * @param preparedTransaction Prepared transaction data
-   * @param options Owner account, optional quote, and multi-factor validator index
+   * @param options Owner account, optional quote, and multi-factor validator ID
    * @returns This owner's signature contribution
    * @see {@link prepareTransaction} to prepare the transaction data for signing
    * @see {@link assembleTransaction} to combine independent owner signatures
@@ -237,8 +237,9 @@ interface RhinestoneAccount {
   /**
    * Assemble independently collected owner signatures into a signed transaction.
    * Signatures are deduplicated and ordered according to the configured owner set.
-   * Thresholds are read from the local account configuration; callers must keep
-   * it synchronized with any onchain owner or threshold changes.
+   * Account thresholds are read from the local configuration; an explicit
+   * transaction signer set determines active MFA IDs and contributing owners.
+   * Callers must keep these synchronized with onchain owner and threshold changes.
    * @param preparedTransaction The prepared transaction every owner signed
    * @param signatures Owner signatures returned by `signTransaction` with an `owner` option
    * @returns Signed transaction data ready for submission

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,14 +34,19 @@ import {
   waitForExecution as waitForExecutionInternal,
 } from './execution'
 import {
+  assembleTransaction as assembleTransactionInternal,
   getTargetExecutionSignature as getTargetExecutionSignatureInternal,
   getTransactionMessages as getTransactionMessagesInternal,
+  type OwnerPasskeySignature,
+  type OwnerSignature,
+  type OwnerSignatureData,
   type PreparedQuotes,
   type PreparedTransactionData,
   type PreparedUserOperationData,
   prepareTransaction as prepareTransactionInternal,
   prepareUserOperation as prepareUserOperationInternal,
   type QuoteSelection,
+  type SignAsOwnerOptions,
   type SignedTransactionData,
   type SignedUserOperationData,
   signAuthorizations as signAuthorizationsInternal,
@@ -205,7 +210,20 @@ interface RhinestoneAccount {
     targetExecution?: TypedDataDefinition
   }
   /**
-   * Sign a prepared transaction.
+   * Sign a prepared transaction as one configured owner. The returned signature
+   * can be serialized and shared with the party coordinating submission.
+   * @param preparedTransaction Prepared transaction data
+   * @param options Owner account, optional quote, and multi-factor validator index
+   * @returns This owner's signature contribution
+   * @see {@link prepareTransaction} to prepare the transaction data for signing
+   * @see {@link assembleTransaction} to combine independent owner signatures
+   */
+  signTransaction(
+    preparedTransaction: PreparedTransactionData,
+    options: SignAsOwnerOptions,
+  ): Promise<OwnerSignature>
+  /**
+   * Sign a prepared transaction with the transaction's configured signers.
    * @param preparedTransaction Prepared transaction data
    * @param options Optional override; pass `{ intentId }` to sign a specific quote from `preparedTransaction.quotes.all`
    * @returns The signed transaction data
@@ -215,6 +233,21 @@ interface RhinestoneAccount {
   signTransaction(
     preparedTransaction: PreparedTransactionData,
     options?: QuoteSelection,
+  ): Promise<SignedTransactionData>
+  /**
+   * Assemble independently collected owner signatures into a signed transaction.
+   * Signatures are deduplicated and ordered according to the configured owner set.
+   * Thresholds are read from the local account configuration; callers must keep
+   * it synchronized with any onchain owner or threshold changes.
+   * @param preparedTransaction The prepared transaction every owner signed
+   * @param signatures Owner signatures returned by `signTransaction` with an `owner` option
+   * @returns Signed transaction data ready for submission
+   * @see {@link signTransaction} to create each owner signature
+   * @see {@link submitTransaction} to submit the result
+   */
+  assembleTransaction(
+    preparedTransaction: PreparedTransactionData,
+    signatures: OwnerSignature[],
   ): Promise<SignedTransactionData>
   /**
    * Sign the EIP-7702 authorizations required for a transaction.
@@ -458,9 +491,27 @@ async function createAccountInternal(
 
   function signTransaction(
     preparedTransaction: PreparedTransactionData,
+    options: SignAsOwnerOptions,
+  ): Promise<OwnerSignature>
+  function signTransaction(
+    preparedTransaction: PreparedTransactionData,
     options?: QuoteSelection,
-  ) {
+  ): Promise<SignedTransactionData>
+  function signTransaction(
+    preparedTransaction: PreparedTransactionData,
+    options?: QuoteSelection | SignAsOwnerOptions,
+  ): Promise<SignedTransactionData | OwnerSignature> {
+    if (options && 'owner' in options) {
+      return signTransactionInternal(config, preparedTransaction, options)
+    }
     return signTransactionInternal(config, preparedTransaction, options)
+  }
+
+  function assembleTransaction(
+    preparedTransaction: PreparedTransactionData,
+    signatures: OwnerSignature[],
+  ) {
+    return assembleTransactionInternal(config, preparedTransaction, signatures)
   }
 
   function signAuthorizations(preparedTransaction: PreparedTransactionData) {
@@ -629,6 +680,7 @@ async function createAccountInternal(
     prepareTransaction,
     getTransactionMessages,
     signTransaction,
+    assembleTransaction,
     signAuthorizations,
     signMessage,
     signTypedData,
@@ -811,6 +863,7 @@ export type {
   PreparedTransactionData,
   Quote,
   QuoteSelection,
+  SignAsOwnerOptions,
   SignedTransactionData,
   TransactionResult,
   PreparedUserOperationData,
@@ -838,4 +891,7 @@ export type {
   OperationStatus,
   FailureReason,
   ChainOperation,
+  OwnerPasskeySignature,
+  OwnerSignature,
+  OwnerSignatureData,
 }

--- a/test/types/independent-signing.ts
+++ b/test/types/independent-signing.ts
@@ -18,6 +18,11 @@ const selectedOwnerSignature: Promise<OwnerSignature> = account.signTransaction(
   prepared,
   { owner: accountA, intentId: 'intent-id' },
 )
+const multiFactorOwnerSignature: Promise<OwnerSignature> =
+  account.signTransaction(prepared, {
+    owner: accountA,
+    validatorId: '0x1234',
+  })
 const signedTransaction: Promise<SignedTransactionData> =
   account.signTransaction(prepared)
 const selectedSignedTransaction: Promise<SignedTransactionData> =
@@ -27,6 +32,7 @@ const assembledTransaction: Promise<SignedTransactionData> =
 
 void ownerSignature
 void selectedOwnerSignature
+void multiFactorOwnerSignature
 void signedTransaction
 void selectedSignedTransaction
 void assembledTransaction

--- a/test/types/independent-signing.ts
+++ b/test/types/independent-signing.ts
@@ -1,0 +1,32 @@
+import type {
+  OwnerSignature,
+  PreparedTransactionData,
+  RhinestoneAccount,
+  SignedTransactionData,
+} from '../../src/index'
+import { accountA } from '../consts'
+
+declare const account: RhinestoneAccount
+declare const prepared: PreparedTransactionData
+declare const signatures: OwnerSignature[]
+
+const ownerSignature: Promise<OwnerSignature> = account.signTransaction(
+  prepared,
+  { owner: accountA },
+)
+const selectedOwnerSignature: Promise<OwnerSignature> = account.signTransaction(
+  prepared,
+  { owner: accountA, intentId: 'intent-id' },
+)
+const signedTransaction: Promise<SignedTransactionData> =
+  account.signTransaction(prepared)
+const selectedSignedTransaction: Promise<SignedTransactionData> =
+  account.signTransaction(prepared, { intentId: 'intent-id' })
+const assembledTransaction: Promise<SignedTransactionData> =
+  account.assembleTransaction(prepared, signatures)
+
+void ownerSignature
+void selectedOwnerSignature
+void signedTransaction
+void selectedSignedTransaction
+void assembledTransaction


### PR DESCRIPTION
- Add per-owner `signTransaction` overloads that return serializable owner signatures.
- Add `assembleTransaction` to validate and combine ECDSA, passkey, and multi-factor signatures into submittable transactions.
- Preserve account-specific and legacy validator packing, with typed errors for invalid owners, quotes, thresholds, and unsupported validators.
- Add golden equivalence coverage across account implementations, public type tests, reference metadata, and a minor changeset.

Closes [RHI-4647](https://linear.app/rhinestone/issue/RHI-4647)
