### PR TITLE
feat: add customDeadline transaction option (tokenless fill deadline)

### DIFF
--- a/.changeset/tokenless-custom-deadline.md
+++ b/.changeset/tokenless-custom-deadline.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add `customDeadline` transaction option to override the on-chain fill deadline. Accepts an absolute unix timestamp (seconds) and is honored only on the tokenless (same-chain / no-funding) route — ignored elsewhere. Bounds (`now + 120s` .. `now + 86400s`) are enforced by the orchestrator. When honored, the quoted `expiresAt` and the bundle claim/nonce expiry track this value automatically.

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -95,6 +95,7 @@ async function sendTransaction(
     sourceAssets,
     feeAsset,
     appFees,
+    customDeadline,
   } = transaction
   const isUserOpSigner = signers?.type === 'guardians'
   if (isUserOpSigner) {
@@ -113,6 +114,7 @@ async function sendTransaction(
     sourceAssets,
     feeAsset,
     appFees,
+    customDeadline,
   })
 }
 
@@ -153,6 +155,7 @@ async function sendTransactionInternal(
     lockFunds?: boolean
     feeAsset?: Address | TokenSymbol
     appFees?: AppFeeRate
+    customDeadline?: number
   },
 ) {
   const accountAddress = getAddress(config)
@@ -188,6 +191,7 @@ async function sendTransactionInternal(
       options.lockFunds,
       options.sourceCalls,
       options.appFees,
+      options.customDeadline,
     )
   }
 }
@@ -243,6 +247,7 @@ async function sendTransactionAsIntent(
   lockFunds?: boolean,
   sourceCalls?: Record<number, CallInput[]>,
   appFees?: AppFeeRate,
+  customDeadline?: number,
 ) {
   const prepared = await prepareTransactionAsIntent(
     config,
@@ -263,6 +268,7 @@ async function sendTransactionAsIntent(
     signers,
     sourceCalls,
     appFees,
+    customDeadline,
   )
   if (!prepared) {
     throw new OrderPathRequiredForIntentsError()

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -257,6 +257,79 @@ describe('prepareTransactionAsIntent', () => {
     expect(intentInput.options.appFees).toEqual({ feeBps: 100 })
   })
 
+  test('includes customDeadline in options when provided', async () => {
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+
+    const customDeadline = 9_999_999_999
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      customDeadline,
+    )
+
+    expect(mockGetIntentRoute).toHaveBeenCalledOnce()
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.customDeadline).toBe(customDeadline)
+  })
+
+  test('omits customDeadline from options when not provided', async () => {
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    expect(mockGetIntentRoute).toHaveBeenCalledOnce()
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.customDeadline).toBeUndefined()
+  })
+
   test('claim-only session sends SIG_MODE_ERC1271 in routing request', async () => {
     mockGetIntentRoute.mockResolvedValue({
       intentOp: {},

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -276,6 +276,7 @@ async function prepareTransaction(
     sourceAssets,
     feeAsset,
     appFees,
+    customDeadline,
     lockFunds,
     auxiliaryFunds,
     account,
@@ -312,6 +313,7 @@ async function prepareTransaction(
     signers,
     sourceCalls,
     appFees,
+    customDeadline,
   )
 
   return {
@@ -739,6 +741,7 @@ function getTransactionParams(transaction: Transaction) {
   const sourceAssets = transaction.sourceAssets
   const feeAsset = transaction.feeAsset
   const appFees = transaction.appFees
+  const customDeadline = transaction.customDeadline
   const lockFunds = transaction.lockFunds
   const auxiliaryFunds = transaction.auxiliaryFunds
   const account = transaction.experimental_accountOverride
@@ -759,6 +762,7 @@ function getTransactionParams(transaction: Transaction) {
     sourceAssets,
     feeAsset,
     appFees,
+    customDeadline,
     lockFunds,
     auxiliaryFunds,
     account,
@@ -882,6 +886,7 @@ async function prepareTransactionAsIntent(
   signers: SignerSet | undefined,
   sourceCalls: Record<number, CallInput[]> | undefined,
   appFees?: AppFeeRate,
+  customDeadline?: number,
 ) {
   const calls = parseCalls(callInputs, targetChain.id)
   const accountAccessList = createAccountAccessList(sourceChains, sourceAssets)
@@ -1014,6 +1019,7 @@ async function prepareTransactionAsIntent(
       topupCompact: lockFunds ?? false,
       feeToken: feeAsset,
       appFees,
+      customDeadline,
       sponsorSettings: sponsored
         ? typeof sponsored === 'object'
           ? {

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -104,6 +104,12 @@ interface IntentOptions {
   settlementLayers?: SettlementLayer[]
   signatureMode?: SignatureMode
   auxiliaryFunds?: AuxiliaryFunds
+  /**
+   * Absolute unix timestamp (seconds) overriding the on-chain fill deadline.
+   * Tokenless route only; ignored elsewhere. Bounds (`now + 120s` ..
+   * `now + 86400s`) are enforced by the orchestrator.
+   */
+  customDeadline?: number
 }
 
 interface AppFeeRate {

--- a/src/types.ts
+++ b/src/types.ts
@@ -482,6 +482,15 @@ interface BaseTransaction {
   sourceAssets?: SourceAssetInput
   feeAsset?: Address | TokenSymbol
   appFees?: AppFeeRate
+  /**
+   * Absolute unix timestamp (seconds) overriding the on-chain fill deadline.
+   * Honored only on the tokenless (same-chain / no-funding) route and silently
+   * ignored on every other route. Must be between `now + 120s` and
+   * `now + 86400s` (24h); out-of-range values are rejected by the orchestrator
+   * with a `400`. When honored, the quoted `expiresAt` and the bundle
+   * claim/nonce expiry track this value automatically.
+   */
+  customDeadline?: number
   settlementLayers?: SettlementLayer[]
   lockFunds?: boolean
   auxiliaryFunds?: AuxiliaryFunds


### PR DESCRIPTION
## What

Adds an optional **`customDeadline`** to the transaction/intent options — an absolute unix timestamp (seconds) that overrides the on-chain fill deadline (default is `DEFAULT_FILL_EXPIRATION_PERIOD`, 2 min).

```ts
await account.sendTransaction({
  chain,
  calls,
  customDeadline: Math.floor(Date.now() / 1000) + 3600, // 1h
})
```

## Behavior

- **Tokenless (same-chain / no-funding) route only.** Silently ignored on every other route — the intent still succeeds, but with the default 2-min deadline (the only client-visible signal is a shorter `expiresAt`).
- **Bounds enforced orchestrator-side:** `now + 120s … now + 86400s` (24h). Out-of-range → `400`. The 24h cap is a hardcoded orchestrator constant, not per-client tunable.
- When honored, the quoted `expiresAt` and the bundle claim/nonce expiry track the override automatically.

## How

Mirrors the existing `appFees` passthrough exactly, threaded through both entry paths into `IntentOptions.customDeadline`:
- `prepareTransaction` → `getTransactionParams` → `prepareTransactionAsIntent` → the `options` literal
- `sendTransaction` → `sendTransactionInternal` → `sendTransactionAsIntent` → `prepareTransactionAsIntent`

The orchestrator already accepts `options.customDeadline` on the alps wire (which this v1 SDK targets via `x-api-version: 2026-01.alps`); this PR just makes it typed and reachable through the high-level API.

## Tests

`tsc --noEmit` clean, `biome check` clean, `vitest` 34/34 (incl. 2 new: set / omit `customDeadline` in options).

## Follow-up (not in this PR)

v2 (blanc) SDK: the orchestrator OpenAPI sync (`rhinestonewtf/openapi` #129) is now merged with `customDeadline`, so `bun run generate:wire` + the same high-level plumbing will bring it to the v2 line.