### PR TITLE
feat: add customDeadline transaction option (v2)

### DIFF
--- a/.changeset/tokenless-custom-deadline.md
+++ b/.changeset/tokenless-custom-deadline.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add `customDeadline` transaction option to override the on-chain fill deadline. Accepts an absolute unix timestamp (seconds) and is honored only on the same-chain (tokenless) route — ignored elsewhere. Bounds (`now + 120s` .. `now + 86400s`) are enforced by the orchestrator. When honored, the quoted `expiresAt` and the bundle claim/nonce expiry track this value automatically.

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -112,6 +112,7 @@ async function sendTransactionInternal(
     settlementLayers?: SettlementLayerFilter
     sourceAssets?: SourceAssetInput
     appFees?: AppFeeRate
+    customDeadline?: number
   },
 ) {
   const accountAddress = getAddress(config)
@@ -141,6 +142,7 @@ async function sendTransactionInternal(
     options.sourceAssets,
     options.sourceCalls,
     options.appFees,
+    options.customDeadline,
   )
 }
 
@@ -193,6 +195,7 @@ async function sendTransactionAsIntent(
   sourceAssets?: SourceAssetInput,
   sourceCalls?: Record<number, SourceCallInput[]>,
   appFees?: AppFeeRate,
+  customDeadline?: number,
 ) {
   const prepared = await prepareTransactionAsIntent(
     config,
@@ -211,6 +214,7 @@ async function sendTransactionAsIntent(
     signers,
     sourceCalls,
     appFees,
+    customDeadline,
   )
   if (!prepared) {
     throw new OrderPathRequiredForIntentsError()

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -265,6 +265,69 @@ describe('prepareTransactionAsIntent', () => {
     expect(intentInput.options.appFees).toEqual({ feeBps: 100 })
   })
 
+  test('includes customDeadline in options when provided', async () => {
+    mockCreateQuote.mockResolvedValue({ routes: [mockQuote] })
+
+    const customDeadline = 9_999_999_999
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      customDeadline,
+    )
+
+    expect(mockCreateQuote).toHaveBeenCalledOnce()
+    const intentInput: IntentInput = mockCreateQuote.mock.calls[0][0]
+    expect(intentInput.options.customDeadline).toBe(customDeadline)
+  })
+
+  test('omits customDeadline from options when not provided', async () => {
+    mockCreateQuote.mockResolvedValue({ routes: [mockQuote] })
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    expect(mockCreateQuote).toHaveBeenCalledOnce()
+    const intentInput: IntentInput = mockCreateQuote.mock.calls[0][0]
+    expect(intentInput.options.customDeadline).toBeUndefined()
+  })
+
   test('claim-only session already enabled sends SIG_MODE_ERC1271 in routing request', async () => {
     mockCreateQuote.mockResolvedValue({ routes: [mockQuote] })
     vi.spyOn(validators, 'isSessionEnabled').mockResolvedValue(true)

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -377,6 +377,7 @@ async function prepareTransaction(
     sourceAssets,
     auxiliaryFunds,
     appFees,
+    customDeadline,
     account,
     recipient,
     sourceCalls,
@@ -420,6 +421,7 @@ async function prepareTransaction(
     signers,
     sourceCalls,
     appFees,
+    customDeadline,
   )
 
   return {
@@ -1386,6 +1388,7 @@ function getTransactionParams(transaction: Transaction) {
   const sourceAssets = transaction.sourceAssets
   const auxiliaryFunds = transaction.auxiliaryFunds
   const appFees = transaction.appFees
+  const customDeadline = transaction.customDeadline
   const account = transaction.experimental_accountOverride
   const recipient = transaction.recipient
   const sourceCalls = transaction.sourceCalls
@@ -1404,6 +1407,7 @@ function getTransactionParams(transaction: Transaction) {
     sourceAssets,
     auxiliaryFunds,
     appFees,
+    customDeadline,
     account,
     recipient,
     sourceCalls,
@@ -1564,6 +1568,7 @@ async function prepareTransactionAsIntent(
   signers: SignerSet | undefined,
   sourceCalls?: Record<number, SourceCallInput[]>,
   appFees?: AppFeeRate,
+  customDeadline?: number,
 ) {
   const targetChainId = getChainId(targetChain)
   const calls = parseCalls(callInputs, targetChainId)
@@ -1773,6 +1778,7 @@ async function prepareTransactionAsIntent(
       signatureMode,
       auxiliaryFunds: combinedAuxiliaryFunds,
       appFees,
+      customDeadline,
     },
     ...(Object.keys(preClaimExecutions).length > 0 && { preClaimExecutions }),
   }

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -1388,7 +1388,10 @@ function getTransactionParams(transaction: Transaction) {
   const sourceAssets = transaction.sourceAssets
   const auxiliaryFunds = transaction.auxiliaryFunds
   const appFees = transaction.appFees
-  const customDeadline = transaction.customDeadline
+  // customDeadline lives only on same-chain transactions (see types.ts) — it's
+  // meaningless cross-chain, so narrow before reading it.
+  const customDeadline =
+    'chain' in transaction ? transaction.customDeadline : undefined
   const account = transaction.experimental_accountOverride
   const recipient = transaction.recipient
   const sourceCalls = transaction.sourceCalls

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -125,6 +125,12 @@ type AuxiliaryFunds = {
 
 interface IntentOptions {
   appFees?: AppFeeRate
+  /**
+   * Absolute unix timestamp (seconds) overriding the on-chain fill deadline.
+   * Same-chain (tokenless) route only; ignored elsewhere. Bounds (`now + 120s`
+   * .. `now + 86400s`) are enforced by the orchestrator.
+   */
+  customDeadline?: number
   sponsorSettings?: SponsorSettings
   settlementLayers?: SettlementLayerFilter
   signatureMode?: SignatureMode

--- a/src/orchestrator/wire.gen.ts
+++ b/src/orchestrator/wire.gen.ts
@@ -167,6 +167,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/app-fees/withdrawals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List App-Fee Withdrawals
+         * @description The authenticated project's app-fee withdrawals (newest first) with each withdrawal's status and USD value paid out.
+         */
+        get: operations["listAppFeeWithdrawals"];
+        put?: never;
+        /**
+         * Create App-Fee Withdrawal
+         * @description Withdraw the authenticated project's full app-fee balance to a whitelisted stablecoin on the chosen chain, paid to the project's registered payout address.
+         */
+        post: operations["createAppFeeWithdrawal"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/app-fees/withdrawals/{nonce}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get App-Fee Withdrawal
+         * @description A single app-fee withdrawal owned by the authenticated project, with its status and USD value paid out.
+         */
+        get: operations["getAppFeeWithdrawal"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -306,7 +350,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -461,7 +505,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -561,7 +605,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -661,7 +705,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -992,7 +1036,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1092,7 +1136,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1192,7 +1236,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1292,7 +1336,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1456,7 +1500,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1556,7 +1600,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1656,7 +1700,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1844,7 +1888,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -1944,7 +1988,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2044,7 +2088,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2269,7 +2313,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2369,7 +2413,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2469,7 +2513,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2569,7 +2613,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2744,7 +2788,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2844,7 +2888,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -2972,7 +3016,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -3752,7 +3796,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -3852,7 +3896,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -3952,7 +3996,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -4080,7 +4124,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -4180,7 +4224,7 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input
@@ -4280,7 +4324,1417 @@ export interface operations {
                         }[];
                     } | {
                         /** @enum {string} */
-                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+        };
+    };
+    listAppFeeWithdrawals: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description API version. Required; pinned to this document. */
+                "x-api-version": "2026-04.blanc";
+                /** @description API key. */
+                "x-api-key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        withdrawals: {
+                            requestNonce: string;
+                            /** @enum {string} */
+                            status: "PENDING" | "COMPLETED" | "FAILED";
+                            payoutUsd: number;
+                            targetChainId: number;
+                            targetToken: string;
+                            targetAmount: string;
+                            payoutAddress: string;
+                            txHash: string | null;
+                            createdAt: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description API key scope denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+        };
+    };
+    createAppFeeWithdrawal: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description API version. Required; pinned to this document. */
+                "x-api-version": "2026-04.blanc";
+                /** @description API key. */
+                "x-api-key": string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    targetChainId: number;
+                    targetToken: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        requestNonce: string;
+                    };
+                };
+            };
+            /** @description No payout address, nothing to withdraw, or invalid target */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description A withdrawal is in progress or failed delivery is awaiting finalization */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+        };
+    };
+    getAppFeeWithdrawal: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description API version. Required; pinned to this document. */
+                "x-api-version": "2026-04.blanc";
+                /** @description API key. */
+                "x-api-key": string;
+            };
+            path: {
+                nonce: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        requestNonce: string;
+                        /** @enum {string} */
+                        status: "PENDING" | "COMPLETED" | "FAILED";
+                        payoutUsd: number;
+                        targetChainId: number;
+                        targetToken: string;
+                        targetAmount: string;
+                        payoutAddress: string;
+                        txHash: string | null;
+                        createdAt: string;
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Missing or invalid API key */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description API key scope denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Withdrawal not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        code: "VALIDATION_ERROR";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Per-field validation issues */
+                        details?: {
+                            /** @description Human-readable issue description */
+                            message: string;
+                            /** @description Structured issue context (e.g. `{ path: "body.accountAddress" }`) */
+                            context?: {
+                                [key: string]: unknown;
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "SIMULATION_FAILED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Classified on-chain simulation failure details */
+                        details?: {
+                            nonce?: string;
+                            category: string;
+                            errorSelector: string;
+                            errorName: string;
+                            errorArgs?: {
+                                [key: string]: string;
+                            };
+                            retryable: boolean;
+                            /** @enum {string} */
+                            retryHint?: "RE_PREPARE" | "RETRY_LATER";
+                            simulations?: unknown;
+                        } & {
+                            [key: string]: unknown;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "INSUFFICIENT_LIQUIDITY";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Fillable subset and unfillable remainder */
+                        details?: {
+                            /** @description Intents fillable with current liquidity */
+                            availableIntents: {
+                                [key: string]: string;
+                            }[];
+                            /** @description Token amounts that cannot be filled */
+                            unfillable: {
+                                [key: string]: string;
+                            };
+                        };
+                    } | {
+                        /** @enum {string} */
+                        code: "KEY_SCOPE_DENIED";
+                        /**
+                         * @description Human-readable error message
+                         * @example Invalid input
+                         */
+                        message: string;
+                        /** @description Single-element list describing the failing scope */
+                        details?: {
+                            message: string;
+                            context: {
+                                /**
+                                 * @description Which scope rejected the request
+                                 * @enum {string}
+                                 */
+                                scope: "allowMainnet" | "intents" | "deposits";
+                                /** @description Minimum level the endpoint demands */
+                                required: boolean | ("read" | "write");
+                                /** @description Level resolved on the key */
+                                actual: boolean | ("none" | "read" | "write");
+                            };
+                        }[];
+                    } | {
+                        /** @enum {string} */
+                        code: "NOT_FOUND" | "UNAUTHORIZED" | "FORBIDDEN" | "CONFLICT" | "WITHDRAWAL_IN_PROGRESS" | "WITHDRAWAL_FINALIZATION_PENDING" | "UNPROCESSABLE_CONTENT" | "TOO_MANY_REQUESTS" | "SETTLEMENT_QUOTE_ERROR" | "SETTLEMENT_EXECUTION_ERROR" | "EXTERNAL_SERVICE_TIMEOUT" | "RELAYER_MARKET_UNAVAILABLE" | "INTERNAL_ERROR";
                         /**
                          * @description Human-readable error message
                          * @example Invalid input

--- a/src/orchestrator/wire.gen.ts
+++ b/src/orchestrator/wire.gen.ts
@@ -3277,6 +3277,11 @@ export interface operations {
                          * @enum {string}
                          */
                         selectionStrategy?: "cheapest" | "fastest" | "best";
+                        /**
+                         * @description Absolute unix timestamp (seconds) overriding the on-chain fill deadline. **TOKENLESS intents only** — ignored on every other route. Must be between `now + 120s` and `now + 86400s`. The bundle claim/nonce expiry and the response `expiresAt` track this value automatically.
+                         * @example 1893456000
+                         */
+                        customDeadline?: number;
                     };
                 };
             };

--- a/src/types.ts
+++ b/src/types.ts
@@ -823,15 +823,6 @@ interface BaseTransaction {
   eip7702InitSignature?: Hex
   sourceAssets?: SourceAssetInput
   appFees?: AppFeeRate
-  /**
-   * Absolute unix timestamp (seconds) overriding the on-chain fill deadline.
-   * Honored only on the same-chain (tokenless) route and silently ignored on
-   * every other route. Must be between `now + 120s` and `now + 86400s` (24h);
-   * out-of-range values are rejected by the orchestrator with a `400`. When
-   * honored, the quoted `expiresAt` and the bundle claim/nonce expiry track
-   * this value automatically.
-   */
-  customDeadline?: number
   settlementLayers?: SettlementLayerFilter
   auxiliaryFunds?: AuxiliaryFunds
   experimental_accountOverride?: {
@@ -846,6 +837,16 @@ interface SameChainTransaction extends BaseTransaction {
   chain: Chain
   tokenRequests?: TokenRequests
   recipient?: RhinestoneAccountConfig | Address
+  /**
+   * Absolute unix timestamp (seconds) overriding the on-chain fill deadline
+   * (default 2 min). Same-chain only — the field lives on this type precisely
+   * because the orchestrator honors it only on the same-chain (tokenless)
+   * route; cross-chain transactions cannot set it. Must be between
+   * `now + 120s` and `now + 86400s` (24h); out-of-range values are rejected
+   * by the orchestrator with a `400`. When honored, the quoted `expiresAt`
+   * and the bundle claim/nonce expiry track this value automatically.
+   */
+  customDeadline?: number
 }
 
 interface CrossChainEvmTransaction extends BaseTransaction {

--- a/src/types.ts
+++ b/src/types.ts
@@ -823,6 +823,15 @@ interface BaseTransaction {
   eip7702InitSignature?: Hex
   sourceAssets?: SourceAssetInput
   appFees?: AppFeeRate
+  /**
+   * Absolute unix timestamp (seconds) overriding the on-chain fill deadline.
+   * Honored only on the same-chain (tokenless) route and silently ignored on
+   * every other route. Must be between `now + 120s` and `now + 86400s` (24h);
+   * out-of-range values are rejected by the orchestrator with a `400`. When
+   * honored, the quoted `expiresAt` and the bundle claim/nonce expiry track
+   * this value automatically.
+   */
+  customDeadline?: number
   settlementLayers?: SettlementLayerFilter
   auxiliaryFunds?: AuxiliaryFunds
   experimental_accountOverride?: {


### PR DESCRIPTION
Ports the v1 `customDeadline` option (shipped in `@rhinestone/sdk@1.11.0`, #658) to the v2 (blanc) line.

## What
Optional **`customDeadline`** on the transaction/intent options — an absolute unix timestamp (seconds) overriding the on-chain fill deadline (default 2 min).

```ts
await account.prepareTransaction({
  chain,
  calls,
  customDeadline: Math.floor(Date.now() / 1000) + 3600, // 1h
})
```

## How
Mirrors the `appFees` passthrough exactly (parity verified: appFees↔customDeadline counts match in every file):
- `wire.gen.ts` — the generated field (from the published `orchestrator/blanc.json`, updated via openapi #129). Added surgically to keep the diff to this one field rather than sweeping in unrelated spec drift since beta.41.
- `types.ts` `BaseTransaction`, `orchestrator/types.ts` `IntentOptions`.
- `prepareTransaction` → `prepareTransactionAsIntent` → `options` literal, plus the `sendTransactionInternal`/`sendTransactionAsIntent` path for symmetry.

## Behavior
Honored only on the same-chain (tokenless) route; silently ignored elsewhere. Bounds `now + 120s … now + 86400s` (24h) enforced orchestrator-side (400 on violation).

## Tests
`tsc --noEmit` clean, `biome check` clean, `vitest` 38/38 (incl. 2 new: set / omit `customDeadline`).