### PR TITLE
chore: bump shared-configs to 1.7.15 (Avalanche 43114)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -27,7 +26,7 @@
       "name": "@rhinestone/sdk",
       "version": "1.5.0",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.7.13",
+        "@rhinestone/shared-configs": "1.7.15",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -178,7 +177,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.13", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.55.0" } }, "sha512-/MSG//fDURGslc+SqEk/XSztGBwYNsDjPeojygT/L/UgwEDUaGilxCOaLLHmwXX/MwczDWWUad47CKevoYfNtA=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.15", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.55.0" } }, "sha512-Y8s/pHBCnamNAEtA/Nk3QAhDh+pPLa66/6zObw8y2TqkS0Ah3nx5UPmwLYmOyXMGiqRLpnGPtkg5rwI3hrhi4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 

--- a/src/package.json
+++ b/src/package.json
@@ -166,7 +166,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.7.13",
+    "@rhinestone/shared-configs": "1.7.15",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
Bumps `@rhinestone/shared-configs` to `1.7.15` so the SDK targets Avalanche C-Chain (43114). Part of the Avalanche rollout.

Changes:
- `src/package.json`: `@rhinestone/shared-configs` `1.7.13` → `1.7.15`
- `bun.lock`: regenerated via `bun install`

Note: `main` was already at `1.7.13` (not `1.7.8`); shared-configs is only referenced in `src/package.json` (no root `package.json` entry), so only that dep + the lockfile changed — matching the established `upgrade(shared-configs)` pattern. `bun run build` passes. Do not publish/deploy until go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABjAoynGa1Az3hzBbTcXEr