### PR TITLE
chore: bump shared-configs to 1.7.15 (Avalanche 43114)

### DIFF
--- a/.changeset/avalanche-43114.md
+++ b/.changeset/avalanche-43114.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": patch
+---
+
+Bump @rhinestone/shared-configs to 1.7.15 to add Avalanche C-Chain (43114) support.

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "^1.7.8",
+        "@rhinestone/shared-configs": "^1.7.15",
         "viem": "^2.55.0",
       },
       "devDependencies": {
@@ -26,9 +26,9 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "2.0.0-beta.38",
+      "version": "2.0.0-beta.42",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.7.8",
+        "@rhinestone/shared-configs": "1.7.15",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -189,7 +189,7 @@
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
 
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.8", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.55.0" } }, "sha512-Es4zeRf+rqd5JMmY3mLyJ+3BiDhIriIPqA7pZfirksTnX1ad3rfHxFuSZJCGadCPy1lOKhhP0vOT2Bbpunz/7Q=="],
+    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.15", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.55.0" } }, "sha512-Y8s/pHBCnamNAEtA/Nk3QAhDh+pPLa66/6zObw8y2TqkS0Ah3nx5UPmwLYmOyXMGiqRLpnGPtkg5rwI3hrhi4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "^1.7.8",
+    "@rhinestone/shared-configs": "^1.7.15",
     "viem": "^2.55.0"
   },
   "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -75,7 +75,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.7.8",
+    "@rhinestone/shared-configs": "1.7.15",
     "solady": "^0.1.26"
   },
   "peerDependencies": {


### PR DESCRIPTION
Ports Avalanche C-Chain (43114) onto the **2.0-beta (`release`)** line — mirrors #645 (robinhood). Bumps `@rhinestone/shared-configs` 1.7.8 → 1.7.15 (root + `src/package.json` + `bun.lock`) + a patch changeset.

The SDK's `orchestrator/registry.ts` `getWrappedTokenAddress` reads chain data from shared-configs, so on 1.7.15 chain **43114** resolves (WAVAX) instead of throwing `Unsupported chain 43114`. This unblocks deposit-service-processor #552 + simulation-tests (both on `2.0.0-beta.x`). Build verified green against 1.7.15.

Merging this triggers the changesets `Release (beta)` PR (`beta.42 → beta.43`); merging that publishes `2.0.0-beta.43` to npm `@beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABjAoynGa1Az3hzBbTcXEr