### PR TITLE
ci: target shared-configs updates at release package

### DIFF
--- a/.github/workflows/update-shared-configs.yaml
+++ b/.github/workflows/update-shared-configs.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           echo "install_command=${{ steps.pm.outputs.add }} @rhinestone/shared-configs@${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "files=package.json ${{ steps.pm.outputs.lockfile }}" >> "$GITHUB_OUTPUT"
+          echo "files=src/package.json ${{ steps.pm.outputs.lockfile }}" >> "$GITHUB_OUTPUT"
 
       - name: Check for existing branch
         id: check
@@ -95,6 +95,7 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: |
           git checkout -b "${{ steps.vars.outputs.branch }}"
+          cd src
           eval "${{ steps.vars.outputs.install_command }}"
 
       - name: Commit and push

--- a/bun.lock
+++ b/bun.lock
@@ -1,9 +1,9 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
-        "@rhinestone/shared-configs": "^1.7.15",
         "viem": "^2.55.0",
       },
       "devDependencies": {
@@ -26,7 +26,7 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "2.0.0-beta.42",
+      "version": "2.0.0-beta.43",
       "dependencies": {
         "@rhinestone/shared-configs": "1.7.15",
         "solady": "^0.1.26",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "./src"
   ],
   "dependencies": {
-    "@rhinestone/shared-configs": "^1.7.15",
     "viem": "^2.55.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- run automated shared-configs bumps from `src/` so the published package manifest is updated
- remove the duplicate root dependency and collapse its lockfile entry
- mirror the behavior from #499 on the `release` branch

`bun run check`, `bun run typecheck`, and `bun run build` pass. The two existing `src/index.test.ts` failures reproduce unchanged on `release`.
