### PR TITLE
refactor(sdk)!: require token addresses, drop symbol inputs

### DIFF
--- a/.changeset/require-token-addresses.md
+++ b/.changeset/require-token-addresses.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': major
+---
+
+Require token **addresses** (not symbols) for all token inputs — `tokenRequests`, `CalldataInput.to`, `ExactInputConfig`, `SimpleTokenList`, and cross-chain permit legs (`from`/`to`). Token symbols (`'USDC'`, `'WETH'`, …) are no longer accepted; pass the token's address for the target chain. This removes the SDK's per-chain symbol→address resolution — the first step of dropping the bundled `@rhinestone/shared-configs` chain data so new chains no longer require an SDK release.

--- a/.changeset/sync-wire-types-usdg.md
+++ b/.changeset/sync-wire-types-usdg.md
@@ -2,4 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Accept `USDG` as a token symbol in `accountAccessList` and fee-token wire typings, matching the published orchestrator OpenAPI spec.
+Add `USDG` to the fee-token wire typings, matching the published orchestrator OpenAPI spec.

--- a/src/README.md
+++ b/src/README.md
@@ -143,7 +143,7 @@ const prepared = await account.prepareTransaction({
   targetChain: arbitrumSepolia,
   calls: [
     {
-      to: 'USDC',
+      to: usdc,
       value: 0n,
       data: encodeFunctionData({
         abi: erc20Abi,
@@ -152,7 +152,7 @@ const prepared = await account.prepareTransaction({
       }),
     },
   ],
-  tokenRequests: [{ address: 'USDC', amount }],
+  tokenRequests: [{ address: usdc, amount }],
 })
 
 const signed = await account.signTransaction(prepared)

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -2427,11 +2427,16 @@ function createAccountAccessList(
       return out
     }
 
-    return chainIds
-      ? { chainIds, tokens: sourceAssets as SimpleTokenList }
-      : { tokens: sourceAssets as SimpleTokenList }
+    const tokens = sourceAssets as SimpleTokenList
+    validateTokenAddresses(tokens)
+    return chainIds ? { chainIds, tokens } : { tokens }
   }
 
+  // ChainTokenMap: validate every per-chain list too, so symbols can't slip
+  // through this input the way they can't through tokenRequests/ExactInputConfig.
+  for (const tokens of Object.values(sourceAssets)) {
+    validateTokenAddresses(tokens)
+  }
   return { chainTokens: sourceAssets }
 }
 

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -104,11 +104,7 @@ import {
   isNonEvmChain,
   type NonEvmAddress,
 } from '../orchestrator/destinations'
-import {
-  getChainById,
-  getTokenAddress,
-  resolveTokenAddress,
-} from '../orchestrator/registry'
+import { getChainById, resolveTokenAddress } from '../orchestrator/registry'
 import {
   type AccountAccessList,
   type AppFeeRate,
@@ -146,7 +142,6 @@ import type {
   SourceCallInput,
   Sponsorship,
   TokenRequest,
-  TokenSymbol,
   Transaction,
   UserOperationTransaction,
   WebauthnValidatorConfig,
@@ -1429,8 +1424,7 @@ function getTokenRequests(
     // Inside this branch targetChain is a viem `Chain`, which excludes the
     // non-EVM transaction variant — token requests are EVM-typed here.
     const evmRequests = initialTokenRequests as TokenRequest[]
-    validateTokenSymbols(
-      targetChain,
+    validateTokenAddresses(
       evmRequests.map((tokenRequest) => tokenRequest.address),
     )
   }
@@ -2504,26 +2498,10 @@ function getSetupOperationsAndDelegations(
   }
 }
 
-function validateTokenSymbols(
-  chain: Chain,
-  tokenAddressOrSymbols: (Address | TokenSymbol)[],
-) {
-  function validateTokenSymbol(
-    chain: Chain,
-    addressOrSymbol: Address | TokenSymbol,
-  ) {
-    // Address
-    if (isAddress(addressOrSymbol, { strict: false })) {
-      return true
-    }
-    // Token symbol
-    const address = getTokenAddress(addressOrSymbol, chain.id)
-    return isAddress(address, { strict: false })
-  }
-
-  for (const addressOrSymbol of tokenAddressOrSymbols) {
-    if (!validateTokenSymbol(chain, addressOrSymbol)) {
-      throw new Error(`Invalid token symbol: ${addressOrSymbol}`)
+function validateTokenAddresses(tokenAddresses: Address[]) {
+  for (const address of tokenAddresses) {
+    if (!isAddress(address, { strict: false })) {
+      throw new Error(`Invalid token address: ${address}`)
     }
   }
 }

--- a/src/modules/validators/cross-chain-permits.ts
+++ b/src/modules/validators/cross-chain-permits.ts
@@ -1,23 +1,10 @@
-import { type Address, isAddress } from 'viem'
-import { getTokenAddress } from '../../orchestrator/registry'
-import type {
-  CrossChainPermissionInput,
-  CrossChainPermit,
-  TokenSymbol,
-} from '../../types'
+import type { CrossChainPermissionInput, CrossChainPermit } from '../../types'
 
 function dateToUnixSeconds(input: Date): bigint {
   // Date.getTime() returns milliseconds since epoch; the on-chain policy
   // expects unix-seconds. Integer division matches the Permit2 deadline
   // convention.
   return BigInt(Math.floor(input.getTime() / 1000))
-}
-
-function resolveTokenForChain(
-  token: Address | TokenSymbol,
-  chainId: number,
-): Address {
-  return isAddress(token) ? token : getTokenAddress(token, chainId)
 }
 
 // Normalise the single-object / array / omitted shapes into arrays. An
@@ -31,8 +18,9 @@ function normalizeLegs<T>(legs: T | T[] | undefined): T[] | undefined {
 
 /**
  * Resolve a {@link CrossChainPermissionInput} into a {@link CrossChainPermit}:
- * normalise single/array legs, resolve `TokenSymbol`s to per-chain ERC-20
- * addresses, and convert `Date` validity bounds to unix-seconds.
+ * normalise single/array legs and convert `Date` validity bounds to
+ * unix-seconds. Token fields are per-chain ERC-20 addresses (v2 no longer
+ * accepts symbols).
  *
  * @internal Used by `expandCrossChainPermit`; not part of the public API.
  */
@@ -44,12 +32,12 @@ function resolveCrossChainPermission(
 
   const from = fromLegs?.map((leg) => ({
     chain: leg.chain,
-    token: resolveTokenForChain(leg.token, leg.chain.id),
+    token: leg.token,
     maxAmount: leg.maxAmount,
   }))
   const to = toLegs?.map((leg) => ({
     chain: leg.chain,
-    token: resolveTokenForChain(leg.token, leg.chain.id),
+    token: leg.token,
     recipient: leg.recipient,
   }))
 

--- a/src/orchestrator/registry.test.ts
+++ b/src/orchestrator/registry.test.ts
@@ -169,25 +169,15 @@ describe('Registry', () => {
       const address = TOKEN_ADDRESSES.ARBTRUM_USDC
       const result = resolveTokenAddress(address, arbitrum.id)
       expect(result).toBe(address)
+      // Note: UNSUPPORTED_CHAIN_ID is still exercised by the per-getter
+      // "unsupported chain" tests above; the symbol-resolution cases that used
+      // it here were removed with v2's address-only contract.
     })
 
-    test('resolves token symbol to address', () => {
-      const result = resolveTokenAddress(TOKEN_SYMBOLS.USDC, arbitrum.id)
-      expect(result).toBe(TOKEN_ADDRESSES.ARBTRUM_USDC)
-    })
-
-    test('throw error for unsupported token', () => {
+    test('throws for a non-address on an EVM chain (symbols no longer accepted)', () => {
       expect(() =>
-        resolveTokenAddress(TOKEN_SYMBOLS.USDT, baseSepolia.id),
-      ).toThrow(
-        `Unsupported token ${TOKEN_SYMBOLS.USDT} for chain ${baseSepolia.id}`,
-      )
-    })
-
-    test('throws error for unsupported chain', () => {
-      expect(() =>
-        resolveTokenAddress(TOKEN_SYMBOLS.USDC, UNSUPPORTED_CHAIN_ID),
-      ).toThrow(`Unsupported chain ${UNSUPPORTED_CHAIN_ID}`)
+        resolveTokenAddress(TOKEN_SYMBOLS.USDC, baseSepolia.id),
+      ).toThrow(`Expected a token address on EVM chain ${baseSepolia.id}`)
     })
   })
 })

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -116,7 +116,7 @@ function getDefaultAccountAccessList(onTestnets?: boolean) {
 }
 
 function resolveTokenAddress(
-  token: TokenSymbol | Address | NonEvmAddress,
+  token: Address | NonEvmAddress,
   chainId: number,
 ): Address | NonEvmAddress {
   if (isAddress(token)) {
@@ -127,14 +127,15 @@ function resolveTokenAddress(
   // wire schema accepts the raw string for non-EVM chains, so pass it
   // through unchanged. HyperCore is descriptor-addressed too but its tokens
   // are EVM hex addresses (returned above), so it is intentionally absent
-  // from `isNonEvmChainId` — a token *symbol* for HyperCore is not a valid
-  // request and falls through to the throw below.
+  // from `isNonEvmChainId`.
   if (isNonEvmChainId(chainId)) {
     return token
   }
-  // For EVM chains that aren't a hex address, the value must be a known
-  // token symbol. `getTokenAddress` throws if it isn't.
-  return getTokenAddress(token as TokenSymbol, chainId)
+  // v2: token symbols are no longer accepted. An EVM input that isn't a hex
+  // address is invalid — callers must pass the token's address.
+  throw new Error(
+    `Expected a token address on EVM chain ${chainId}, got: ${token}`,
+  )
 }
 
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,13 +275,13 @@ interface CrossChainPermit {
 
 interface FromLeg {
   chain: Chain
-  token: Address | TokenSymbol
+  token: Address
   maxAmount?: bigint
 }
 
 interface ToLeg {
   chain: Chain
-  token: Address | TokenSymbol
+  token: Address
   recipient?: Address | 'any'
 }
 
@@ -656,7 +656,7 @@ type RhinestoneConfig = RhinestoneAccountConfig &
 type TokenSymbol = 'ETH' | 'WETH' | 'USDC' | 'USDT' | 'USDT0'
 
 interface CalldataInput {
-  to: Address | TokenSymbol
+  to: Address
   data?: Hex
   value?: bigint
 }
@@ -691,12 +691,12 @@ type SourceCallInput = CallInput & {
 }
 
 interface TokenRequestWithAmount {
-  address: Address | TokenSymbol
+  address: Address
   amount: bigint
 }
 
 interface TokenRequestWithoutAmount {
-  address: Address | TokenSymbol
+  address: Address
   amount?: undefined
 }
 
@@ -722,13 +722,13 @@ type NonEvmTokenRequests =
   | [NonEvmTokenRequestWithoutAmount]
   | NonEvmTokenRequestWithAmount[]
 
-export type SimpleTokenList = (Address | TokenSymbol)[]
+export type SimpleTokenList = Address[]
 
 export type ChainTokenMap = Record<number, SimpleTokenList>
 
 export type ExactInputConfig = {
   chain: Chain
-  address: Address | TokenSymbol
+  address: Address
   amount?: bigint
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,8 +287,8 @@ interface ToLeg {
 
 /**
  * Ergonomic input for a cross-chain session permit. Set on
- * `SessionDefinition.crossChainPermits`; the SDK resolves token symbols
- * to per-chain addresses and `Date`s to on-chain deadlines, then expands
+ * `SessionDefinition.crossChainPermits`; token fields are per-chain
+ * addresses. The SDK converts `Date`s to on-chain deadlines, then expands
  * each entry into a {@link Permit2ClaimPolicy} (claim-side) plus optional
  * {@link SpendingLimitsPolicy} / {@link TimeFramePolicy} guardrails.
  */

--- a/test/integration/framework/fixtures.ts
+++ b/test/integration/framework/fixtures.ts
@@ -9,8 +9,9 @@ import {
 } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import type { Chain } from 'viem/chains'
-import type { Session, TokenSymbol } from '../../../src/index'
+import type { Session } from '../../../src/index'
 import { toSession } from '../../../src/modules/validators/smart-sessions'
+import { getTokenAddress } from '../../../src/orchestrator/registry'
 
 export const noopTarget: Address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
@@ -38,11 +39,11 @@ export function createNoopCall() {
   }
 }
 
-export function createUsdcRequestWithoutFunds() {
+export function createUsdcRequestWithoutFunds(chainId: number) {
   return {
     tokenRequests: [
       {
-        address: 'USDC' as TokenSymbol,
+        address: getTokenAddress('USDC', chainId),
         amount: 1_000_000n,
       },
     ],

--- a/test/integration/scenarios/preclaim-ops.itest.ts
+++ b/test/integration/scenarios/preclaim-ops.itest.ts
@@ -134,7 +134,7 @@ describe.sequential('SDK integration preclaim-ops', () => {
         targetChain,
         sponsored: true,
         calls: [],
-        tokenRequests: [{ address: 'USDC', amount: 10_000n }],
+        tokenRequests: [{ address: usdc, amount: 10_000n }],
         sourceCalls: {
           [sourceChain.id]: [
             {


### PR DESCRIPTION
## What

Token inputs are now **address-only** across the SDK's public surface. Token symbols (`'USDC'`, `'WETH'`, …) are no longer accepted — callers pass the token's address for the target chain.

Affected inputs: `tokenRequests[].address`, `CalldataInput.to`, `ExactInputConfig.address`, `SimpleTokenList`, and cross-chain permit legs (`from`/`to`).

## Why

Symbols required a per-chain **symbol→address lookup in the bundled `@rhinestone/shared-configs` registry**. Addresses need no lookup. This is **step 1** of removing the SDK's bundled chain data, so that adding a new chain no longer requires an SDK release. (Symbols were also poor practice in prod — ambiguous and prone to chain-local variants like `USDC.e`; an address is unambiguous.)

Internals: `resolveTokenAddress` collapses to an address validator (keeps the non-EVM passthrough); `validateTokenSymbols` → `validateTokenAddresses`.

## Scope

This is the first, self-contained slice. The larger effort (source remaining chain data — supported-chain list, tokens, wrapped-native — from the orchestrator `/chains` endpoint at runtime, then drop the `shared-configs` dependency) is a follow-up cross-repo workstream and is **not** in this PR.

## Verification

- `tsc --noEmit` — clean
- `biome check` — clean (129 files)
- unit tests — 491 passed
- `bun run build` — clean

Breaking change; changeset included (`major`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)