### PR TITLE
feat: Rhinestone protocol fee — options.protocolFees + sponsorable flag (RHI-4904)

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -19,7 +19,11 @@ import {
   getSupportedChainIds,
   isTestnet,
 } from '../orchestrator/registry'
-import type { AppFeeRate, SettlementLayer } from '../orchestrator/types'
+import type {
+  AppFeeRate,
+  ProtocolFeeRate,
+  SettlementLayer,
+} from '../orchestrator/types'
 import type {
   CalldataInput,
   CallInput,
@@ -95,6 +99,7 @@ async function sendTransaction(
     sourceAssets,
     feeAsset,
     appFees,
+    protocolFees,
   } = transaction
   const isUserOpSigner = signers?.type === 'guardians'
   if (isUserOpSigner) {
@@ -113,6 +118,7 @@ async function sendTransaction(
     sourceAssets,
     feeAsset,
     appFees,
+    protocolFees,
   })
 }
 
@@ -153,6 +159,7 @@ async function sendTransactionInternal(
     lockFunds?: boolean
     feeAsset?: Address | TokenSymbol
     appFees?: AppFeeRate
+    protocolFees?: ProtocolFeeRate
   },
 ) {
   const accountAddress = getAddress(config)
@@ -188,6 +195,7 @@ async function sendTransactionInternal(
       options.lockFunds,
       options.sourceCalls,
       options.appFees,
+      options.protocolFees,
     )
   }
 }
@@ -243,6 +251,7 @@ async function sendTransactionAsIntent(
   lockFunds?: boolean,
   sourceCalls?: Record<number, CallInput[]>,
   appFees?: AppFeeRate,
+  protocolFees?: ProtocolFeeRate,
 ) {
   const prepared = await prepareTransactionAsIntent(
     config,
@@ -263,6 +272,7 @@ async function sendTransactionAsIntent(
     signers,
     sourceCalls,
     appFees,
+    protocolFees,
   )
   if (!prepared) {
     throw new OrderPathRequiredForIntentsError()

--- a/src/execution/utils.test.ts
+++ b/src/execution/utils.test.ts
@@ -257,6 +257,122 @@ describe('prepareTransactionAsIntent', () => {
     expect(intentInput.options.appFees).toEqual({ feeBps: 100 })
   })
 
+  test('includes protocolFees in options when provided (RHI-4904)', async () => {
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { feeBps: 35 },
+    )
+
+    expect(mockGetIntentRoute).toHaveBeenCalledOnce()
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.protocolFees).toEqual({ feeBps: 35 })
+    expect(intentInput.options.appFees).toBeUndefined()
+  })
+
+  test('maps sponsored.protocolFees onto sponsorSettings (RHI-4904)', async () => {
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      { gas: false, bridging: false, swaps: false, protocolFees: true },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { feeBps: 35 },
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.sponsorSettings).toEqual({
+      gasSponsored: false,
+      bridgeFeesSponsored: false,
+      swapFeesSponsored: false,
+      protocolFeesSponsored: true,
+    })
+  })
+
+  test('boolean sponsored: true enables protocolFeesSponsored too (RHI-4904)', async () => {
+    mockGetIntentRoute.mockResolvedValue({
+      intentOp: {},
+      intentCost: {},
+    })
+
+    await prepareTransactionAsIntent(
+      {
+        owners: { type: 'ecdsa', accounts: [accountA], threshold: 1 },
+        apiKey: 'test',
+      },
+      [arbitrum],
+      base,
+      [],
+      undefined,
+      [{ address: zeroAddress, amount: 1n }],
+      undefined,
+      true,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    const intentInput: IntentInput = mockGetIntentRoute.mock.calls[0][0]
+    expect(intentInput.options.sponsorSettings).toEqual({
+      gasSponsored: true,
+      bridgeFeesSponsored: true,
+      swapFeesSponsored: true,
+      protocolFeesSponsored: true,
+    })
+  })
+
   test('claim-only session sends SIG_MODE_ERC1271 in routing request', async () => {
     mockGetIntentRoute.mockResolvedValue({
       intentOp: {},

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -95,6 +95,7 @@ import {
   type IntentOpElement,
   type Account as OrchestratorAccount,
   type OriginSignature,
+  type ProtocolFeeRate,
   type SettlementLayer,
   SIG_MODE_EMISSARY_EXECUTION_ERC1271,
   SIG_MODE_ERC1271,
@@ -276,6 +277,7 @@ async function prepareTransaction(
     sourceAssets,
     feeAsset,
     appFees,
+    protocolFees,
     lockFunds,
     auxiliaryFunds,
     account,
@@ -312,6 +314,7 @@ async function prepareTransaction(
     signers,
     sourceCalls,
     appFees,
+    protocolFees,
   )
 
   return {
@@ -739,6 +742,7 @@ function getTransactionParams(transaction: Transaction) {
   const sourceAssets = transaction.sourceAssets
   const feeAsset = transaction.feeAsset
   const appFees = transaction.appFees
+  const protocolFees = transaction.protocolFees
   const lockFunds = transaction.lockFunds
   const auxiliaryFunds = transaction.auxiliaryFunds
   const account = transaction.experimental_accountOverride
@@ -759,6 +763,7 @@ function getTransactionParams(transaction: Transaction) {
     sourceAssets,
     feeAsset,
     appFees,
+    protocolFees,
     lockFunds,
     auxiliaryFunds,
     account,
@@ -882,6 +887,7 @@ async function prepareTransactionAsIntent(
   signers: SignerSet | undefined,
   sourceCalls: Record<number, CallInput[]> | undefined,
   appFees?: AppFeeRate,
+  protocolFees?: ProtocolFeeRate,
 ) {
   const calls = parseCalls(callInputs, targetChain.id)
   const accountAccessList = createAccountAccessList(sourceChains, sourceAssets)
@@ -1014,17 +1020,20 @@ async function prepareTransactionAsIntent(
       topupCompact: lockFunds ?? false,
       feeToken: feeAsset,
       appFees,
+      protocolFees,
       sponsorSettings: sponsored
         ? typeof sponsored === 'object'
           ? {
               gasSponsored: sponsored.gas,
               bridgeFeesSponsored: sponsored.bridging,
               swapFeesSponsored: sponsored.swaps,
+              protocolFeesSponsored: sponsored.protocolFees ?? false,
             }
           : {
               gasSponsored: sponsored,
               bridgeFeesSponsored: sponsored,
               swapFeesSponsored: sponsored,
+              protocolFeesSponsored: sponsored,
             }
         : undefined,
       settlementLayers,

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -100,6 +100,7 @@ interface IntentOptions {
   topupCompact: boolean
   feeToken?: Address | SupportedTokenSymbol
   appFees?: AppFeeRate
+  protocolFees?: ProtocolFeeRate
   sponsorSettings?: SponsorSettings
   settlementLayers?: SettlementLayer[]
   signatureMode?: SignatureMode
@@ -107,6 +108,15 @@ interface IntentOptions {
 }
 
 interface AppFeeRate {
+  feeBps: number
+}
+
+/**
+ * Rate for the Rhinestone protocol fee (RHI-4904) — a clone of the app fee
+ * that always accrues to Rhinestone regardless of the caller's API key, and
+ * (unlike the app fee) can be sponsored via `sponsorSettings.protocolFees`.
+ */
+interface ProtocolFeeRate {
   feeBps: number
 }
 
@@ -129,6 +139,7 @@ interface SponsorSettings {
   gasSponsored: boolean
   bridgeFeesSponsored: boolean
   swapFeesSponsored: boolean
+  protocolFeesSponsored?: boolean
 }
 
 interface PortfolioToken {
@@ -513,6 +524,7 @@ export type {
   AppFee,
   AppFeeBalances,
   AppFeeRate,
+  ProtocolFeeRate,
   ApprovalRequired,
   AuxiliaryFunds,
   Execution,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import type { ModuleType } from './modules/common'
 import type {
   AppFeeRate,
   AuxiliaryFunds,
+  ProtocolFeeRate,
   SettlementLayer,
 } from './orchestrator/types'
 
@@ -456,6 +457,7 @@ type Sponsorship =
       gas: boolean
       bridging: boolean
       swaps: boolean
+      protocolFees?: boolean
     }
 
 interface BaseTransaction {
@@ -482,6 +484,7 @@ interface BaseTransaction {
   sourceAssets?: SourceAssetInput
   feeAsset?: Address | TokenSymbol
   appFees?: AppFeeRate
+  protocolFees?: ProtocolFeeRate
   settlementLayers?: SettlementLayer[]
   lockFunds?: boolean
   auxiliaryFunds?: AuxiliaryFunds


### PR DESCRIPTION
## Summary

Client support for the orchestrator's new **Rhinestone protocol fee** ([RHI-4904](https://linear.app/rhinestone/issue/RHI-4904), [orchestrator#1756](https://github.com/rhinestonewtf/orchestrator/pull/1756)): a clone of the integrator app fee that always accrues to Rhinestone regardless of the caller's API key, is collected alongside the app fee in **one batched transfer**, and — unlike the app fee — can be **sponsored** by the client.

- `transaction.protocolFees: { feeBps }` (0–10000) threaded through `sendTransaction` / `prepareTransactionAsIntent` into `IntentOptions.protocolFees`, exactly parallel to `appFees`.
- `sponsored.protocolFees` (object form) maps onto `sponsorSettings.protocolFeesSponsored`; the boolean `sponsored: true` shorthand enables it along with the other categories. When sponsored, the orchestrator charges the client's sponsorship balance instead of the user (no surcharge on the fee itself) — all-or-nothing, rejecting with `INSUFFICIENT_SPONSOR_BALANCE` when short.
- `ProtocolFeeRate` exported; `FeeBreakdown.protocolFee` / `FeeBreakdownUSD.protocolFeeUSD` response fields were already typed (previously always `0`) and are live once the orchestrator PR ships.

## Tests

`prepareTransactionAsIntent` serialization: `protocolFees` lands in `options` (and doesn't leak into `appFees`); the sponsored-object mapping produces all four `sponsorSettings` flags; the boolean shorthand enables `protocolFeesSponsored` too. `bun run test` green (35), `tsc --noEmit` clean, touched files biome-clean (repo-wide `check` has pre-existing failures on `main` unrelated to this diff).

Depends on rhinestonewtf/orchestrator#1756 — inert against older orchestrators (unknown option ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)