### PR TITLE
refactor(sdk)!: read chain data from /chains at runtime, drop shared-configs

### DIFF
--- a/.changeset/runtime-chain-catalog.md
+++ b/.changeset/runtime-chain-catalog.md
@@ -7,7 +7,7 @@ Read chain data at runtime from the orchestrator instead of bundling it. The SDK
 Breaking changes:
 
 - **`SupportedChain` is now `number`** (open) rather than a closed union of chain ids.
-- **New `account.createSession(definition)`** — resolves the chain's wrapped-native token from `/chains` and permits native-wrapping automatically. The standalone `toSession(definition, options)` is now pure: pass `options.wrappedNativeToken` to opt into the native-wrap action (otherwise it is omitted).
+- **New `RhinestoneSDK.createSession(definition)`** (`sdk.createSession(...)`) — resolves the chain's wrapped-native token from `/chains` and permits native-wrapping automatically. It is project-scoped (needs the API key, not an account). The standalone `toSession(definition, options)` is now pure: pass `options.wrappedNativeToken` to opt into the native-wrap action (otherwise it is omitted).
 - **Removed the `alchemy` provider type.** Supply RPC URLs yourself via `provider: { type: 'custom', urls: { [chainId]: url } }`, or omit `provider` to use viem's default transport.
 - **Removed the token-registry helpers** `getWethAddress`, `getTokenSymbol`, and `isTokenAddressSupported`. Fetch equivalent data from the orchestrator's `/chains` endpoint.
 

--- a/.changeset/runtime-chain-catalog.md
+++ b/.changeset/runtime-chain-catalog.md
@@ -1,0 +1,16 @@
+---
+'@rhinestone/sdk': major
+---
+
+Read chain data at runtime from the orchestrator instead of bundling it. The SDK no longer depends on `@rhinestone/shared-configs`: the supported-chain set, per-chain tokens, and the wrapped-native token are fetched (once, lazily, and cached) from the orchestrator's `GET /chains`, and `Chain` objects come from `viem`. A new chain no longer requires an SDK release.
+
+Breaking changes:
+
+- **`SupportedChain` is now `number`** (open) rather than a closed union of chain ids.
+- **New `account.createSession(definition)`** — resolves the chain's wrapped-native token from `/chains` and permits native-wrapping automatically. The standalone `toSession(definition, options)` is now pure: pass `options.wrappedNativeToken` to opt into the native-wrap action (otherwise it is omitted).
+- **Removed the `alchemy` provider type.** Supply RPC URLs yourself via `provider: { type: 'custom', urls: { [chainId]: url } }`, or omit `provider` to use viem's default transport.
+- **Removed the token-registry helpers** `getWethAddress`, `getTokenSymbol`, and `isTokenAddressSupported`. Fetch equivalent data from the orchestrator's `/chains` endpoint.
+
+The signed Permit2 arbiter allow-set stays bundled (it must remain client-trusted), now as a small inlined constant rather than read from shared-configs.
+
+Requires an orchestrator that returns `wrappedNativeToken` on `/chains`.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -28,7 +27,6 @@
       "name": "@rhinestone/sdk",
       "version": "2.0.0-beta.43",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.7.15",
         "solady": "^0.1.26",
       },
       "peerDependencies": {
@@ -188,8 +186,6 @@
     "@redocly/openapi-core": ["@redocly/openapi-core@1.34.15", "", { "dependencies": { "@redocly/ajv": "8.11.2", "@redocly/config": "0.22.0", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.1.1", "minimatch": "5.1.9", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q=="],
 
     "@rhinestone/sdk": ["@rhinestone/sdk@workspace:src"],
-
-    "@rhinestone/shared-configs": ["@rhinestone/shared-configs@1.7.15", "", { "peerDependencies": { "typescript": "^5", "viem": "^2.55.0" } }, "sha512-Y8s/pHBCnamNAEtA/Nk3QAhDh+pPLa66/6zObw8y2TqkS0Ah3nx5UPmwLYmOyXMGiqRLpnGPtkg5rwI3hrhi4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.40.1", "", { "os": "android", "cpu": "arm" }, "sha512-kxz0YeeCrRUHz3zyqvd7n+TVRlNyTifBsmnmNPtk3hQURUyG9eAB+usz6DAwagMusjx/zb3AjvDUvhFGDAexGw=="],
 

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -172,6 +172,7 @@ export const manifest: Group[] = [
         group: 'Smart sessions',
         experimental: true,
         items: [
+          accountMethod('createSession'),
           accountMethod('experimental_getSessionDetails', true),
           accountMethod('experimental_isSessionEnabled', true),
           accountMethod('experimental_signEnableSession', true),

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -87,6 +87,13 @@ export const manifest: Group[] = [
       },
       {
         kind: 'symbol',
+        symbol: 'createSession',
+        source: '.',
+        container: 'RhinestoneSDK',
+        callStyle: 'sdkMethod',
+      },
+      {
+        kind: 'symbol',
         symbol: 'getIntentStatus',
         source: '.',
         container: 'RhinestoneSDK',
@@ -172,7 +179,6 @@ export const manifest: Group[] = [
         group: 'Smart sessions',
         experimental: true,
         items: [
-          accountMethod('createSession'),
           accountMethod('experimental_getSessionDetails', true),
           accountMethod('experimental_isSessionEnabled', true),
           accountMethod('experimental_signEnableSession', true),

--- a/src/accounts/json-rpc/index.test.ts
+++ b/src/accounts/json-rpc/index.test.ts
@@ -5,14 +5,6 @@ import { createTransport } from './index'
 
 describe('JSON-RPC', () => {
   describe('createTransport', () => {
-    test('Alchemy', () => {
-      const transport = createTransport(base, {
-        type: 'alchemy',
-        apiKey: '123',
-      })
-      expect(transport).toBeDefined()
-    })
-
     test('Custom', () => {
       const transport = createTransport(mainnet, {
         type: 'custom',

--- a/src/accounts/json-rpc/index.ts
+++ b/src/accounts/json-rpc/index.ts
@@ -1,27 +1,16 @@
 import { type Chain, http, type Transport } from 'viem'
-import type { SupportedChain } from '../../orchestrator'
 import type { ProviderConfig } from '../../types'
-import { getAlchemyUrl, getCustomUrl } from './providers'
+import { getCustomUrl } from './providers'
 
 function createTransport(chain: Chain, provider?: ProviderConfig): Transport {
   if (!provider) {
     return http()
   }
-
-  switch (provider.type) {
-    case 'alchemy': {
-      const alchemyUrl = getAlchemyUrl(
-        chain.id as SupportedChain,
-        provider.apiKey,
-      )
-      return http(alchemyUrl)
-    }
-    case 'custom': {
-      const customUrl = getCustomUrl(chain.id, provider.urls)
-      // Fall back to default provider if no custom URL configured for this chain
-      return http(customUrl)
-    }
-  }
+  // Caller supplies the RPC URL per chain (v2: the SDK no longer bundles
+  // provider slugs or builds Alchemy URLs). Falls back to viem's default
+  // transport when no URL is configured for this chain.
+  const customUrl = getCustomUrl(chain.id, provider.urls)
+  return http(customUrl)
 }
 
 export { createTransport }

--- a/src/accounts/json-rpc/providers.test.ts
+++ b/src/accounts/json-rpc/providers.test.ts
@@ -1,24 +1,8 @@
-import { arbitrum, polygon, sepolia } from 'viem/chains'
+import { arbitrum, sepolia } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
-import { getAlchemyUrl, getCustomUrl } from './providers'
+import { getCustomUrl } from './providers'
 
 describe('Providers', () => {
-  describe('Alchemy', () => {
-    test('Network', () => {
-      const mockApiKey = '123'
-
-      expect(getAlchemyUrl(arbitrum.id, mockApiKey)).toBe(
-        'https://arb-mainnet.g.alchemy.com/v2/123',
-      )
-      expect(getAlchemyUrl(sepolia.id, mockApiKey)).toBe(
-        'https://eth-sepolia.g.alchemy.com/v2/123',
-      )
-      expect(getAlchemyUrl(polygon.id, mockApiKey)).toBe(
-        'https://polygon-mainnet.g.alchemy.com/v2/123',
-      )
-    })
-  })
-
   describe('Custom', () => {
     test('Returns URL for configured chain', () => {
       const urls = {

--- a/src/accounts/json-rpc/providers.ts
+++ b/src/accounts/json-rpc/providers.ts
@@ -1,21 +1,3 @@
-import { providerRegistry as providers } from '@rhinestone/shared-configs'
-
-import type { SupportedChain } from '../../orchestrator'
-
-function getAlchemyUrl(chainId: SupportedChain, apiKey: string): string {
-  const urlTemplate = providers.Alchemy.url_template
-  const chainParam = providers.Alchemy.chain_mapping[chainId]
-  if (!chainParam) {
-    throw new Error(`Unsupported chain: ${chainId}`)
-  }
-  return (
-    urlTemplate
-      .replace('{{chain_param}}', chainParam)
-      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder token in the upstream shared-configs url_template
-      .replace('${ALCHEMY_API_KEY}', apiKey)
-  )
-}
-
 function getCustomUrl(
   chainId: number,
   urls: Record<number, string>,
@@ -23,4 +5,4 @@ function getCustomUrl(
   return urls[chainId]
 }
 
-export { getAlchemyUrl, getCustomUrl }
+export { getCustomUrl }

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -14,7 +14,7 @@ import {
   type SplitIntentsInput,
 } from '../orchestrator'
 import type { NonEvmAddress } from '../orchestrator/destinations'
-import { getChainById, isTestnet } from '../orchestrator/registry'
+import { getChainById } from '../orchestrator/registry'
 import type { AppFeeRate, SettlementLayerFilter } from '../orchestrator/types'
 import type {
   CalldataInput,
@@ -356,13 +356,13 @@ async function getPortfolio(config: RhinestoneConfig, onTestnets: boolean) {
     config.headers,
   )
   const catalog = await orchestrator.getChainCatalog()
-  const filteredChainIds = catalog.getSupportedChainIds().filter((id) => {
-    try {
-      return isTestnet(id) === onTestnets
-    } catch {
-      return false
-    }
-  })
+  // Filter on the catalog's own `testnet` flag — authoritative for every chain
+  // the orchestrator supports (incl. non-EVM and chains newer than the SDK's
+  // viem). Filtering through viem would silently drop unknown chains, so their
+  // balances would disappear until an SDK/viem bump.
+  const filteredChainIds = catalog
+    .getSupportedChainIds()
+    .filter((id) => catalog.isTestnet(id) === onTestnets)
   return orchestrator.getPortfolio(address, { chainIds: filteredChainIds })
 }
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -14,11 +14,7 @@ import {
   type SplitIntentsInput,
 } from '../orchestrator'
 import type { NonEvmAddress } from '../orchestrator/destinations'
-import {
-  getChainById,
-  getSupportedChainIds,
-  isTestnet,
-} from '../orchestrator/registry'
+import { getChainById, isTestnet } from '../orchestrator/registry'
 import type { AppFeeRate, SettlementLayerFilter } from '../orchestrator/types'
 import type {
   CalldataInput,
@@ -359,8 +355,8 @@ async function getPortfolio(config: RhinestoneConfig, onTestnets: boolean) {
     config.endpointUrl,
     config.headers,
   )
-  const supportedChainIds = getSupportedChainIds()
-  const filteredChainIds = supportedChainIds.filter((id) => {
+  const catalog = await orchestrator.getChainCatalog()
+  const filteredChainIds = catalog.getSupportedChainIds().filter((id) => {
     try {
       return isTestnet(id) === onTestnets
     } catch {

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -1944,7 +1944,8 @@ async function signDestinationSeparately(
   destination: TypedDataDefinition,
   targetExecution: boolean,
 ): Promise<Hex> {
-  const destinationChain = getChainById(targetChain.id)
+  // `targetChain` is already the destination viem `Chain`; no lookup needed.
+  const destinationChain = targetChain
   const destinationSignatures = await signIntentTypedData(
     config,
     signers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -505,6 +505,14 @@ async function createAccountInternal(
     const wrappedNativeToken = catalog.getWrappedNativeToken(
       definition.chain.id,
     )?.address as Address | undefined
+    // Fail fast: without the wrapped-native address we can't add the native-wrap
+    // `deposit()` permission, and a silently under-scoped session would
+    // sign/enable fine but break native-wrap intents later.
+    if (!wrappedNativeToken) {
+      throw new Error(
+        `createSession: the orchestrator's /chains has no wrapped-native token for chain ${definition.chain.id}. The chain must be supported and advertise its wrappedNativeToken.`,
+      )
+    }
     return toSession(definition, {
       wrappedNativeToken,
       useDevContracts: config.useDevContracts,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  Abi,
   Address,
   Chain,
   HashTypedDataParameters,
@@ -72,6 +73,7 @@ import {
 import {
   isSessionEnabled as isSessionEnabledInternal,
   type SessionDetails,
+  toSession,
 } from './modules/validators/smart-sessions'
 import type {
   AppFeeBalances,
@@ -97,6 +99,7 @@ import type {
   TokenRequirements,
   WrapRequired,
 } from './orchestrator'
+import { getOrchestrator } from './orchestrator'
 
 export type { AppFeeBalances, AppFeeRate } from './orchestrator'
 
@@ -154,6 +157,17 @@ interface SubmitTransactionOptions {
 interface RhinestoneAccount {
   /** The resolved account configuration. */
   config: RhinestoneAccountConfig
+  /**
+   * Create a smart session, resolving the chain's wrapped-native token from the
+   * orchestrator's chain catalog (`GET /chains`) so native-token wrapping is
+   * permitted automatically. For a fully offline build, use the standalone
+   * {@link toSession} and pass `wrappedNativeToken` yourself.
+   * @param definition The session definition
+   * @returns The resolved session
+   */
+  createSession<const TAbis extends readonly Abi[]>(
+    definition: SessionDefinition<TAbis>,
+  ): Promise<Session>
   /**
    * Deploy the account on a given chain.
    * @param chain Chain to deploy the account on
@@ -479,6 +493,24 @@ async function createAccountInternal(
     return signEip7702InitDataInternal(config)
   }
 
+  async function createSession<const TAbis extends readonly Abi[]>(
+    definition: SessionDefinition<TAbis>,
+  ): Promise<Session> {
+    const orchestrator = getOrchestrator(
+      config._authProvider ?? createAuthProvider(config),
+      config.endpointUrl,
+      config.headers,
+    )
+    const catalog = await orchestrator.getChainCatalog()
+    const wrappedNativeToken = catalog.getWrappedNativeToken(
+      definition.chain.id,
+    )?.address as Address | undefined
+    return toSession(definition, {
+      wrappedNativeToken,
+      useDevContracts: config.useDevContracts,
+    })
+  }
+
   function prepareTransaction(transaction: Transaction) {
     return prepareTransactionInternal(config, transaction)
   }
@@ -674,6 +706,7 @@ async function createAccountInternal(
 
   return {
     config,
+    createSession,
     deploy,
     isDeployed,
     setup,

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,17 +158,6 @@ interface RhinestoneAccount {
   /** The resolved account configuration. */
   config: RhinestoneAccountConfig
   /**
-   * Create a smart session, resolving the chain's wrapped-native token from the
-   * orchestrator's chain catalog (`GET /chains`) so native-token wrapping is
-   * permitted automatically. For a fully offline build, use the standalone
-   * {@link toSession} and pass `wrappedNativeToken` yourself.
-   * @param definition The session definition
-   * @returns The resolved session
-   */
-  createSession<const TAbis extends readonly Abi[]>(
-    definition: SessionDefinition<TAbis>,
-  ): Promise<Session>
-  /**
    * Deploy the account on a given chain.
    * @param chain Chain to deploy the account on
    * @param params Optional deployment parameters (sponsorship)
@@ -493,32 +482,6 @@ async function createAccountInternal(
     return signEip7702InitDataInternal(config)
   }
 
-  async function createSession<const TAbis extends readonly Abi[]>(
-    definition: SessionDefinition<TAbis>,
-  ): Promise<Session> {
-    const orchestrator = getOrchestrator(
-      config._authProvider ?? createAuthProvider(config),
-      config.endpointUrl,
-      config.headers,
-    )
-    const catalog = await orchestrator.getChainCatalog()
-    const wrappedNativeToken = catalog.getWrappedNativeToken(
-      definition.chain.id,
-    )?.address as Address | undefined
-    // Fail fast: without the wrapped-native address we can't add the native-wrap
-    // `deposit()` permission, and a silently under-scoped session would
-    // sign/enable fine but break native-wrap intents later.
-    if (!wrappedNativeToken) {
-      throw new Error(
-        `createSession: the orchestrator's /chains has no wrapped-native token for chain ${definition.chain.id}. The chain must be supported and advertise its wrappedNativeToken.`,
-      )
-    }
-    return toSession(definition, {
-      wrappedNativeToken,
-      useDevContracts: config.useDevContracts,
-    })
-  }
-
   function prepareTransaction(transaction: Transaction) {
     return prepareTransactionInternal(config, transaction)
   }
@@ -714,7 +677,6 @@ async function createAccountInternal(
 
   return {
     config,
-    createSession,
     deploy,
     isDeployed,
     setup,
@@ -743,6 +705,28 @@ async function createAccountInternal(
     experimental_signEnableSession,
     getInitData,
   }
+}
+
+async function createSessionInternal<const TAbis extends readonly Abi[]>(
+  authProvider: AuthProvider,
+  endpointUrl: string | undefined,
+  headers: Record<string, string> | undefined,
+  useDevContracts: boolean | undefined,
+  definition: SessionDefinition<TAbis>,
+): Promise<Session> {
+  const orchestrator = getOrchestrator(authProvider, endpointUrl, headers)
+  const catalog = await orchestrator.getChainCatalog()
+  const wrappedNativeToken = catalog.getWrappedNativeToken(definition.chain.id)
+    ?.address as Address | undefined
+  // Fail fast: without the wrapped-native address we can't add the native-wrap
+  // `deposit()` permission, and a silently under-scoped session would
+  // sign/enable fine but break native-wrap intents later.
+  if (!wrappedNativeToken) {
+    throw new Error(
+      `createSession: the orchestrator's /chains has no wrapped-native token for chain ${definition.chain.id}. The chain must be supported and advertise its wrappedNativeToken.`,
+    )
+  }
+  return toSession(definition, { wrappedNativeToken, useDevContracts })
 }
 
 /**
@@ -804,6 +788,27 @@ class RhinestoneSDK {
       headers: this.headers,
     }
     return createAccountInternal(rhinestoneConfig)
+  }
+
+  /**
+   * Create a smart session, resolving the chain's wrapped-native token from the
+   * orchestrator's chain catalog (`GET /chains`) so native-token wrapping is
+   * permitted automatically. Project-scoped — needs the API key but no account.
+   * For a fully offline build, use the standalone {@link toSession} and pass
+   * `wrappedNativeToken` yourself.
+   * @param definition The session definition
+   * @returns The resolved session
+   */
+  createSession<const TAbis extends readonly Abi[]>(
+    definition: SessionDefinition<TAbis>,
+  ): Promise<Session> {
+    return createSessionInternal(
+      this.authProvider,
+      this.endpointUrl,
+      this.headers,
+      this.useDevContracts,
+      definition,
+    )
   }
 
   /**

--- a/src/modules/validators/policies/claim/arbiters.ts
+++ b/src/modules/validators/policies/claim/arbiters.ts
@@ -1,15 +1,10 @@
-import {
-  contractAddresses,
-  contractAddressesDev,
-} from '@rhinestone/shared-configs'
 import type { Address } from 'viem'
 import type { CrossChainSettlementLayer } from '../../../../types'
 
 /**
- * The contract registry keys (per `shared-configs/contracts.{,dev}.js`)
- * that each settlement layer expands to. `ACROSS` whitelists both arbiter
- * impls so a session is permissioned for the 7579 and multicall paths
- * regardless of which one the orchestrator picks at intent time.
+ * The arbiter contract keys that each settlement layer expands to. `ACROSS`
+ * whitelists both arbiter impls so a session is permissioned for the 7579 and
+ * multicall paths regardless of which one the orchestrator picks at intent time.
  */
 const SETTLEMENT_LAYER_CONTRACT_KEYS: Record<
   CrossChainSettlementLayer,
@@ -21,18 +16,51 @@ const SETTLEMENT_LAYER_CONTRACT_KEYS: Record<
 }
 
 /**
- * Collects every distinct arbiter address that any chain in the registry
- * has deployed for the given settlement layers. The resulting whitelist
- * is what the Permit2 claim policy enforces on-chain — a session signed
- * once with this whitelist is valid against any of those arbiters.
+ * Bundled arbiter allow-set — the deployed arbiter addresses per key, per
+ * environment (the union across chains).
  *
- * **"Any" means any of the *supported* settlement layers**, not any
- * address on earth. When `layers` is empty or undefined, this resolver
- * expands to the union of every layer in
- * {@link SETTLEMENT_LAYER_CONTRACT_KEYS}, so the on-chain arbiter check
- * stays meaningful (the worst case is still a Rhinestone-blessed
- * arbiter). To get a truly unrestricted whitelist a caller would have
- * to bypass this helper entirely.
+ * v2: this is a small, signed-path **constant** bundled in the SDK rather than
+ * read from `@rhinestone/shared-configs`. The arbiter is baked into the user's
+ * Permit2 session signature, so it must stay **client-trusted** — never sourced
+ * from the orchestrator you transact against. Rhinestone's arbiters are CREATE2
+ * and near-uniform across chains, so this is a handful of addresses per key
+ * (e.g. `ecoArbiter` has a mainnet and a testnet address). A new *chain* reuses
+ * these; only a contract redeploy or a new settlement layer changes them.
+ */
+const ARBITER_ADDRESSES: Record<
+  'prod' | 'dev',
+  Record<string, readonly Address[]>
+> = {
+  prod: {
+    samechainArbiter: ['0x000000000006e2569CaF8Ff021810790e0A0D740'],
+    ecoArbiter: [
+      '0x2e7627CCfAe4eDb336eEb5a70f08415B0F1a2b8C',
+      '0xA212A6ACCC8db0e4cdf4394D0A851c70Fc27A8F0',
+    ],
+    across7579Arbiter: ['0x28a4D41776968c1201A807ec51fFB405362B8882'],
+    acrossMulticallArbiter: ['0xA162fabb9a0EeF2736485A587aAAB3d015e14224'],
+  },
+  dev: {
+    samechainArbiter: ['0x8fA7720Eee299223f25De8DC03C68A28541dCD10'],
+    ecoArbiter: [
+      '0x1BeBAfb3D05d84A5Bfd94800c88d1342f755d8AB',
+      '0x8A061029AE4c5Cf69b5368119B3b0C80B31F55fE',
+    ],
+    across7579Arbiter: ['0x1b19973F7a29E950ad4FaF8872745B6378005517'],
+    acrossMulticallArbiter: ['0x8343FBBA0526deC1c952A098057021027648bcf9'],
+  },
+}
+
+/**
+ * Collects every distinct arbiter address for the given settlement layers. The
+ * resulting whitelist is what the Permit2 claim policy enforces on-chain — a
+ * session signed once with this whitelist is valid against any of those
+ * arbiters.
+ *
+ * **"Any" means any of the *supported* settlement layers**, not any address on
+ * earth. When `layers` is empty or undefined, this expands to the union of
+ * every layer in {@link SETTLEMENT_LAYER_CONTRACT_KEYS}, so the on-chain arbiter
+ * check stays meaningful (the worst case is still a Rhinestone-blessed arbiter).
  *
  * @param layers   Settlement layers the session is permitted to use.
  *                 Empty/undefined ⇒ all supported layers.
@@ -49,20 +77,17 @@ export function getArbitersForSettlementLayers(
         ) as CrossChainSettlementLayer[])
       : layers
 
-  const registry = useDevContracts ? contractAddressesDev : contractAddresses
+  const book = ARBITER_ADDRESSES[useDevContracts ? 'dev' : 'prod']
   const keys = effectiveLayers.flatMap((l) => SETTLEMENT_LAYER_CONTRACT_KEYS[l])
   const seen = new Set<string>()
   const addresses: Address[] = []
 
-  // shared-configs is shaped Record<chainId, Record<contractKey, Address>>.
-  // The same logical arbiter often shares an address across chains, but a
-  // given key may also have multiple addresses live in the wild (e.g.
-  // post-redeploy). We collect every unique address we see for the keys
-  // the caller asked for, deduplicated case-insensitively.
-  for (const chainContracts of Object.values(registry)) {
-    for (const key of keys) {
-      const addr = (chainContracts as Record<string, Address | undefined>)[key]
-      if (!addr) continue
+  // The same logical arbiter often shares an address across chains, but a given
+  // key may have multiple addresses live (e.g. a mainnet + testnet deployment).
+  // Collect every unique address for the requested keys, deduped
+  // case-insensitively.
+  for (const key of keys) {
+    for (const addr of book[key] ?? []) {
       const norm = addr.toLowerCase()
       if (seen.has(norm)) continue
       seen.add(norm)

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -48,19 +48,24 @@ const baseSession: Session = toSession({
   owners: { type: 'ecdsa', accounts: [accountA] },
 })
 
-const sessionWithAction: Session = toSession({
-  chain: base,
-  owners: { type: 'ecdsa', accounts: [accountA] },
-  permissions: [
-    {
-      abi: erc20Abi,
-      address: '0x1111111111111111111111111111111111111111' as Address,
-      functions: {
-        transfer: {},
+const sessionWithAction: Session = toSession(
+  {
+    chain: base,
+    owners: { type: 'ecdsa', accounts: [accountA] },
+    permissions: [
+      {
+        abi: erc20Abi,
+        address: '0x1111111111111111111111111111111111111111' as Address,
+        functions: {
+          transfer: {},
+        },
       },
-    },
-  ],
-})
+    ],
+  },
+  // WETH on Base — opts into the native-wrap injected action (v2: the
+  // wrapped-native address is supplied, not looked up from bundled config).
+  { wrappedNativeToken: '0x4200000000000000000000000000000000000006' },
+)
 
 const dummySig = `0x${'00'.repeat(65)}` as Hex
 const USDC: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -1098,7 +1098,7 @@ function resolveSessionData(
 
   // Native-token wrapping: permit `deposit()` on the chain's wrapped-native
   // token. Only injected when the wrapped-native address is known — supplied by
-  // `account.createSession` (resolved from `/chains`). Direct `toSession`
+  // `RhinestoneSDK.createSession` (resolved from `/chains`). Direct `toSession`
   // callers pass `wrappedNativeToken` to opt in.
   const nativeWrapActions: Action[] = wrappedNativeToken
     ? [

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -30,10 +30,7 @@ import {
   SCOPE_MULTICHAIN,
 } from '../../execution/compact'
 import { signTypedData } from '../../execution/utils'
-import {
-  getChainById,
-  getWrappedTokenAddress,
-} from '../../orchestrator/registry'
+import { getChainById } from '../../orchestrator/registry'
 import type {
   Action,
   ArgPolicyExpression,
@@ -773,13 +770,14 @@ async function getDisableSessionCall(
 
 function toSession<const TAbis extends readonly Abi[]>(
   definition: SessionDefinition<TAbis>,
-  options: { useDevContracts?: boolean } = {},
+  options: { useDevContracts?: boolean; wrappedNativeToken?: Address } = {},
 ): Session {
   const addresses = resolvePolicyAddresses(definition.policyAddresses)
   const sessionData = resolveSessionData(
     definition,
     options.useDevContracts,
     addresses,
+    options.wrappedNativeToken,
   )
   // Cross-chain permits add synthesized claim policies that must appear
   // on the returned `Session` too — `getSessionData(session)` re-encodes
@@ -1046,6 +1044,7 @@ function resolveSessionData(
   session: SessionDefinition,
   useDevContracts?: boolean,
   addresses: ResolvedPolicyAddresses = DEFAULT_POLICY_ADDRESSES,
+  wrappedNativeToken?: Address,
 ): SessionData {
   // ENS validation is HCA-only, and HCA accounts cannot install the smart
   // session validator, so an ENS session owner would silently resolve to the
@@ -1097,18 +1096,27 @@ function resolveSessionData(
     (e) => e.fallbackPolicies,
   )
 
+  // Native-token wrapping: permit `deposit()` on the chain's wrapped-native
+  // token. Only injected when the wrapped-native address is known — supplied by
+  // `account.createSession` (resolved from `/chains`). Direct `toSession`
+  // callers pass `wrappedNativeToken` to opt in.
+  const nativeWrapActions: Action[] = wrappedNativeToken
+    ? [
+        {
+          target: wrappedNativeToken,
+          selector: toFunctionSelector({
+            type: 'function',
+            name: 'deposit',
+            inputs: [],
+            outputs: [],
+            stateMutability: 'payable',
+          }),
+        },
+      ]
+    : []
+
   const injectedActions: Action[] = [
-    // Native token wrapping
-    {
-      target: getWrappedTokenAddress(session.chain),
-      selector: toFunctionSelector({
-        type: 'function',
-        name: 'deposit',
-        inputs: [],
-        outputs: [],
-        stateMutability: 'payable',
-      }),
-    },
+    ...nativeWrapActions,
     // Intent-execution fallback for any non-scoped call. Cross-chain
     // permits attach their synthesized SpendingLimits / TimeFrame
     // guardrails to this same fallback so the on-chain emissary applies

--- a/src/no-bundled-chain-data.test.ts
+++ b/src/no-bundled-chain-data.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+
+// Guard against re-introducing a build-time dependency on
+// `@rhinestone/shared-configs`. In v2 the SDK reads chain data at runtime from
+// the orchestrator's `/chains` (the chain catalog); the only chain constants
+// that remain inlined are the signed arbiter allow-set and the tiny CAIP-2
+// non-EVM table. A stray import here would put the SDK back in the position
+// where adding a chain requires an SDK release.
+const sources = import.meta.glob('./**/*.ts', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+describe('no bundled chain-data dependency', () => {
+  test('no source file imports @rhinestone/shared-configs', () => {
+    const offenders = Object.entries(sources)
+      .filter(([path]) => !path.endsWith('.test.ts'))
+      .filter(([, src]) =>
+        /\bfrom\s+['"]@rhinestone\/shared-configs['"]/.test(src),
+      )
+      .map(([path]) => path)
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/no-bundled-chain-data.test.ts
+++ b/src/no-bundled-chain-data.test.ts
@@ -4,18 +4,27 @@ import { describe, expect, test } from 'vitest'
 // `@rhinestone/shared-configs`. In v2 the SDK reads chain data at runtime from
 // the orchestrator's `/chains` (the chain catalog); the only chain constants
 // that remain inlined are the signed arbiter allow-set and the tiny CAIP-2
-// non-EVM table. A stray import here would put the SDK back in the position
-// where adding a chain requires an SDK release.
-const sources = import.meta.glob('./**/*.ts', {
-  query: '?raw',
-  import: 'default',
-  eager: true,
-}) as Record<string, string>
+// non-EVM table. A stray import — in `src` OR the integration suite — would put
+// the SDK back where adding a chain needs a release, and (since the dependency
+// is gone from the workspace) would break module resolution.
+const sources: Record<string, string> = {
+  ...import.meta.glob('./**/*.ts', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }),
+  ...import.meta.glob('../test/**/*.ts', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }),
+}
 
 describe('no bundled chain-data dependency', () => {
-  test('no source file imports @rhinestone/shared-configs', () => {
+  test('nothing in src/ or test/ imports @rhinestone/shared-configs', () => {
     const offenders = Object.entries(sources)
-      .filter(([path]) => !path.endsWith('.test.ts'))
+      // Exclude this guard file itself (it names the package in the matcher).
+      .filter(([path]) => !path.endsWith('no-bundled-chain-data.test.ts'))
       .filter(([, src]) =>
         /\bfrom\s+['"]@rhinestone\/shared-configs['"]/.test(src),
       )

--- a/src/orchestrator/caip2.ts
+++ b/src/orchestrator/caip2.ts
@@ -1,17 +1,13 @@
-// CAIP-2 wire format. The namespace ↔ numeric-id mapping is owned by
-// `@rhinestone/shared-configs` (the same source the orchestrator uses), so the
-// SDK and orchestrator can't drift on the wire shape — adding a chain is a
-// shared-configs registry entry, not a hand-maintained table in each repo.
-// HyperCore is a first-class `virtual` registry entry there: its canonical id
-// is `hypercore:mainnet` (EVM-settled, so `isNonEvmChainId(1337) === false`).
+// CAIP-2 wire format. EVM chains map programmatically (`eip155:<id>`); the
+// handful of non-EVM / virtual chains carry an explicit id ↔ caip2 mapping.
+//
+// v2: this small table is bundled here rather than read from
+// `@rhinestone/shared-configs`. EVM is the common case and needs no table, so a
+// new EVM chain needs no SDK change; a new non-EVM chain is rare and adds one
+// entry below. HyperCore is EVM-settled (id 1337) so `isNonEvmChainId` is
+// `false` for it even though its wire id is the non-`eip155` `hypercore:mainnet`.
 //
 // Spec: https://chainagnostic.org/CAIPs/caip-2
-
-import {
-  chainIdFromCaip2,
-  getCaip2,
-  isNonEvmChainId as isNonEvmChainIdFromRegistry,
-} from '@rhinestone/shared-configs'
 
 type EvmCaip2ChainId = `eip155:${number}`
 type SolanaCaip2ChainId = `solana:${string}`
@@ -23,32 +19,47 @@ type Caip2ChainId =
   | TronCaip2ChainId
   | HyperCoreCaip2ChainId
 
+// Non-`eip155` chains. `nonEvm` distinguishes genuinely non-EVM VMs
+// (Solana/Tron) from EVM-settled virtual chains (HyperCore) — see
+// `isNonEvmChainId`.
+const NON_EVM_CHAINS = [
+  { id: 1337, caip2: 'hypercore:mainnet', nonEvm: false },
+  { id: 728126428, caip2: 'tron:mainnet', nonEvm: true },
+  {
+    id: 792703809,
+    caip2: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    nonEvm: true,
+  },
+] as const satisfies ReadonlyArray<{
+  id: number
+  caip2: Caip2ChainId
+  nonEvm: boolean
+}>
+
 const EIP155_CAIP2_REGEX = /^eip155:\d+$/
 
 function toCaip2(chainId: number): Caip2ChainId {
   if (!Number.isInteger(chainId) || chainId < 0) {
     throw new Error(`Invalid chain id: ${chainId}`)
   }
-  // `getCaip2` returns the registry-declared caip2 (Solana/Tron/HyperCore) or
-  // the `eip155:<id>` fallback for plain EVM chains.
-  return getCaip2(chainId) as Caip2ChainId
+  const nonEvm = NON_EVM_CHAINS.find((c) => c.id === chainId)
+  return nonEvm ? nonEvm.caip2 : `eip155:${chainId}`
 }
 
 function fromCaip2(chainId: string): number {
-  // eip155 references aren't registry-backed (they compose programmatically),
-  // so parse them numerically here. This also keeps accepting the legacy
-  // `eip155:1337` HyperCore id for back-compat.
+  // eip155 references compose programmatically. This also keeps accepting the
+  // legacy `eip155:1337` HyperCore id for back-compat.
   if (EIP155_CAIP2_REGEX.test(chainId)) {
     return Number(chainId.slice('eip155:'.length))
   }
-  const id = chainIdFromCaip2(chainId)
-  if (id !== undefined) return id
+  const entry = NON_EVM_CHAINS.find((c) => c.caip2 === chainId)
+  if (entry) return entry.id
   throw new Error(`Invalid CAIP-2 chain id: ${chainId}`)
 }
 
 function isCaip2(chainId: string): chainId is Caip2ChainId {
   if (EIP155_CAIP2_REGEX.test(chainId)) return true
-  return chainIdFromCaip2(chainId) !== undefined
+  return NON_EVM_CHAINS.some((c) => c.caip2 === chainId)
 }
 
 function isEvmCaip2(chainId: string): chainId is EvmCaip2ChainId {
@@ -58,12 +69,10 @@ function isEvmCaip2(chainId: string): chainId is EvmCaip2ChainId {
 /**
  * True when a numeric chain id is genuinely non-EVM (Solana / Tron). HyperCore
  * (1337) is EVM-settled, so this is `false` for it even though its wire id is
- * the non-eip155 `hypercore:mainnet` namespace — `registry.ts` /
- * `execution/utils.ts` rely on HyperCore being EVM-classified here. Sourced
- * from the shared-configs registry `vmType`.
+ * the non-`eip155` `hypercore:mainnet` namespace.
  */
 function isNonEvmChainId(chainId: number): boolean {
-  return isNonEvmChainIdFromRegistry(chainId)
+  return NON_EVM_CHAINS.some((c) => c.id === chainId && c.nonEvm)
 }
 
 export type {

--- a/src/orchestrator/chain-catalog.ts
+++ b/src/orchestrator/chain-catalog.ts
@@ -22,9 +22,9 @@ export type ChainInfo = {
   // `'all'` for swap-quoter chains — the orchestrator supports any token there,
   // so no explicit list is returned.
   supportedTokens: 'all' | CatalogToken[]
-  // Optional during the rollout window: orchestrator deployments predating
-  // rhinestonewtf/orchestrator#1758 don't return it yet. Consumers that need it
-  // must handle `undefined` (or wait for the deploy to propagate).
+  // Kept optional so consumers stay robust if the orchestrator ever omits it
+  // (e.g. a rollback). The wire type (`WireChainsResponse`) marks it required,
+  // so field drift is caught at the client adapter — not silently here.
   wrappedNativeToken?: CatalogToken
 }
 

--- a/src/orchestrator/chain-catalog.ts
+++ b/src/orchestrator/chain-catalog.ts
@@ -49,6 +49,16 @@ export class ChainCatalog {
     return this.chains[chainId]
   }
 
+  /**
+   * Whether the chain is a testnet, per the orchestrator's `/chains`. Uses the
+   * catalog's own flag so it is authoritative for every supported chain
+   * (including non-EVM and chains newer than the SDK's viem), rather than
+   * viem's local chain list.
+   */
+  isTestnet(chainId: number): boolean {
+    return this.chains[chainId]?.testnet ?? false
+  }
+
   /** The wrapped-native (e.g. WETH) token for the chain, if the orchestrator advertises it. */
   getWrappedNativeToken(chainId: number): CatalogToken | undefined {
     return this.chains[chainId]?.wrappedNativeToken

--- a/src/orchestrator/chain-catalog.ts
+++ b/src/orchestrator/chain-catalog.ts
@@ -1,0 +1,60 @@
+// Runtime chain catalog, sourced from the orchestrator's `GET /chains`.
+//
+// This replaces the SDK's bundled `@rhinestone/shared-configs` chain data: the
+// orchestrator is authoritative for chain *facts* (which chains are supported,
+// their tokens, and the wrapped-native token), so the SDK reads them at runtime
+// instead of baking them in at build time. That's what lets a new chain go live
+// without an SDK release.
+//
+// `Chain` objects themselves (rpc/nativeCurrency/formatters, needed for signing
+// and `createPublicClient`) still come from viem — `/chains` can't carry those.
+// The catalog only owns the chain *facts*.
+
+export type CatalogToken = {
+  symbol: string
+  address: string
+  decimals: number
+}
+
+export type ChainInfo = {
+  name: string
+  testnet: boolean
+  // `'all'` for swap-quoter chains — the orchestrator supports any token there,
+  // so no explicit list is returned.
+  supportedTokens: 'all' | CatalogToken[]
+  // Optional during the rollout window: orchestrator deployments predating
+  // rhinestonewtf/orchestrator#1758 don't return it yet. Consumers that need it
+  // must handle `undefined` (or wait for the deploy to propagate).
+  wrappedNativeToken?: CatalogToken
+}
+
+export type ChainInfoMap = Record<number, ChainInfo>
+
+/**
+ * Read-only view over the chain facts returned by `GET /chains`. Built once
+ * (prefetched at account construction) and read synchronously thereafter.
+ */
+export class ChainCatalog {
+  constructor(private readonly chains: ChainInfoMap) {}
+
+  getSupportedChainIds(): number[] {
+    return Object.keys(this.chains).map(Number)
+  }
+
+  isSupported(chainId: number): boolean {
+    return chainId in this.chains
+  }
+
+  getChainInfo(chainId: number): ChainInfo | undefined {
+    return this.chains[chainId]
+  }
+
+  /** The wrapped-native (e.g. WETH) token for the chain, if the orchestrator advertises it. */
+  getWrappedNativeToken(chainId: number): CatalogToken | undefined {
+    return this.chains[chainId]?.wrappedNativeToken
+  }
+
+  getSupportedTokens(chainId: number): 'all' | CatalogToken[] | undefined {
+    return this.chains[chainId]?.supportedTokens
+  }
+}

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -1,6 +1,11 @@
 import type { Address } from 'viem'
 import type { AuthProvider } from '../auth/provider'
 import { fromCaip2, isCaip2, toCaip2 } from './caip2'
+import {
+  ChainCatalog,
+  type ChainInfo,
+  type ChainInfoMap,
+} from './chain-catalog'
 import { API_VERSION, SDK_VERSION } from './consts'
 import {
   type ErrorEnvelope,
@@ -58,6 +63,9 @@ export class Orchestrator {
   private serverUrl: string
   private authProvider: AuthProvider
   private extraHeaders?: Record<string, string>
+  // Memoized so the chain catalog is fetched at most once per client, lazily on
+  // first use — never at account construction.
+  private chainCatalogPromise?: Promise<ChainCatalog>
 
   constructor(
     serverUrl: string,
@@ -106,6 +114,41 @@ export class Orchestrator {
         amount: BigInt(c.amount),
       })),
     }))
+  }
+
+  /**
+   * Fetch the supported chains and their facts (tokens, wrapped-native token)
+   * from the orchestrator's public `/chains` endpoint. Returns a map keyed by
+   * numeric chain id (CAIP-2 keys on the wire are decoded).
+   */
+  async getChains(): Promise<ChainInfoMap> {
+    const json = (await this.fetch(`${this.serverUrl}/chains`, {
+      headers: await this.getHeaders(),
+    })) as Record<string, ChainInfo>
+    const out: ChainInfoMap = {}
+    for (const [key, info] of Object.entries(json)) {
+      let id: number
+      try {
+        id = isCaip2(key) ? fromCaip2(key) : Number(key)
+      } catch {
+        // Skip chains whose CAIP-2 id we can't map to a numeric id.
+        continue
+      }
+      if (Number.isFinite(id)) out[id] = info
+    }
+    return out
+  }
+
+  /**
+   * Lazily fetch (once) the runtime chain catalog from `/chains`. Cached for the
+   * lifetime of this client; callers that need chain facts await this instead of
+   * relying on bundled chain data.
+   */
+  getChainCatalog(): Promise<ChainCatalog> {
+    this.chainCatalogPromise ??= this.getChains().then(
+      (chains) => new ChainCatalog(chains),
+    )
+    return this.chainCatalogPromise
   }
 
   async getAppFeeBalances(): Promise<AppFeeBalances> {

--- a/src/orchestrator/client.ts
+++ b/src/orchestrator/client.ts
@@ -1,11 +1,7 @@
 import type { Address } from 'viem'
 import type { AuthProvider } from '../auth/provider'
 import { fromCaip2, isCaip2, toCaip2 } from './caip2'
-import {
-  ChainCatalog,
-  type ChainInfo,
-  type ChainInfoMap,
-} from './chain-catalog'
+import { ChainCatalog, type ChainInfoMap } from './chain-catalog'
 import { API_VERSION, SDK_VERSION } from './consts'
 import {
   type ErrorEnvelope,
@@ -38,6 +34,7 @@ import { convertBigIntFields } from './utils'
 import type {
   WireAppFeeBalancesResponse,
   WireBridgeFill,
+  WireChainsResponse,
   WireCost,
   WireCostInputEntry,
   WireCostOutputEntry,
@@ -124,9 +121,9 @@ export class Orchestrator {
   async getChains(): Promise<ChainInfoMap> {
     const json = (await this.fetch(`${this.serverUrl}/chains`, {
       headers: await this.getHeaders(),
-    })) as Record<string, ChainInfo>
+    })) as WireChainsResponse
     const out: ChainInfoMap = {}
-    for (const [key, info] of Object.entries(json)) {
+    for (const [key, entry] of Object.entries(json)) {
       let id: number
       try {
         id = isCaip2(key) ? fromCaip2(key) : Number(key)
@@ -134,7 +131,16 @@ export class Orchestrator {
         // Skip chains whose CAIP-2 id we can't map to a numeric id.
         continue
       }
-      if (Number.isFinite(id)) out[id] = info
+      if (!Number.isFinite(id)) continue
+      // Adapter boundary: map the generated wire shape → the domain `ChainInfo`.
+      // If the orchestrator renames or drops a field, `wire.gen.ts` regenerates
+      // and this mapping fails to typecheck instead of drifting silently.
+      out[id] = {
+        name: entry.name,
+        testnet: entry.testnet,
+        supportedTokens: entry.supportedTokens,
+        wrappedNativeToken: entry.wrappedNativeToken,
+      }
     }
     return out
   }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -43,11 +43,6 @@ import {
   UnsupportedTokenError,
   ValidationError,
 } from './error'
-import {
-  getTokenSymbol,
-  getWethAddress,
-  isTokenAddressSupported,
-} from './registry'
 import type {
   AppFeeBalances,
   AppFeeRate,
@@ -182,8 +177,6 @@ export {
   UnsupportedTokenError,
   ValidationError,
   getOrchestrator,
-  getWethAddress,
-  getTokenSymbol,
   isOrchestratorError,
   isRetryable,
   isConnectionError,
@@ -194,5 +187,4 @@ export {
   isSponsorLimitExceeded,
   isInsufficientSponsorBalance,
   isSponsorError,
-  isTokenAddressSupported,
 }

--- a/src/orchestrator/registry.test.ts
+++ b/src/orchestrator/registry.test.ts
@@ -18,10 +18,11 @@ describe('Registry', () => {
       expect(chain.name).toBe(arbitrum.name)
     })
 
-    test('throws error for unknown chain', () => {
-      expect(() => getChainById(UNSUPPORTED_CHAIN_ID)).toThrow(
-        `Unsupported chain ${UNSUPPORTED_CHAIN_ID}`,
-      )
+    test('falls back to a minimal chain for ids viem does not know', () => {
+      // Must not gate signing on the SDK's viem version: any orchestrator-
+      // supported id must resolve to a `Chain` carrying that id.
+      const chain = getChainById(UNSUPPORTED_CHAIN_ID)
+      expect(chain.id).toBe(UNSUPPORTED_CHAIN_ID)
     })
   })
 
@@ -34,10 +35,8 @@ describe('Registry', () => {
       expect(isTestnet(sepolia.id)).toBe(true)
     })
 
-    test('throws error for unknown chain', () => {
-      expect(() => isTestnet(UNSUPPORTED_CHAIN_ID)).toThrow(
-        `Unsupported chain ${UNSUPPORTED_CHAIN_ID}`,
-      )
+    test('returns false for an unknown chain (minimal fallback has no testnet flag)', () => {
+      expect(isTestnet(UNSUPPORTED_CHAIN_ID)).toBe(false)
     })
   })
 

--- a/src/orchestrator/registry.test.ts
+++ b/src/orchestrator/registry.test.ts
@@ -1,104 +1,16 @@
-import { type Chain, zeroAddress } from 'viem'
-import { arbitrum, base, baseSepolia, sepolia } from 'viem/chains'
+import type { Address } from 'viem'
+import { arbitrum, baseSepolia, sepolia } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
-import {
-  getChainById,
-  getDefaultAccountAccessList,
-  getSupportedChainIds,
-  getTokenAddress,
-  getTokenSymbol,
-  getWethAddress,
-  isTestnet,
-  isTokenAddressSupported,
-  resolveTokenAddress,
-} from './registry'
+import { getChainById, isTestnet, resolveTokenAddress } from './registry'
 
-const DEPRECATED_CHAIN_ID = 5 // Goerli
-const UNSUPPORTED_CHAIN_ID = 81457 // Blast
+// A chain id absent from both viem and the Rhinestone-supported set. (v2
+// resolves `Chain` objects via viem, so a real-but-unsupported chain like Blast
+// would now resolve — this must be a genuinely unknown id to still exercise throws.)
+const UNSUPPORTED_CHAIN_ID = 424242
 
-const TOKEN_SYMBOLS = {
-  ETH: 'ETH',
-  USDC: 'USDC',
-  USDT: 'USDT',
-  WETH: 'WETH',
-} as const
-
-const TOKEN_ADDRESSES = {
-  ARBTRUM_USDC: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-  BASE_WETH: '0x4200000000000000000000000000000000000006',
-} as const
-
-const UNSUPPORTED_TOKEN_ADDRESS = '0x1234567890123456789012345678901234567890'
+const ARBITRUM_USDC = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Address
 
 describe('Registry', () => {
-  describe('getSupportedChainIds', () => {
-    test('returns supported chain IDs', () => {
-      const chainIds = getSupportedChainIds()
-      expect(chainIds).toContain(arbitrum.id)
-      expect(chainIds).toContain(base.id)
-      expect(chainIds).toContain(sepolia.id)
-    })
-
-    test('does not include unsupported chains', () => {
-      const chainIds = getSupportedChainIds()
-      expect(chainIds).not.toContain(DEPRECATED_CHAIN_ID)
-      expect(chainIds).not.toContain(UNSUPPORTED_CHAIN_ID)
-    })
-  })
-
-  describe('getTokenSymbol', () => {
-    test('returns correct symbol for supported token', () => {
-      const symbol = getTokenSymbol(TOKEN_ADDRESSES.ARBTRUM_USDC, arbitrum.id)
-      expect(symbol).toBe(TOKEN_SYMBOLS.USDC)
-    })
-
-    test('throws error for unsupported chain', () => {
-      expect(() =>
-        getTokenSymbol(TOKEN_ADDRESSES.ARBTRUM_USDC, UNSUPPORTED_CHAIN_ID),
-      ).toThrow(`Unsupported chain ${UNSUPPORTED_CHAIN_ID}`)
-    })
-
-    test('returns undefined for unsupported token on supported chain', () => {
-      const symbol = getTokenSymbol(UNSUPPORTED_TOKEN_ADDRESS, arbitrum.id)
-      expect(symbol).toBeUndefined()
-    })
-  })
-
-  describe('getTokenAddress', () => {
-    test('returns zero address for ETH', () => {
-      const address = getTokenAddress(TOKEN_SYMBOLS.ETH, arbitrum.id)
-      expect(address).toBe(zeroAddress)
-    })
-
-    test('returns correct address for token symbol', () => {
-      const address = getTokenAddress(TOKEN_SYMBOLS.USDC, arbitrum.id)
-      expect(address).toBe(TOKEN_ADDRESSES.ARBTRUM_USDC)
-    })
-
-    test('throws error for unsupported chain', () => {
-      expect(() =>
-        getTokenAddress(TOKEN_SYMBOLS.USDC, UNSUPPORTED_CHAIN_ID),
-      ).toThrow(`Unsupported chain ${UNSUPPORTED_CHAIN_ID}`)
-    })
-  })
-
-  describe('getWethAddress', () => {
-    test('returns correct WETH address', () => {
-      const address = getWethAddress(base)
-      expect(address).toBe(TOKEN_ADDRESSES.BASE_WETH)
-    })
-
-    test('throws error for unsupported chain', () => {
-      const unsupportedChain = {
-        id: UNSUPPORTED_CHAIN_ID,
-        name: 'Unsupported',
-      } as Chain
-      expect(() => getWethAddress(unsupportedChain)).toThrow(
-        `Unsupported chain ${UNSUPPORTED_CHAIN_ID}`,
-      )
-    })
-  })
-
   describe('getChainById', () => {
     test('returns correct chain for supported ID', () => {
       const chain = getChainById(arbitrum.id)
@@ -106,7 +18,7 @@ describe('Registry', () => {
       expect(chain.name).toBe(arbitrum.name)
     })
 
-    test('throws error for unsupported chain', () => {
+    test('throws error for unknown chain', () => {
       expect(() => getChainById(UNSUPPORTED_CHAIN_ID)).toThrow(
         `Unsupported chain ${UNSUPPORTED_CHAIN_ID}`,
       )
@@ -122,61 +34,23 @@ describe('Registry', () => {
       expect(isTestnet(sepolia.id)).toBe(true)
     })
 
-    test('throws error for unsupported chain', () => {
+    test('throws error for unknown chain', () => {
       expect(() => isTestnet(UNSUPPORTED_CHAIN_ID)).toThrow(
         `Unsupported chain ${UNSUPPORTED_CHAIN_ID}`,
       )
     })
   })
 
-  describe('isTokenAddressSupported', () => {
-    test('returns true for supported token', () => {
-      const isSupported = isTokenAddressSupported(
-        TOKEN_ADDRESSES.ARBTRUM_USDC,
-        arbitrum.id,
-      )
-      expect(isSupported).toBe(true)
-    })
-
-    test('returns false for unsupported token or chain', () => {
-      expect(
-        isTokenAddressSupported(UNSUPPORTED_TOKEN_ADDRESS, arbitrum.id),
-      ).toBe(false)
-      expect(
-        isTokenAddressSupported(
-          TOKEN_ADDRESSES.ARBTRUM_USDC,
-          UNSUPPORTED_CHAIN_ID,
-        ),
-      ).toBe(false)
-    })
-  })
-
-  describe('getDefaultAccountAccessList', () => {
-    test('filters chains by testnet status', () => {
-      const arbitrumList = getDefaultAccountAccessList(false)
-      const testnetList = getDefaultAccountAccessList(true)
-
-      expect(arbitrumList.chainIds).toContain(arbitrum.id)
-      expect(arbitrumList.chainIds).not.toContain(sepolia.id)
-
-      expect(testnetList.chainIds).toContain(sepolia.id)
-      expect(testnetList.chainIds).not.toContain(arbitrum.id)
-    })
-  })
-
   describe('resolveTokenAddress', () => {
-    test('returns address as-is when given valid address', () => {
-      const address = TOKEN_ADDRESSES.ARBTRUM_USDC
-      const result = resolveTokenAddress(address, arbitrum.id)
-      expect(result).toBe(address)
-      // Note: UNSUPPORTED_CHAIN_ID is still exercised by the per-getter
-      // "unsupported chain" tests above; the symbol-resolution cases that used
-      // it here were removed with v2's address-only contract.
+    test('returns the address as-is when given a valid address', () => {
+      expect(resolveTokenAddress(ARBITRUM_USDC, arbitrum.id)).toBe(
+        ARBITRUM_USDC,
+      )
     })
 
     test('throws for a non-address on an EVM chain (symbols no longer accepted)', () => {
       expect(() =>
-        resolveTokenAddress(TOKEN_SYMBOLS.USDC, baseSepolia.id),
+        resolveTokenAddress('USDC' as Address, baseSepolia.id),
       ).toThrow(`Expected a token address on EVM chain ${baseSepolia.id}`)
     })
   })

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -1,8 +1,7 @@
-import { type Address, type Chain, isAddress } from 'viem'
+import { type Address, type Chain, defineChain, isAddress } from 'viem'
 import * as viemChains from 'viem/chains'
 import { isNonEvmChainId } from './caip2'
 import type { NonEvmAddress } from './destinations'
-import { UnsupportedChainError } from './error'
 
 // Chain objects (rpc / nativeCurrency / formatters, needed for signing and
 // `createPublicClient`) come from viem — not from bundled chain config. The
@@ -13,11 +12,19 @@ const allViemChains = (Object.values(viemChains) as unknown as Chain[]).filter(
 )
 
 function getChainById(chainId: number): Chain {
-  const chain = allViemChains.find((c) => c.id === chainId)
-  if (!chain) {
-    throw new UnsupportedChainError(chainId)
-  }
-  return chain
+  const known = allViemChains.find((c) => c.id === chainId)
+  if (known) return known
+  // The SDK must not gate signing/execution on its bundled viem version: a chain
+  // the orchestrator supports before viem knows it must still resolve. Fall back
+  // to a minimal chain carrying the id — the field EIP-712 signing needs. Richer
+  // metadata (formatters, default RPC) is only available for viem-known chains;
+  // RPC-needing paths already accept a caller-supplied transport.
+  return defineChain({
+    id: chainId,
+    name: `Chain ${chainId}`,
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    rpcUrls: { default: { http: [] } },
+  })
 }
 
 function isTestnet(chainId: number): boolean {

--- a/src/orchestrator/registry.ts
+++ b/src/orchestrator/registry.ts
@@ -1,83 +1,19 @@
-import {
-  type ChainEntry,
-  chainRegistry,
-  chains,
-} from '@rhinestone/shared-configs'
 import { type Address, type Chain, isAddress } from 'viem'
-import type { TokenSymbol } from '../types'
+import * as viemChains from 'viem/chains'
 import { isNonEvmChainId } from './caip2'
 import type { NonEvmAddress } from './destinations'
-import { UnsupportedChainError, UnsupportedTokenError } from './error'
+import { UnsupportedChainError } from './error'
 
-function getSupportedChainIds(): number[] {
-  return chains.map((chain) => chain.id)
-}
-
-function getChainEntry(chainId: number): ChainEntry | undefined {
-  return chainRegistry[chainId.toString()]
-}
-
-function getWethAddress(chain: Chain): Address {
-  const chainEntry = getChainEntry(chain.id)
-  if (!chainEntry) {
-    throw new UnsupportedChainError(chain.id)
-  }
-
-  const wethToken = chainEntry.tokens.find((token) => token.symbol === 'WETH')
-  if (!wethToken) {
-    throw new UnsupportedTokenError('WETH', chain.id)
-  }
-
-  return wethToken.address as Address
-}
-
-function getWrappedTokenAddress(chain: Chain): Address {
-  const chainEntry = getChainEntry(chain.id)
-  if (!chainEntry) {
-    throw new UnsupportedChainError(chain.id)
-  }
-
-  const token =
-    chainEntry.wrappedNativeToken ??
-    chainEntry.tokens.find((t) => t.symbol === 'WETH')
-  if (!token) {
-    throw new UnsupportedTokenError('WETH', chain.id)
-  }
-  return token.address as Address
-}
-
-function getTokenSymbol(
-  tokenAddress: Address,
-  chainId: number,
-): string | undefined {
-  const chainEntry = getChainEntry(chainId)
-  if (!chainEntry) {
-    throw new UnsupportedChainError(chainId)
-  }
-
-  const token = chainEntry.tokens.find(
-    (t) => t.address.toLowerCase() === tokenAddress.toLowerCase(),
-  )
-
-  return token?.symbol
-}
-
-function getTokenAddress(tokenSymbol: TokenSymbol, chainId: number): Address {
-  const chainEntry = getChainEntry(chainId)
-  if (!chainEntry) {
-    throw new UnsupportedChainError(chainId)
-  }
-
-  const token = chainEntry.tokens.find((t) => t.symbol === tokenSymbol)
-  if (!token) {
-    throw new UnsupportedTokenError(tokenSymbol, chainId)
-  }
-
-  return token.address as Address
-}
+// Chain objects (rpc / nativeCurrency / formatters, needed for signing and
+// `createPublicClient`) come from viem — not from bundled chain config. The
+// supported *set* is gated by the orchestrator; this resolves any known viem
+// chain by id.
+const allViemChains = (Object.values(viemChains) as unknown as Chain[]).filter(
+  (c) => typeof c?.id === 'number',
+)
 
 function getChainById(chainId: number): Chain {
-  const chain = chains.find((chain) => chain.id === chainId)
+  const chain = allViemChains.find((c) => c.id === chainId)
   if (!chain) {
     throw new UnsupportedChainError(chainId)
   }
@@ -87,32 +23,6 @@ function getChainById(chainId: number): Chain {
 function isTestnet(chainId: number): boolean {
   const chain = getChainById(chainId)
   return chain.testnet ?? false
-}
-
-function isTokenAddressSupported(address: Address, chainId: number): boolean {
-  const chainEntry = getChainEntry(chainId)
-  if (!chainEntry) {
-    return false
-  }
-
-  return chainEntry.tokens.some(
-    (token) => token.address.toLowerCase() === address.toLowerCase(),
-  )
-}
-
-function getDefaultAccountAccessList(onTestnets?: boolean) {
-  const supportedChainIds = getSupportedChainIds()
-  const filteredChainIds = supportedChainIds.filter((chainId) => {
-    try {
-      return isTestnet(chainId) === !!onTestnets
-    } catch {
-      return false
-    }
-  })
-
-  return {
-    chainIds: filteredChainIds,
-  }
 }
 
 function resolveTokenAddress(
@@ -138,15 +48,4 @@ function resolveTokenAddress(
   )
 }
 
-export {
-  getTokenSymbol,
-  getTokenAddress,
-  getWethAddress,
-  getWrappedTokenAddress,
-  getChainById,
-  getSupportedChainIds,
-  isTestnet,
-  isTokenAddressSupported,
-  getDefaultAccountAccessList,
-  resolveTokenAddress,
-}
+export { getChainById, isTestnet, resolveTokenAddress }

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -1,13 +1,21 @@
-import type {
-  SettlementLayer as CrossChainSettlementLayer,
-  SupportedChain,
-  SupportedMainnet,
-  SupportedOPStackMainnet,
-  SupportedOPStackTestnet,
-  SupportedTestnet,
-} from '@rhinestone/shared-configs'
 import type { Address, Chain, Hex, TypedDataDefinition } from 'viem'
 import type { NonEvmAddress } from './destinations'
+
+// Cross-chain settlement layers exposed for filtering. v2: defined locally (a
+// closed capability union) rather than read from shared-configs — adding a
+// layer is a real code change.
+type CrossChainSettlementLayer =
+  | 'ACROSS'
+  | 'ECO'
+  | 'RELAY'
+  | 'OFT'
+  | 'NEAR'
+  | 'RHINO'
+  | 'CCTP'
+
+// v2: chain ids are open (`number`), not a closed union — a new chain needs no
+// SDK release.
+type SupportedChain = number
 
 type SupportedTokenSymbol = 'ETH' | 'WETH' | 'USDC' | 'USDT' | 'USDT0'
 type SupportedToken = SupportedTokenSymbol | Address
@@ -366,19 +374,20 @@ export type TokenPrices = {
   [key in SupportedTokenSymbol]?: number
 }
 
-export type GasPrices = {
-  [key in SupportedMainnet | SupportedTestnet]?: bigint
-}
+export type GasPrices = Partial<Record<number, bigint>>
 
 export type OPNetworkParams =
-  | {
-      [key in SupportedOPStackMainnet | SupportedOPStackTestnet]?: {
-        l1BaseFee: bigint
-        l1BlobBaseFee: bigint
-        baseFeeScalar: bigint
-        blobFeeScalar: bigint
-      }
-    }
+  | Partial<
+      Record<
+        number,
+        {
+          l1BaseFee: bigint
+          l1BlobBaseFee: bigint
+          baseFeeScalar: bigint
+          blobFeeScalar: bigint
+        }
+      >
+    >
   | {
       estimatedCalldataSize: number
     }

--- a/src/orchestrator/wire.gen.ts
+++ b/src/orchestrator/wire.gen.ts
@@ -255,6 +255,13 @@ export interface operations {
                                 address: string;
                                 decimals: number;
                             }[];
+                            /** @description The wrapped-native token (e.g. WETH) for the chain. Lets clients resolve the wrapped-native address without bundling a token registry. */
+                            wrappedNativeToken: {
+                                symbol: string;
+                                /** @description Token contract address (format depends on the chain) */
+                                address: string;
+                                decimals: number;
+                            };
                         };
                     };
                 };
@@ -3166,9 +3173,9 @@ export interface operations {
                     /** @description Account access list specifying which chains and tokens an account may access */
                     accountAccessList?: {
                         chainIds?: number[];
-                        tokens?: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
+                        tokens?: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "AVAX" | "WAVAX" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
                         chainTokens?: {
-                            [key: string]: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
+                            [key: string]: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "AVAX" | "WAVAX" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
                         };
                         chainTokenAmounts?: {
                             [key: string]: {
@@ -3177,9 +3184,9 @@ export interface operations {
                         };
                         exclude?: {
                             chainIds?: number[];
-                            tokens?: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
+                            tokens?: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "AVAX" | "WAVAX" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
                             chainTokens?: {
-                                [key: string]: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
+                                [key: string]: (string | ("ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "AVAX" | "WAVAX" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL"))[];
                             };
                         };
                     };
@@ -3287,7 +3294,7 @@ export interface operations {
                          * @description Reserved for future use. No effect today.
                          * @enum {string}
                          */
-                        feeToken?: "ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL";
+                        feeToken?: "ETH" | "USDC" | "WETH" | "USDT" | "USDT0" | "BNB" | "WBNB" | "XDAI" | "WXDAI" | "POL" | "WPOL" | "MON" | "WMON" | "S" | "WS" | "HYPE" | "WHYPE" | "USDG" | "XPL" | "WXPL" | "AVAX" | "WAVAX" | "MockUSD" | "TRX" | "WTRX" | "SOL" | "WSOL";
                         appFees?: {
                             /**
                              * @description App fee rate in basis points of the input value (0–10000 = 0–100%).
@@ -3322,7 +3329,7 @@ export interface operations {
                          */
                         selectionStrategy?: "cheapest" | "fastest" | "best";
                         /**
-                         * @description Absolute unix timestamp (seconds) overriding the on-chain fill deadline. **TOKENLESS intents only** — ignored on every other route. Must be between `now + 120s` and `now + 86400s`. The bundle claim/nonce expiry and the response `expiresAt` track this value automatically.
+                         * @description Absolute unix timestamp (seconds) overriding the on-chain fill deadline. **TOKENLESS intents only.** If the intent resolves to any other route (cross-chain or same-chain), the request is **rejected** with `INVALID_CUSTOM_DEADLINE` (422) rather than silently ignoring the override. Must be between `now + 120s` and `now + 86400s`. The bundle claim/nonce expiry and the response `expiresAt` track this value automatically.
                          * @example 1893456000
                          */
                         customDeadline?: number;
@@ -3574,6 +3581,19 @@ export interface operations {
                                         };
                                         /** @description Aggregate integrator app fee */
                                         app: {
+                                            /**
+                                             * @description Total cost of this category in USD, regardless of who pays.
+                                             * @example 0.029
+                                             */
+                                            usd: number;
+                                            /**
+                                             * @description True when a sponsor absorbs some or all of this category. The user-vs-sponsor split is not surfaced.
+                                             * @example false
+                                             */
+                                            sponsored: boolean;
+                                        };
+                                        /** @description Rhinestone's surcharge on the sponsored fee, charged to the sponsor. 0 when the intent is not sponsored. */
+                                        sponsorSurcharge: {
                                             /**
                                              * @description Total cost of this category in USD, regardless of who pays.
                                              * @example 0.029

--- a/src/orchestrator/wire.ts
+++ b/src/orchestrator/wire.ts
@@ -43,3 +43,6 @@ export type WirePortfolioResponse = SuccessJson<'getPortfolio', 200>
 
 // GET /app-fees/balances
 export type WireAppFeeBalancesResponse = SuccessJson<'getAppFeeBalances', 200>
+
+// GET /chains
+export type WireChainsResponse = SuccessJson<'listChains', 200>

--- a/src/package.json
+++ b/src/package.json
@@ -75,7 +75,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@rhinestone/shared-configs": "1.7.15",
     "solady": "^0.1.26"
   },
   "peerDependencies": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,15 +86,12 @@ interface MultiFactorValidatorConfig {
   module?: Address
 }
 
-type ProviderConfig =
-  | {
-      type: 'alchemy'
-      apiKey: string
-    }
-  | {
-      type: 'custom'
-      urls: Record<number, string>
-    }
+// v2: the SDK no longer bundles provider slugs / builds Alchemy URLs. Callers
+// supply the RPC URL per chain (or omit `provider` to use viem's default).
+type ProviderConfig = {
+  type: 'custom'
+  urls: Record<number, string>
+}
 
 type BundlerConfig =
   | {
@@ -213,8 +210,8 @@ interface Permit2ClaimPolicy {
 
 /**
  * Settlement layers supported by the cross-chain session abstraction.
- * Each value maps to one or more Permit2 arbiter addresses sourced from
- * `@rhinestone/shared-configs` — devs pick a layer, the SDK resolves it
+ * Each value maps to one or more Permit2 arbiter addresses (a bundled,
+ * client-trusted allow-set) — devs pick a layer, the SDK resolves it
  * to the on-chain arbiter whitelist.
  *
  * The set is intentionally narrower than the orchestrator's broader
@@ -268,7 +265,7 @@ interface CrossChainPermit {
   /**
    * Settlement layers this session is permitted to use. Omit (or pass
    * `[]`) for any supported layer — the SDK resolves to the union of
-   * every known arbiter from `@rhinestone/shared-configs`.
+   * every known arbiter in its bundled allow-set.
    */
   settlementLayers?: CrossChainSettlementLayer[]
 }
@@ -324,9 +321,8 @@ interface CrossChainPermissionInput {
   /**
    * Settlement layers this session is permitted to use. Omit (or pass
    * `[]`) to allow **any of the supported settlement layers** — the SDK
-   * resolves to the union of every known arbiter from
-   * `@rhinestone/shared-configs`. Pass a subset (e.g. `['ECO']`) to
-   * narrow.
+   * resolves to the union of every known arbiter in its bundled
+   * allow-set. Pass a subset (e.g. `['ECO']`) to narrow.
    */
   settlementLayers?: CrossChainSettlementLayer[]
 }

--- a/test/integration/framework/fixtures.ts
+++ b/test/integration/framework/fixtures.ts
@@ -1,4 +1,3 @@
-import { chainRegistry } from '@rhinestone/shared-configs'
 import {
   type Address,
   encodeFunctionData,
@@ -11,7 +10,7 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import type { Chain } from 'viem/chains'
 import type { Session } from '../../../src/index'
 import { toSession } from '../../../src/modules/validators/smart-sessions'
-import { getTokenAddress } from '../../../src/orchestrator/registry'
+import { getTokenAddress } from './tokens'
 
 export const noopTarget: Address = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
@@ -51,13 +50,7 @@ export function createUsdcRequestWithoutFunds(chainId: number) {
 }
 
 export function createUnfundedUsdcTransferCall(chain: Chain) {
-  const usdcAddress = chainRegistry[chain.id.toString()].tokens.find(
-    (token) => token.symbol === 'USDC',
-  )?.address as Address | undefined
-
-  if (!usdcAddress) {
-    throw new Error(`USDC is not configured for chain ${chain.id}`)
-  }
+  const usdcAddress = getTokenAddress('USDC', chain.id)
 
   return {
     to: usdcAddress,

--- a/test/integration/framework/funding.ts
+++ b/test/integration/framework/funding.ts
@@ -11,8 +11,8 @@ import {
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import type { RhinestoneAccount } from '../../../src/index'
-import { getTokenAddress } from '../../../src/orchestrator/registry'
 import { getIntegrationFunderPrivateKey } from '../config/environment'
+import { getTokenAddress } from './tokens'
 
 // Optional per-chain RPC override, e.g. INTEGRATION_RPC_URL_84532=https://...
 // Falls back to the viem chain's default public RPC.

--- a/test/integration/framework/tokens.ts
+++ b/test/integration/framework/tokens.ts
@@ -1,0 +1,20 @@
+import type { Address } from 'viem'
+import { arbitrumSepolia, baseSepolia } from 'viem/chains'
+
+// Token addresses for the chains the integration suite runs against. Replaces
+// the SDK's removed `getTokenAddress` (v2 no longer bundles a token registry —
+// chain/token data is fetched from the orchestrator at runtime).
+const TOKENS: Record<string, Record<number, Address>> = {
+  USDC: {
+    [baseSepolia.id]: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    [arbitrumSepolia.id]: '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d',
+  },
+}
+
+export function getTokenAddress(symbol: 'USDC', chainId: number): Address {
+  const address = TOKENS[symbol]?.[chainId]
+  if (!address) {
+    throw new Error(`No ${symbol} address configured for chain ${chainId}`)
+  }
+  return address
+}

--- a/test/integration/scenarios/preclaim-ops.itest.ts
+++ b/test/integration/scenarios/preclaim-ops.itest.ts
@@ -9,7 +9,6 @@ import {
   DUMMY_PRECLAIMOP_SELECTOR,
   DUMMY_PRECLAIMOP_TARGET,
 } from '../../../src/modules/validators/smart-sessions'
-import { getTokenAddress } from '../../../src/orchestrator/registry'
 import { sourceChain, targetChain } from '../config/chains'
 import { createIntegrationSDK } from '../config/environment'
 import {
@@ -29,6 +28,7 @@ import {
   expectCompletedOperation,
   expectOutcome,
 } from '../framework/runner'
+import { getTokenAddress } from '../framework/tokens'
 
 type Execution = { to: string; value: bigint; data: string }
 

--- a/test/integration/scenarios/ssx-policies.itest.ts
+++ b/test/integration/scenarios/ssx-policies.itest.ts
@@ -3,7 +3,6 @@ import { describe, test } from 'vitest'
 import { SimulationFailedError } from '../../../src/errors/index'
 import type { RhinestoneAccount, Session } from '../../../src/index'
 import { toSession } from '../../../src/modules/validators/smart-sessions'
-import { getTokenAddress } from '../../../src/orchestrator/registry'
 import { sourceChain } from '../config/chains'
 import { createIntegrationSDK } from '../config/environment'
 import { createOwner } from '../framework/fixtures'
@@ -14,6 +13,7 @@ import {
   expectNoFailedOperations,
   expectOutcome,
 } from '../framework/runner'
+import { getTokenAddress } from '../framework/tokens'
 
 const ALICE: Address = '0x1111111111111111111111111111111111111111'
 const BOB: Address = '0x2222222222222222222222222222222222222222'


### PR DESCRIPTION
> ⛔ **DRAFT — DO NOT MERGE until `wrappedNativeToken` is live on prod `/chains`.**
> Gated on rhinestonewtf/orchestrator#1758 being **deployed to prod** (not just merged). Release trigger: `curl https://v1.orchestrator.rhinestone.dev/chains` contains `wrappedNativeToken`. Until then this would break wrapped-native resolution on prod.

## What

Replaces the SDK's bundled `@rhinestone/shared-configs` chain data with **runtime reads from the orchestrator's `GET /chains`** (a lazily-fetched, cached `ChainCatalog` on the Orchestrator client) + **viem** for `Chain` objects. **Adding a chain no longer requires an SDK release.**

## Design

- **Lazy, not eager** — `getChainCatalog()` fetches `/chains` once on first use, cached on the client. **Never at `createAccount`** (which stays offline).
- **viem for chain identity** — `getChainById`/`isTestnet` resolve any viem chain; the supported *set* is gated by the orchestrator.
- **Signed data stays bundled & client-trusted** — the Permit2 arbiter allow-set is a small inlined constant (never sourced from the orchestrator you transact against). The caip2 non-EVM table is likewise a tiny bundled constant.

## Breaking changes (major changeset included)

- `SupportedChain` → `number` (open chain-id type).
- New **`account.createSession(definition)`** (resolves wrapped-native from `/chains`); `toSession` is now pure — pass `wrappedNativeToken` to opt into native-wrap.
- Removed the **`alchemy`** provider type — supply `provider: { type: 'custom', urls }` or omit it.
- Removed token-registry helpers `getWethAddress` / `getTokenSymbol` / `isTokenAddressSupported`.

## Verification

- `tsc` clean · `biome` clean · **477 unit tests pass** · `build` clean
- **Zero** `@rhinestone/shared-configs` imports in src (+ a guard test that fails CI if one returns); dependency removed from `package.json`.
- Signed arbiter path verified: bundled allow-set generated from the pinned shared-configs, arbiter + permit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)