### PR TITLE
feat: add opt-in Nexus v1.2.1 account support

### DIFF
--- a/.changeset/nexus-1-2-1.md
+++ b/.changeset/nexus-1-2-1.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Add opt-in support for Nexus v1.2.1 via `account: { type: 'nexus', version: '1.2.1' }`. The previous Nexus stays the default.

--- a/src/accounts/nexus.test.ts
+++ b/src/accounts/nexus.test.ts
@@ -187,6 +187,31 @@ describe('Accounts: Nexus', () => {
 
       expect(address).toEqual('0x68484B775e4a2828A50C7404ce8530f146d5598e')
     })
+
+    test('Existing account (1.2.1 factory)', () => {
+      // A persisted 1.2.1 { factory, factoryData } must recompute the same
+      // counterfactual address as the direct config, i.e. against the 1.2.1
+      // implementation — not the 1.2.0 default.
+      const config = {
+        owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+        account: { type: 'nexus', version: '1.2.1' },
+      } as const
+      const direct = getAddress(config)
+      const deployArgs = getDeployArgs(config)
+      assertNotNull(deployArgs)
+
+      const fromInitData = getAddress({
+        owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+        initData: {
+          address: direct,
+          factory: deployArgs.factory,
+          factoryData: deployArgs.factoryData,
+        },
+      })
+
+      expect(fromInitData).toEqual(direct)
+      expect(fromInitData).toEqual('0x011ce90AB2e42C509E46bCF72ef12f9FbCa64e7e')
+    })
   })
 
   describe('Get Install Data', () => {

--- a/src/accounts/nexus.test.ts
+++ b/src/accounts/nexus.test.ts
@@ -99,6 +99,31 @@ describe('Accounts: Nexus', () => {
         '0x0d51f0b7000000000000000000000000db8fca317427c3f85b6734af6455f287011c54b50000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
       )
     })
+
+    test('ECDSA owners (1.2.1)', () => {
+      const previous = getDeployArgs({
+        owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+      })
+      const deployArgs = getDeployArgs({
+        owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+        account: { type: 'nexus', version: '1.2.1' },
+      })
+      assertNotNull(previous)
+      assertNotNull(deployArgs)
+
+      expect(deployArgs.factory).toEqual(
+        '0x0000000099d5576c73a3b190dabeeaa0f128ce6b',
+      )
+      expect(deployArgs.implementation).toEqual(
+        '0x000000000d41c0bf0063dba53343389cdb2c9c78',
+      )
+      // 1.2.1 only swaps the implementation + factory; the bootstrap and the
+      // calldata it drives are unchanged from 1.2.0.
+      expect(deployArgs.factoryData).toEqual(previous.factoryData)
+      expect(deployArgs.initializationCallData).toEqual(
+        previous.initializationCallData,
+      )
+    })
   })
 
   describe('Get Address', () => {
@@ -139,6 +164,28 @@ describe('Accounts: Nexus', () => {
       })
 
       expect(address).toEqual('0xBecba00993a919FfD35064a777E94643014A19Aa')
+    })
+
+    test('ECDSA owners (1.2.1)', () => {
+      const previous = getAddress({
+        owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+      })
+      const address = getAddress({
+        owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+        account: { type: 'nexus', version: '1.2.1' },
+      })
+
+      expect(address).toEqual('0x011ce90AB2e42C509E46bCF72ef12f9FbCa64e7e')
+      expect(address).not.toEqual(previous)
+    })
+
+    test('Passkey owner (1.2.1)', () => {
+      const address = getAddress({
+        owners: { type: 'passkey', accounts: [passkeyAccount] },
+        account: { type: 'nexus', version: '1.2.1' },
+      })
+
+      expect(address).toEqual('0x68484B775e4a2828A50C7404ce8530f146d5598e')
     })
   })
 

--- a/src/accounts/nexus.ts
+++ b/src/accounts/nexus.ts
@@ -44,6 +44,13 @@ const NEXUS_FACTORY_ADDRESS: Address =
 const NEXUS_BOOTSTRAP_ADDRESS: Address =
   '0x00000000006efb61d8c9546ff1b500de3f244ea7'
 
+// Nexus 1.2.1 ships a new implementation + factory; the bootstrap and the proxy
+// creation code are unchanged from 1.2.0. Opt in with `account.version = '1.2.1'`.
+const NEXUS_IMPLEMENTATION_1_2_1: Address =
+  '0x000000000d41c0bf0063dba53343389cdb2c9c78'
+const NEXUS_FACTORY_1_2_1: Address =
+  '0x0000000099d5576c73a3b190dabeeaa0f128ce6b'
+
 const NEXUS_IMPLEMENTATION_1_0_0: Address =
   '0x000000039dfcad030719b07296710f045f0558f7'
 const NEXUS_BOOTSTRAP_1_0_0: Address =
@@ -52,6 +59,34 @@ const NEXUS_K1_VALIDATOR: Address = '0x00000004171351c442b202678c48d8ab5b321e8f'
 
 const NEXUS_CREATION_CODE =
   '0x60806040526102aa803803806100148161018c565b92833981016040828203126101885781516001600160a01b03811692909190838303610188576020810151906001600160401b03821161018857019281601f8501121561018857835161006e610069826101c5565b61018c565b9481865260208601936020838301011161018857815f926020809301865e8601015260017f90b772c2cb8a51aa7a8a65fc23543c6d022d5b3f8e2b92eed79fba7eef8293005d823b15610176577f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc80546001600160a01b031916821790557fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f80a282511561015e575f8091610146945190845af43d15610156573d91610137610069846101c5565b9283523d5f602085013e6101e0565b505b604051606b908161023f8239f35b6060916101e0565b50505034156101485763b398979f60e01b5f5260045ffd5b634c9c8ce360e01b5f5260045260245ffd5b5f80fd5b6040519190601f01601f191682016001600160401b038111838210176101b157604052565b634e487b7160e01b5f52604160045260245ffd5b6001600160401b0381116101b157601f01601f191660200190565b9061020457508051156101f557805190602001fd5b63d6bda27560e01b5f5260045ffd5b81511580610235575b610215575090565b639996b31560e01b5f9081526001600160a01b0391909116600452602490fd5b50803b1561020d56fe60806040523615605c575f8073ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416368280378136915af43d5f803e156058573d5ff35b3d5ffd5b00fea164736f6c634300081b000a'
+
+// Resolves the implementation + factory a fresh account deploys against. All
+// versions except '1.2.1' deploy the previous (1.2.0) contracts.
+function getNexusDeployment(version: NexusAccount['version']): {
+  implementation: Address
+  factory: Address
+} {
+  if (version === '1.2.1') {
+    return {
+      implementation: NEXUS_IMPLEMENTATION_1_2_1,
+      factory: NEXUS_FACTORY_1_2_1,
+    }
+  }
+  return {
+    implementation: NEXUS_IMPLEMENTATION_ADDRESS,
+    factory: NEXUS_FACTORY_ADDRESS,
+  }
+}
+
+// Whether the factory is one of the current Nexus factories (1.2.0 / 1.2.1),
+// which share the same proxy creation code. Legacy (1.0.0) factories use a
+// different proxy and account init encoding.
+function isNexusV1Factory(factory: Address): boolean {
+  const normalized = factory.toLowerCase()
+  return (
+    normalized === NEXUS_FACTORY_ADDRESS || normalized === NEXUS_FACTORY_1_2_1
+  )
+}
 
 function getDeployArgs(config: RhinestoneAccountConfig) {
   if (config.initData) {
@@ -79,6 +114,9 @@ function getDeployArgs(config: RhinestoneAccountConfig) {
   const account = config.account
   const defaultSalt = keccak256('0x')
   const salt = (account as NexusAccount)?.salt ?? defaultSalt
+  const { implementation, factory } = getNexusDeployment(
+    (account as NexusAccount)?.version,
+  )
   const moduleSetup = getModuleSetup(config)
   // Filter out the default validator
   const defaultValidator = moduleSetup.validators.find(
@@ -163,10 +201,10 @@ function getDeployArgs(config: RhinestoneAccountConfig) {
   })
 
   return {
-    factory: NEXUS_FACTORY_ADDRESS,
+    factory,
     factoryData,
     salt,
-    implementation: NEXUS_IMPLEMENTATION_ADDRESS,
+    implementation,
     initializationCallData,
     initData,
   }
@@ -182,27 +220,25 @@ function getAddress(config: RhinestoneAccountConfig) {
   }
   const { factory, salt, initializationCallData, implementation } = deployArgs
 
-  const creationCode =
-    factory.toLowerCase() === NEXUS_FACTORY_ADDRESS
-      ? NEXUS_CREATION_CODE
-      : '0x603d3d8160223d3973000000039dfcad030719b07296710f045f0558f760095155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3'
+  const creationCode = isNexusV1Factory(factory)
+    ? NEXUS_CREATION_CODE
+    : '0x603d3d8160223d3973000000039dfcad030719b07296710f045f0558f760095155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3'
 
-  const accountInitData =
-    factory.toLowerCase() === NEXUS_FACTORY_ADDRESS
-      ? encodeAbiParameters(
-          [
-            {
-              name: 'address',
-              type: 'address',
-            },
-            {
-              name: 'calldata',
-              type: 'bytes',
-            },
-          ],
-          [implementation, initializationCallData],
-        )
-      : '0x'
+  const accountInitData = isNexusV1Factory(factory)
+    ? encodeAbiParameters(
+        [
+          {
+            name: 'address',
+            type: 'address',
+          },
+          {
+            name: 'calldata',
+            type: 'bytes',
+          },
+        ],
+        [implementation, initializationCallData],
+      )
+    : '0x'
   const address = getContractAddress({
     opcode: 'CREATE2',
     from: factory,
@@ -294,14 +330,7 @@ function isDefaultValidatorConfigured(
   return defaultValidator ? size(defaultValidator.initData) > 0 : false
 }
 
-function getDefaultValidatorAddress(
-  version:
-    | '1.0.2'
-    | '1.2.0'
-    | 'rhinestone-1.0.0-beta'
-    | 'rhinestone-1.0.0'
-    | undefined,
-): Address {
+function getDefaultValidatorAddress(version: NexusAccount['version']): Address {
   if (!version) {
     return NEXUS_DEFAULT_VALIDATOR_ADDRESS
   }
@@ -310,6 +339,8 @@ function getDefaultValidatorAddress(
       return '0x0000002d6db27c52e3c11c1cf24072004ac75cba'
     case '1.2.0':
       return '0x00000000d12897ddadc2044614a9677b191a2d95'
+    case '1.2.1':
+      return NEXUS_DEFAULT_VALIDATOR_ADDRESS
     case 'rhinestone-1.0.0-beta':
       return '0x0000000000e9e6e96bcaa3c113187cdb7e38aed9'
     case 'rhinestone-1.0.0':
@@ -467,7 +498,7 @@ async function signEip7702InitData(
   if (!deployArgs) {
     throw new Error('Cannot sign EIP-7702 init data: deploy args not available')
   }
-  const { initData } = deployArgs
+  const { initData, implementation } = deployArgs
   if (!eoa.signTypedData) {
     throw new SigningNotSupportedForAccountError()
   }
@@ -485,7 +516,7 @@ async function signEip7702InitData(
     },
     primaryType: 'Initialize',
     message: {
-      nexus: NEXUS_IMPLEMENTATION_ADDRESS,
+      nexus: implementation,
       chainIds: [0n],
       initData,
     },
@@ -509,7 +540,7 @@ function getEip7702InitCall(config: RhinestoneAccountConfig, signature: Hex) {
   if (!deployArgs) {
     throw new Error('Cannot get EIP-7702 init call: deploy args not available')
   }
-  const { initData } = deployArgs
+  const { initData, implementation } = deployArgs
   const encodedData = getEncodedData(initData)
   const accountFullData = concat([signature, encodedData])
   const accountInitCallData = encodeFunctionData({
@@ -533,7 +564,7 @@ function getEip7702InitCall(config: RhinestoneAccountConfig, signature: Hex) {
 
   return {
     initData: accountInitCallData,
-    contract: NEXUS_IMPLEMENTATION_ADDRESS,
+    contract: implementation,
   }
 }
 

--- a/src/accounts/nexus.ts
+++ b/src/accounts/nexus.ts
@@ -88,6 +88,15 @@ function isNexusV1Factory(factory: Address): boolean {
   )
 }
 
+// Maps a current Nexus factory to the implementation it deploys, so a persisted
+// v1.2.1 `initData` payload recomputes against the right implementation (and the
+// 7702 init helpers sign/return it) rather than defaulting to 1.2.0.
+function implementationForFactory(factory: Address): Address {
+  return factory.toLowerCase() === NEXUS_FACTORY_1_2_1
+    ? NEXUS_IMPLEMENTATION_1_2_1
+    : NEXUS_IMPLEMENTATION_ADDRESS
+}
+
 function getDeployArgs(config: RhinestoneAccountConfig) {
   if (config.initData) {
     if (!('factory' in config.initData)) {
@@ -585,7 +594,7 @@ function tryDecodeV1FactoryData(factory: Address, factoryData: Hex) {
       salt,
       factory,
       factoryData,
-      implementation: NEXUS_IMPLEMENTATION_ADDRESS,
+      implementation: implementationForFactory(factory),
       initData,
       initializationCallData,
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,12 @@ interface SafeAccount {
 
 interface NexusAccount {
   type: 'nexus'
-  version?: '1.0.2' | '1.2.0' | 'rhinestone-1.0.0-beta' | 'rhinestone-1.0.0'
+  version?:
+    | '1.0.2'
+    | '1.2.0'
+    | '1.2.1'
+    | 'rhinestone-1.0.0-beta'
+    | 'rhinestone-1.0.0'
   salt?: Hex
 }
 


### PR DESCRIPTION
Adds opt-in support for the new Rhinestone Nexus (v1.2.1) in the v1 SDK.

- Select the new implementation + factory via `account: { type: 'nexus', version: '1.2.1' }`; the previous Nexus (1.2.0) stays the default.
- Only the implementation (`0x0000…0d41c0bf…`) and factory (`0x0000…0099d5576c…`) differ — bootstrap, proxy creation code, default validator (Ownable), and EIP-712 domain version (`1.2.0`) are unchanged.
- EIP-7702 adoption/init now points at the version-resolved implementation.
- Adds deploy-args + counterfactual-address tests for `1.2.1`.

Scope is SDK-only. Correctness of the address derivation (proxy creation code, default validator) will be confirmed by deploying a live 1.2.1 account, since none exists on-chain yet.

Closes [RHI-4924](https://linear.app/rhinestone/issue/RHI-4924)
Relates to [RHI-4923](https://linear.app/rhinestone/issue/RHI-4923)