### PR TITLE
feat(smart-sessions)!: drop experimental_ prefix from smart session API

### DIFF
--- a/.changeset/drop-experimental-smart-session-prefix.md
+++ b/.changeset/drop-experimental-smart-session-prefix.md
@@ -1,0 +1,10 @@
+---
+'@rhinestone/sdk': major
+---
+
+Drop the `experimental_` prefix from the smart-session API now that it's stable. Rename across your integration:
+
+- Config: `experimental_sessions` → `sessions`
+- Signer set: `type: 'experimental_session'` → `type: 'session'`
+- Account methods: `experimental_getSessionDetails` → `getSessionDetails`, `experimental_isSessionEnabled` → `isSessionEnabled`, `experimental_signEnableSession` → `signEnableSession`
+- `@rhinestone/sdk/actions/smart-sessions` actions: `experimental_enable` → `enable`, `experimental_disable` → `disable`, `experimental_enableSession` → `enableSession`, `experimental_disableSession` → `disableSession`

--- a/scripts/contract/run.ts
+++ b/scripts/contract/run.ts
@@ -4,6 +4,7 @@ import { basename, join, resolve } from 'node:path'
 import { generateApiReport } from './api-report.ts'
 import {
   createConsumerLayout,
+  declaresSurfaceChange,
   type PackageManifest,
   readJson,
   runCommand,
@@ -273,26 +274,36 @@ async function main(): Promise<void> {
       runtimeProbePath,
       includeOptionalPeers: true,
     })
-    const assignabilityConsumer = join(
-      temporaryDirectory,
-      'assignability-consumer',
-    )
-    createConsumerLayout({
-      packageDirectory: current.packageDirectory,
-      consumerDirectory: assignabilityConsumer,
-      dependencyRoot: current.dependencyRoot,
-      runtimeProbePath,
-      includeOptionalPeers: true,
-    })
-    cpSync(
-      baseBuild.subject.packageDirectory,
-      join(assignabilityConsumer, 'node_modules/@rhinestone/sdk-base'),
-      { recursive: true },
-    )
-
     compileConsumer(baseConsumers.full)
     compileConsumer(currentConsumers.full)
-    compileConsumer(assignabilityConsumer, assignabilityFixturePath)
+
+    // The bidirectional assignability fixture asserts the public types stay
+    // compatible with the base release. A PR that declares an intentional
+    // surface change (minor/major changeset) is allowed to break that, so skip
+    // it there — matching the changeset-aware relaxation in the Vitest suite.
+    if (declaresSurfaceChange(baseSha, repositoryRoot)) {
+      process.stdout.write(
+        'Skipping bidirectional assignability check: PR declares an intentional public-surface change\n',
+      )
+    } else {
+      const assignabilityConsumer = join(
+        temporaryDirectory,
+        'assignability-consumer',
+      )
+      createConsumerLayout({
+        packageDirectory: current.packageDirectory,
+        consumerDirectory: assignabilityConsumer,
+        dependencyRoot: current.dependencyRoot,
+        runtimeProbePath,
+        includeOptionalPeers: true,
+      })
+      cpSync(
+        baseBuild.subject.packageDirectory,
+        join(assignabilityConsumer, 'node_modules/@rhinestone/sdk-base'),
+        { recursive: true },
+      )
+      compileConsumer(assignabilityConsumer, assignabilityFixturePath)
+    }
     validateMetadata(baseBuild.subject.packageDirectory)
     validateMetadata(current.packageDirectory)
 

--- a/scripts/contract/shared.ts
+++ b/scripts/contract/shared.ts
@@ -4,6 +4,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   symlinkSync,
   writeFileSync,
@@ -74,6 +75,60 @@ export function writeJson(path: string, value: unknown): void {
 
 export function sha256File(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex')
+}
+
+type SemverBump = 'major' | 'minor' | 'patch'
+const BUMP_RANK: Record<SemverBump, number> = { patch: 0, minor: 1, major: 2 }
+
+// Changeset basenames present on a git ref, or null if the ref can't be read.
+function changesetNamesInRef(ref: string, cwd: string): Set<string> | null {
+  const result = spawnSync(
+    'git',
+    ['ls-tree', '-r', '--name-only', ref, '--', '.changeset'],
+    { cwd, encoding: 'utf8' },
+  )
+  if (result.status !== 0) return null
+  return new Set(
+    result.stdout
+      .split('\n')
+      .filter((path) => path.endsWith('.md') && !path.endsWith('README.md'))
+      .map((path) => (path.split('/').pop() ?? '').replace(/\.md$/, '')),
+  )
+}
+
+// Highest `@rhinestone/sdk` bump among changesets this PR adds (present in the
+// working tree but not on `baseSha`). `.changeset/` accumulates merged-but-
+// unreleased changesets — and, in changeset pre mode, released ones too until
+// pre exit — so diffing against the base is the only reliable signal for what
+// this PR changes. Returns null when the base tree can't be read.
+function declaredSdkBump(baseSha: string, cwd: string): SemverBump | null {
+  const changesetDirectory = join(cwd, '.changeset')
+  if (!existsSync(changesetDirectory)) return null
+  const baseChangesets = changesetNamesInRef(baseSha, cwd)
+  if (baseChangesets === null) return null
+  let highest: SemverBump | null = null
+  for (const entry of readdirSync(changesetDirectory)) {
+    if (!entry.endsWith('.md') || entry === 'README.md') continue
+    if (baseChangesets.has(entry.replace(/\.md$/, ''))) continue
+    const source = readFileSync(join(changesetDirectory, entry), 'utf8')
+    const match = source.match(
+      /['"]@rhinestone\/sdk['"]\s*:\s*(major|minor|patch)/,
+    )
+    if (!match) continue
+    const bump = match[1] as SemverBump
+    if (!highest || BUMP_RANK[bump] > BUMP_RANK[highest]) highest = bump
+  }
+  return highest
+}
+
+// True when this PR introduces a minor/major `@rhinestone/sdk` changeset, i.e.
+// documents an intentional public-surface change. The contract suite uses this
+// to relax its strict "no drift" and bidirectional-assignability checks, which
+// an intentional change is allowed to break; patch-only (or no new changeset,
+// or an unreadable base) keeps the strict gate so accidental breaks still fail.
+export function declaresSurfaceChange(baseSha: string, cwd: string): boolean {
+  const bump = declaredSdkBump(baseSha, cwd)
+  return bump === 'major' || bump === 'minor'
 }
 
 function linkDependency(

--- a/scripts/reference/generate.ts
+++ b/scripts/reference/generate.ts
@@ -209,7 +209,7 @@ const RETURN_NAME_OVERRIDES: Record<string, string> = {
   signMessage: 'signature',
   signTypedData: 'signature',
   signEip7702InitData: 'signature',
-  experimental_signEnableSession: 'signature',
+  signEnableSession: 'signature',
   signIntent: 'signatures',
   waitForExecution: 'result',
   deploy: 'success',

--- a/scripts/reference/manifest.ts
+++ b/scripts/reference/manifest.ts
@@ -177,11 +177,10 @@ export const manifest: Group[] = [
       {
         kind: 'group',
         group: 'Smart sessions',
-        experimental: true,
         items: [
-          accountMethod('experimental_getSessionDetails', true),
-          accountMethod('experimental_isSessionEnabled', true),
-          accountMethod('experimental_signEnableSession', true),
+          accountMethod('getSessionDetails'),
+          accountMethod('isSessionEnabled'),
+          accountMethod('signEnableSession'),
         ],
       },
     ],
@@ -235,20 +234,11 @@ export const manifest: Group[] = [
       {
         kind: 'group',
         group: 'Smart sessions',
-        experimental: true,
         items: [
-          action('experimental_enable', './actions/smart-sessions', true),
-          action('experimental_disable', './actions/smart-sessions', true),
-          action(
-            'experimental_enableSession',
-            './actions/smart-sessions',
-            true,
-          ),
-          action(
-            'experimental_disableSession',
-            './actions/smart-sessions',
-            true,
-          ),
+          action('enable', './actions/smart-sessions'),
+          action('disable', './actions/smart-sessions'),
+          action('enableSession', './actions/smart-sessions'),
+          action('disableSession', './actions/smart-sessions'),
         ],
       },
     ],

--- a/src/actions/smart-sessions.ts
+++ b/src/actions/smart-sessions.ts
@@ -17,8 +17,8 @@ function sessionModule(
   config: Parameters<LazyCallInput['resolve']>[0]['config'],
 ) {
   return resolveSmartSessionModule({
-    enabled: config.experimental_sessions?.enabled ?? false,
-    address: config.experimental_sessions?.module,
+    enabled: config.sessions?.enabled ?? false,
+    address: config.sessions?.module,
     environment: environment(config.useDevContracts),
   })
 }
@@ -27,7 +27,7 @@ function sessionModule(
  * Enable smart sessions
  * @returns Calls to enable smart sessions
  */
-function experimental_enable(): LazyCallInput {
+function enable(): LazyCallInput {
   return {
     async resolve(context) {
       const module = sessionModule(context.config)
@@ -43,7 +43,7 @@ function experimental_enable(): LazyCallInput {
  * Disable smart sessions
  * @returns Calls to disable smart sessions
  */
-function experimental_disable(): LazyCallInput {
+function disable(): LazyCallInput {
   return {
     async resolve(context) {
       const module = sessionModule(context.config)
@@ -68,7 +68,7 @@ function experimental_disable(): LazyCallInput {
  * @param session resolved session to enable
  * @returns Calls to enable the smart session
  */
-function experimental_enableSession(
+function enableSession(
   session: Session,
   enableSessionSignature: Hex,
   hashesAndChainIds: {
@@ -107,10 +107,7 @@ function experimental_enableSession(
  *   valid; must be in the future. Omit for no expiry.
  * @returns Calls to disable the smart session
  */
-function experimental_disableSession(
-  session: Session,
-  expires?: Date,
-): LazyCallInput {
+function disableSession(session: Session, expires?: Date): LazyCallInput {
   return {
     async resolve(context) {
       return resolveSessionDisable({
@@ -123,9 +120,4 @@ function experimental_disableSession(
   }
 }
 
-export {
-  experimental_disable,
-  experimental_disableSession,
-  experimental_enable,
-  experimental_enableSession,
-}
+export { disable, disableSession, enable, enableSession }

--- a/src/api/account.test.ts
+++ b/src/api/account.test.ts
@@ -323,7 +323,7 @@ describe('account boundary adapters', () => {
         chain: mainnet,
         calls: [],
         signers: {
-          type: 'experimental_session',
+          type: 'session',
           session: { chain: mainnet } as never,
         },
       }),

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -333,19 +333,19 @@ export interface RhinestoneAccount {
    * @param sessions Sessions to resolve
    * @returns The resolved session details
    */
-  experimental_getSessionDetails(sessions: Session[]): Promise<SessionDetails>
+  getSessionDetails(sessions: Session[]): Promise<SessionDetails>
   /**
    * Check whether a smart session is enabled on the account.
    * @param session Session to check
    * @returns `true` if the session is enabled
    */
-  experimental_isSessionEnabled(session: Session): Promise<boolean>
+  isSessionEnabled(session: Session): Promise<boolean>
   /**
    * Sign the data required to enable a smart session.
    * @param details Session details to enable
    * @returns The enable-session signature
    */
-  experimental_signEnableSession(details: SessionDetails): Promise<Hex>
+  signEnableSession(details: SessionDetails): Promise<Hex>
   /**
    * Get the account owners.
    * @remarks Only returns ECDSA owners; owners managed by other validator types are not included.
@@ -559,10 +559,7 @@ export function createAccountFacade(
         // Independent owner signing is unsupported for smart-session intents;
         // reject before resolving sessions (which would issue an RPC read),
         // matching the legacy fast-fail.
-        if (
-          preparedTransaction.transaction.signers?.type ===
-          'experimental_session'
-        ) {
+        if (preparedTransaction.transaction.signers?.type === 'session') {
           return Promise.reject(new IndependentSigningNotSupportedError())
         }
         const signerId = signerIdForOwner(options.owner)
@@ -820,15 +817,15 @@ export function createAccountFacade(
         .getPortfolio(ctx, onTestnets)
         .then((portfolio) => portfolio.tokens as unknown as Portfolio)
     },
-    experimental_getSessionDetails(sessions) {
+    getSessionDetails(sessions) {
       const ctx = context('get-session-details')
       return workflowsFor(ctx).getSessionDetails(ctx, sessions)
     },
-    experimental_isSessionEnabled(session) {
+    isSessionEnabled(session) {
       const ctx = context('is-session-enabled')
       return workflowsFor(ctx).isSessionEnabled(ctx, session)
     },
-    experimental_signEnableSession(details) {
+    signEnableSession(details) {
       const ctx = context('sign-enable-session')
       return workflowsFor(ctx).signEnableSession(ctx, details)
     },
@@ -872,7 +869,7 @@ function userOperationSignerSelection(
   transaction: UserOperationTransaction,
 ): OwnerSignerSelection | undefined {
   if (!transaction.signers) return undefined
-  if (transaction.signers?.type === 'experimental_session') {
+  if (transaction.signers?.type === 'session') {
     throw new Error('No account found')
   }
   const selection = adaptSignerSelection(context.account, transaction.signers)
@@ -1004,7 +1001,7 @@ export function adaptTransaction(
     ...(transaction.signers
       ? {
           signers:
-            transaction.signers.type === 'experimental_session'
+            transaction.signers.type === 'session'
               ? {
                   kind: 'smart-session',
                   byChain: adaptSessionSelection(
@@ -1050,9 +1047,7 @@ function toAccountConstructionInput(
   return {
     ...(config.account ? { account: config.account } : {}),
     ...(config.owners ? { owners: config.owners } : {}),
-    ...(config.experimental_sessions
-      ? { experimental_sessions: config.experimental_sessions }
-      : {}),
+    ...(config.sessions ? { sessions: config.sessions } : {}),
     ...(config.eoa ? { eoa: config.eoa } : {}),
     ...(config.modules ? { modules: config.modules } : {}),
     ...(config.initData ? { initData: config.initData } : {}),
@@ -1113,7 +1108,7 @@ function adaptSessionSelection(
   chains: readonly { readonly kind: string; readonly id?: number }[],
 ) {
   const signers = transaction.signers
-  if (!signers || signers.type !== 'experimental_session') return {}
+  if (!signers || signers.type !== 'session') return {}
   if ('sessions' in signers) {
     return Object.fromEntries(
       Object.entries(signers.sessions).map(([chainId, selection]) => [

--- a/src/api/signer-selection.test.ts
+++ b/src/api/signer-selection.test.ts
@@ -110,7 +110,7 @@ describe('public signer selection adapter', () => {
     const selected = adaptSignerSelection(
       account({ type: 'ecdsa', accounts: [first] }),
       {
-        type: 'experimental_session',
+        type: 'session',
         sessions: { 1: { session, enableData } },
       },
     )

--- a/src/api/signer-selection.ts
+++ b/src/api/signer-selection.ts
@@ -25,7 +25,7 @@ export function adaptSignerSelection(
   account: ResolvedAccountConfig,
   signers: SignerSet,
 ): AdaptedSignerSelection {
-  if (signers.type === 'experimental_session') {
+  if (signers.type === 'session') {
     return adaptSessionSelection(signers)
   }
   return adaptOwnerSelection(account, signers)
@@ -138,7 +138,7 @@ function replaceOwnerAccount(
 }
 
 function adaptSessionSelection(
-  signers: Extract<SignerSet, { type: 'experimental_session' }>,
+  signers: Extract<SignerSet, { type: 'session' }>,
 ): IntentSessionSelection {
   if ('sessions' in signers) {
     return {

--- a/src/config/account-runtime.test.ts
+++ b/src/config/account-runtime.test.ts
@@ -16,7 +16,7 @@ describe('account runtime', () => {
       owners: { type: 'ecdsa', accounts: [owner] },
       modules: [{ type: 'executor', address: moduleAddress }],
       initData: { address: owner.address },
-      experimental_sessions: {
+      sessions: {
         enabled: true,
         module: moduleAddress,
         compatibilityFallback: fallbackAddress,

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -605,7 +605,7 @@ interface ModuleInput {
 interface RhinestoneAccountConfig {
   account?: AccountProviderConfig
   owners?: OwnerSet
-  experimental_sessions?: {
+  sessions?: {
     enabled: boolean
     module?: Address
     compatibilityFallback?: Address
@@ -806,13 +806,13 @@ interface ChainSessionConfig {
 }
 
 interface SingleSessionSignerSet {
-  type: 'experimental_session'
+  type: 'session'
   session: Session
   enableData?: SessionEnableData
 }
 
 interface PerChainSessionSignerSet {
-  type: 'experimental_session'
+  type: 'session'
   sessions: Record<number, ChainSessionConfig>
 }
 

--- a/src/config/input.ts
+++ b/src/config/input.ts
@@ -47,7 +47,7 @@ export type SdkConstructionInput = SdkConstructionInputBase &
 export interface AccountConstructionInput {
   account?: AccountInput
   owners?: ValidatorInput
-  experimental_sessions?: {
+  sessions?: {
     enabled: boolean
     module?: Address
     compatibilityFallback?: Address

--- a/src/config/legacy.test.ts
+++ b/src/config/legacy.test.ts
@@ -15,7 +15,7 @@ describe('legacy account config compatibility', () => {
     const accountInput = {
       owners,
       modules,
-      experimental_sessions: sessions,
+      sessions: sessions,
     }
     const provider = { type: 'custom' as const, urls: { 1: 'https://rpc' } }
     const headers = { 'x-test': 'value' }
@@ -44,7 +44,7 @@ describe('legacy account config compatibility', () => {
     expect(compatibilityConfig).toEqual(publicConfig)
     expect(compatibilityConfig.owners).toBe(owners)
     expect(compatibilityConfig.modules).toBe(modules)
-    expect(compatibilityConfig.experimental_sessions).toBe(sessions)
+    expect(compatibilityConfig.sessions).toBe(sessions)
     expect(compatibilityConfig.provider).toBe(provider)
     expect(compatibilityConfig.headers).toBe(headers)
     expect(compatibilityConfig._authProvider).toBe(authProvider)

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -91,7 +91,7 @@ const accountConfigArbitrary: fc.Arbitrary<AccountConstructionInput> = fc
             threshold,
           },
         }),
-    ...(sessions ? { experimental_sessions: { enabled: true } } : {}),
+    ...(sessions ? { sessions: { enabled: true } } : {}),
     modules: [
       {
         type: 'executor' as const,
@@ -293,7 +293,7 @@ describe('SDK config resolution', () => {
         ],
       },
       modules: [{ type: 'executor', address: addressA }],
-      experimental_sessions: {
+      sessions: {
         enabled: true,
         module: addressB,
       },
@@ -500,7 +500,7 @@ describe('SDK config resolution', () => {
         module: addressA,
         threshold: 1,
       },
-      experimental_sessions: {
+      sessions: {
         enabled: true,
         compatibilityFallback: addressB,
       },
@@ -636,7 +636,7 @@ describe('account invocation materialization', () => {
     const accountInput: AccountConstructionInput = {
       account: { type: 'safe' },
       owners: { type: 'ecdsa', accounts: [accountA] },
-      experimental_sessions: { enabled: false },
+      sessions: { enabled: false },
     }
     const authProvider = {}
     const compatibility = createLegacyAccountConfig(
@@ -656,10 +656,10 @@ describe('account invocation materialization', () => {
       accounts: [accountB],
       threshold: 1,
     }
-    if (!compatibility.experimental_sessions) {
+    if (!compatibility.sessions) {
       throw new Error('Expected sessions compatibility input')
     }
-    compatibility.experimental_sessions.enabled = true
+    compatibility.sessions.enabled = true
 
     const context = materializeAccountInvocationContext(
       sdk,

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -159,7 +159,7 @@ function resolveAccountDefinition(
 }
 
 function resolveSessions(
-  input: AccountConstructionInput['experimental_sessions'],
+  input: AccountConstructionInput['sessions'],
   environment: ResolvedSdkConfig['environment'],
 ): ResolvedSessionInstallation {
   return {
@@ -186,7 +186,7 @@ function resolveAccountWithDefaults(
     ...(input.eoa ? { eoa: input.eoa } : {}),
     modules: configureModules(input.modules),
     ...(input.initData ? { initData: input.initData } : {}),
-    sessions: resolveSessions(input.experimental_sessions, environment),
+    sessions: resolveSessions(input.sessions, environment),
   }
 }
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -24,7 +24,7 @@ describe('Utils', () => {
     const withoutSessions = experimental_getV0InitData(baseConfig)
     const withSessions = experimental_getV0InitData({
       ...baseConfig,
-      experimental_sessions: {
+      sessions: {
         enabled: true,
       },
     })
@@ -42,7 +42,7 @@ describe('Utils', () => {
         type: 'ecdsa',
         accounts: [accountA],
       },
-      experimental_sessions: {
+      sessions: {
         enabled: true,
       },
     })
@@ -68,7 +68,7 @@ describe('Utils', () => {
     const initData = experimental_getV0InitData({
       account: { type: 'safe' },
       owners: { type: 'ecdsa', accounts: [accountA] },
-      experimental_sessions: { enabled: true },
+      sessions: { enabled: true },
     })
 
     expect(initData.address).toBe('0xe2F9e65cff1e5EBc5dFe7650872ad36619875650')
@@ -81,7 +81,7 @@ describe('Utils', () => {
     const setup = experimental_getModuleSetup({
       account: { type: 'safe' },
       owners: { type: 'ecdsa', accounts: [accountA] },
-      experimental_sessions: { enabled: true },
+      sessions: { enabled: true },
     })
 
     expect(

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -4,7 +4,10 @@ import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import sizeLimits from '../../.size-limit.ts'
 import type { ApiReport } from '../../scripts/contract/api-report.ts'
-import type { PackageManifest } from '../../scripts/contract/shared.ts'
+import {
+  declaresSurfaceChange,
+  type PackageManifest,
+} from '../../scripts/contract/shared.ts'
 
 interface JwtProbeResult {
   ok: boolean
@@ -156,60 +159,12 @@ function privateSourceImports(packageDirectory: string): string[] {
   return violations
 }
 
-type SemverBump = 'major' | 'minor' | 'patch'
-const BUMP_RANK: Record<SemverBump, number> = { patch: 0, minor: 1, major: 2 }
-
-// Changeset basenames present on the PR base commit. `.changeset/` accumulates
-// every merged-but-unreleased changeset (and, in pre mode, released ones too
-// until pre exit), so the only reliable signal for "what this PR changes" is the
-// diff against the base. Returns null when the base tree can't be read, in which
-// case the gate stays strict rather than risk relaxing on incomplete info.
-function baseChangesetNames(): Set<string> | null {
-  const result = spawnSync(
-    'git',
-    ['ls-tree', '-r', '--name-only', baseSha, '--', '.changeset'],
-    { cwd: process.cwd(), encoding: 'utf8' },
-  )
-  if (result.status !== 0) return null
-  return new Set(
-    result.stdout
-      .split('\n')
-      .filter((path) => path.endsWith('.md') && !path.endsWith('README.md'))
-      .map((path) => (path.split('/').pop() ?? '').replace(/\.md$/, '')),
-  )
-}
-
-// Highest `@rhinestone/sdk` bump among changesets this PR adds (present in the
-// working tree but not on the base). A minor/major bump documents an intentional
-// public-surface change; patch (or no new changeset) means the surface is
-// expected to stay identical.
-function declaredSdkBump(): SemverBump | null {
-  const changesetDirectory = join(process.cwd(), '.changeset')
-  if (!existsSync(changesetDirectory)) return null
-  const baseChangesets = baseChangesetNames()
-  if (baseChangesets === null) return null
-  let highest: SemverBump | null = null
-  for (const entry of readdirSync(changesetDirectory)) {
-    if (!entry.endsWith('.md') || entry === 'README.md') continue
-    if (baseChangesets.has(entry.replace(/\.md$/, ''))) continue
-    const source = readFileSync(join(changesetDirectory, entry), 'utf8')
-    const match = source.match(
-      /['"]@rhinestone\/sdk['"]\s*:\s*(major|minor|patch)/,
-    )
-    if (!match) continue
-    const bump = match[1] as SemverBump
-    if (!highest || BUMP_RANK[bump] > BUMP_RANK[highest]) highest = bump
-  }
-  return highest
-}
-
-// When the PR declares an intentional surface change, the strict "no drift"
-// assertions are relaxed to well-formedness checks. The strict gate stays on
-// for patch-only PRs so accidental, undocumented breaks still fail.
-const intentionalSurfaceChange = (() => {
-  const bump = declaredSdkBump()
-  return bump === 'major' || bump === 'minor'
-})()
+// When the PR declares an intentional surface change (a minor/major changeset),
+// the strict "no drift" assertions are relaxed to well-formedness checks. The
+// strict gate stays on for patch-only PRs so accidental, undocumented breaks
+// still fail. `run.ts` gates the bidirectional assignability fixture on the same
+// signal, so the whole contract suite relaxes together.
+const intentionalSurfaceChange = declaresSurfaceChange(baseSha, process.cwd())
 
 describe('packed package contract', () => {
   it('uses a concrete release commit as the base subject', () => {

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -159,39 +159,39 @@ function privateSourceImports(packageDirectory: string): string[] {
 type SemverBump = 'major' | 'minor' | 'patch'
 const BUMP_RANK: Record<SemverBump, number> = { patch: 0, minor: 1, major: 2 }
 
-// Changesets already folded into a previous pre-release. In changeset pre mode
-// the `.md` files are not deleted per release (only at pre exit), so the
-// directory keeps every historical major/minor changeset. Those must be ignored
-// here — otherwise the bump scan would always see an old breaking changeset and
-// permanently relax the gate. Outside pre mode this is empty (files are deleted
-// on release, so every remaining changeset is genuinely new).
-function consumedChangesets(): Set<string> {
-  const preJsonPath = join(process.cwd(), '.changeset', 'pre.json')
-  if (!existsSync(preJsonPath)) return new Set()
-  try {
-    const pre = JSON.parse(readFileSync(preJsonPath, 'utf8')) as {
-      mode?: string
-      changesets?: string[]
-    }
-    if (pre.mode !== 'pre' || !Array.isArray(pre.changesets)) return new Set()
-    return new Set(pre.changesets)
-  } catch {
-    return new Set()
-  }
+// Changeset basenames present on the PR base commit. `.changeset/` accumulates
+// every merged-but-unreleased changeset (and, in pre mode, released ones too
+// until pre exit), so the only reliable signal for "what this PR changes" is the
+// diff against the base. Returns null when the base tree can't be read, in which
+// case the gate stays strict rather than risk relaxing on incomplete info.
+function baseChangesetNames(): Set<string> | null {
+  const result = spawnSync(
+    'git',
+    ['ls-tree', '-r', '--name-only', baseSha, '--', '.changeset'],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  )
+  if (result.status !== 0) return null
+  return new Set(
+    result.stdout
+      .split('\n')
+      .filter((path) => path.endsWith('.md') && !path.endsWith('README.md'))
+      .map((path) => (path.split('/').pop() ?? '').replace(/\.md$/, '')),
+  )
 }
 
-// Highest `@rhinestone/sdk` bump declared by changesets this PR introduces (i.e.
-// not yet consumed by a prior pre-release). A minor/major bump documents an
-// intentional public-surface change; patch (or no new changeset) means the
-// surface is expected to stay identical.
+// Highest `@rhinestone/sdk` bump among changesets this PR adds (present in the
+// working tree but not on the base). A minor/major bump documents an intentional
+// public-surface change; patch (or no new changeset) means the surface is
+// expected to stay identical.
 function declaredSdkBump(): SemverBump | null {
   const changesetDirectory = join(process.cwd(), '.changeset')
   if (!existsSync(changesetDirectory)) return null
-  const consumed = consumedChangesets()
+  const baseChangesets = baseChangesetNames()
+  if (baseChangesets === null) return null
   let highest: SemverBump | null = null
   for (const entry of readdirSync(changesetDirectory)) {
     if (!entry.endsWith('.md') || entry === 'README.md') continue
-    if (consumed.has(entry.replace(/\.md$/, ''))) continue
+    if (baseChangesets.has(entry.replace(/\.md$/, ''))) continue
     const source = readFileSync(join(changesetDirectory, entry), 'utf8')
     const match = source.match(
       /['"]@rhinestone\/sdk['"]\s*:\s*(major|minor|patch)/,

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -156,6 +156,37 @@ function privateSourceImports(packageDirectory: string): string[] {
   return violations
 }
 
+type SemverBump = 'major' | 'minor' | 'patch'
+const BUMP_RANK: Record<SemverBump, number> = { patch: 0, minor: 1, major: 2 }
+
+// Highest `@rhinestone/sdk` bump declared by pending changesets in the working
+// tree. A minor/major bump documents an intentional public-surface change; a
+// patch (or no changeset) means the surface is expected to stay identical.
+function declaredSdkBump(): SemverBump | null {
+  const changesetDirectory = join(process.cwd(), '.changeset')
+  if (!existsSync(changesetDirectory)) return null
+  let highest: SemverBump | null = null
+  for (const entry of readdirSync(changesetDirectory)) {
+    if (!entry.endsWith('.md') || entry === 'README.md') continue
+    const source = readFileSync(join(changesetDirectory, entry), 'utf8')
+    const match = source.match(
+      /['"]@rhinestone\/sdk['"]\s*:\s*(major|minor|patch)/,
+    )
+    if (!match) continue
+    const bump = match[1] as SemverBump
+    if (!highest || BUMP_RANK[bump] > BUMP_RANK[highest]) highest = bump
+  }
+  return highest
+}
+
+// When the PR declares an intentional surface change, the strict "no drift"
+// assertions are relaxed to well-formedness checks. The strict gate stays on
+// for patch-only PRs so accidental, undocumented breaks still fail.
+const intentionalSurfaceChange = (() => {
+  const bump = declaredSdkBump()
+  return bump === 'major' || bump === 'minor'
+})()
+
 describe('packed package contract', () => {
   it('uses a concrete release commit as the base subject', () => {
     expect(baseSha).toMatch(/^[0-9a-f]{40}$/)
@@ -223,22 +254,30 @@ describe('packed package contract', () => {
       'exports',
     )
 
+    if (intentionalSurfaceChange) {
+      // Names may differ from the base; still require every entry point to
+      // resolve to a non-empty export set.
+      for (const [entrypoint, exports] of Object.entries(currentExports)) {
+        expect(
+          exports.length,
+          `entry point ${entrypoint} exports nothing`,
+        ).toBeGreaterThan(0)
+      }
+      return
+    }
+
     expect(currentExports).toEqual(baseExports)
   })
 
   it('keeps a declaration for every runtime value export', () => {
-    const baseExports = runProbe<Record<string, string[]>>(
-      baseConsumerDirectory,
+    const currentExports = runProbe<Record<string, string[]>>(
+      currentConsumerDirectory,
       'exports',
     )
-    for (const [entrypoint, runtimeExports] of Object.entries(baseExports)) {
+    for (const [entrypoint, runtimeExports] of Object.entries(currentExports)) {
       for (const exportName of runtimeExports) {
         expect(
-          baseApiReport.entrypoints[entrypoint][exportName]?.hasValue,
-          `release declaration missing runtime export ${entrypoint}:${exportName}`,
-        ).toBe(true)
-        expect(
-          currentApiReport.entrypoints[entrypoint][exportName]?.hasValue,
+          currentApiReport.entrypoints[entrypoint]?.[exportName]?.hasValue,
           `current declaration missing runtime export ${entrypoint}:${exportName}`,
         ).toBe(true)
       }
@@ -246,6 +285,13 @@ describe('packed package contract', () => {
   })
 
   it('preserves the semantic declaration report for every entry point', () => {
+    if (intentionalSurfaceChange) {
+      // The report is expected to differ; assert it is still well-formed.
+      expect(Object.keys(currentApiReport.entrypoints).length).toBeGreaterThan(
+        0,
+      )
+      return
+    }
     expect(currentApiReport).toEqual(baseApiReport)
   })
 

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -159,15 +159,39 @@ function privateSourceImports(packageDirectory: string): string[] {
 type SemverBump = 'major' | 'minor' | 'patch'
 const BUMP_RANK: Record<SemverBump, number> = { patch: 0, minor: 1, major: 2 }
 
-// Highest `@rhinestone/sdk` bump declared by pending changesets in the working
-// tree. A minor/major bump documents an intentional public-surface change; a
-// patch (or no changeset) means the surface is expected to stay identical.
+// Changesets already folded into a previous pre-release. In changeset pre mode
+// the `.md` files are not deleted per release (only at pre exit), so the
+// directory keeps every historical major/minor changeset. Those must be ignored
+// here — otherwise the bump scan would always see an old breaking changeset and
+// permanently relax the gate. Outside pre mode this is empty (files are deleted
+// on release, so every remaining changeset is genuinely new).
+function consumedChangesets(): Set<string> {
+  const preJsonPath = join(process.cwd(), '.changeset', 'pre.json')
+  if (!existsSync(preJsonPath)) return new Set()
+  try {
+    const pre = JSON.parse(readFileSync(preJsonPath, 'utf8')) as {
+      mode?: string
+      changesets?: string[]
+    }
+    if (pre.mode !== 'pre' || !Array.isArray(pre.changesets)) return new Set()
+    return new Set(pre.changesets)
+  } catch {
+    return new Set()
+  }
+}
+
+// Highest `@rhinestone/sdk` bump declared by changesets this PR introduces (i.e.
+// not yet consumed by a prior pre-release). A minor/major bump documents an
+// intentional public-surface change; patch (or no new changeset) means the
+// surface is expected to stay identical.
 function declaredSdkBump(): SemverBump | null {
   const changesetDirectory = join(process.cwd(), '.changeset')
   if (!existsSync(changesetDirectory)) return null
+  const consumed = consumedChangesets()
   let highest: SemverBump | null = null
   for (const entry of readdirSync(changesetDirectory)) {
     if (!entry.endsWith('.md') || entry === 'README.md') continue
+    if (consumed.has(entry.replace(/\.md$/, ''))) continue
     const source = readFileSync(join(changesetDirectory, entry), 'utf8')
     const match = source.match(
       /['"]@rhinestone\/sdk['"]\s*:\s*(major|minor|patch)/,

--- a/test/integration/framework/assertions.ts
+++ b/test/integration/framework/assertions.ts
@@ -39,7 +39,7 @@ export async function expectSessionDisabled(
   account: RhinestoneAccount,
   session: Session,
 ): Promise<void> {
-  const enabled = await account.experimental_isSessionEnabled(session)
+  const enabled = await account.isSessionEnabled(session)
   expect(enabled, `Session should be disabled on ${account.getAddress()}`).toBe(
     false,
   )
@@ -61,10 +61,10 @@ async function waitForSessionEnabled(
   session: Session,
 ): Promise<boolean> {
   for (let attempt = 0; attempt < 10; attempt++) {
-    if (await account.experimental_isSessionEnabled(session)) return true
+    if (await account.isSessionEnabled(session)) return true
     await sleep(1_000)
   }
-  return account.experimental_isSessionEnabled(session)
+  return account.isSessionEnabled(session)
 }
 
 function sleep(ms: number): Promise<void> {

--- a/test/integration/scenarios/preclaim-ops.itest.ts
+++ b/test/integration/scenarios/preclaim-ops.itest.ts
@@ -49,7 +49,7 @@ describe.sequential('SDK integration preclaim-ops', () => {
     const sdk = createIntegrationSDK()
     const account = await sdk.createAccount({
       owners: { type: 'ecdsa', accounts: [createOwner()] },
-      experimental_sessions: { enabled: true },
+      sessions: { enabled: true },
     })
     const session = createScopedSession({
       chain: sourceChain,
@@ -66,7 +66,7 @@ describe.sequential('SDK integration preclaim-ops', () => {
         sponsored: true,
         calls: [createNoopCall()],
         sourceCalls: { [sourceChain.id]: [createNoopCall()] },
-        signers: { type: 'experimental_session' as const, session },
+        signers: { type: 'session' as const, session },
       }),
     })
 
@@ -164,9 +164,8 @@ async function withEnableData<T extends { signers: { type: string } }>(
   session: Session,
   transaction: T,
 ): Promise<T> {
-  const sessionDetails = await account.experimental_getSessionDetails([session])
-  const userSignature =
-    await account.experimental_signEnableSession(sessionDetails)
+  const sessionDetails = await account.getSessionDetails([session])
+  const userSignature = await account.signEnableSession(sessionDetails)
 
   return {
     ...transaction,

--- a/test/integration/scenarios/sigmode.itest.ts
+++ b/test/integration/scenarios/sigmode.itest.ts
@@ -56,7 +56,7 @@ describe.sequential('SDK integration sigmode', () => {
     const sdk = createIntegrationSDK()
     const account = await sdk.createAccount({
       owners: { type: 'ecdsa', accounts: [createOwner()] },
-      experimental_sessions: { enabled: true },
+      sessions: { enabled: true },
     })
     const session = createScopedSession({
       chain: sourceChain,
@@ -71,7 +71,7 @@ describe.sequential('SDK integration sigmode', () => {
         chain: sourceChain,
         sponsored: true,
         calls: [createNoopCall()],
-        signers: { type: 'experimental_session' as const, session },
+        signers: { type: 'session' as const, session },
       }),
     })
 
@@ -91,7 +91,7 @@ describe.sequential('SDK integration sigmode', () => {
     const sdk = createIntegrationSDK()
     const account = await sdk.createAccount({
       owners: { type: 'ecdsa', accounts: [createOwner()] },
-      experimental_sessions: { enabled: true },
+      sessions: { enabled: true },
     })
     const session = createUnscopedSession({
       chain: sourceChain,
@@ -105,7 +105,7 @@ describe.sequential('SDK integration sigmode', () => {
         chain: sourceChain,
         sponsored: true,
         calls: [createNoopCall()],
-        signers: { type: 'experimental_session' as const, session },
+        signers: { type: 'session' as const, session },
       }),
     })
     expectOutcome(enable, { kind: 'success' })
@@ -119,7 +119,7 @@ describe.sequential('SDK integration sigmode', () => {
         chain: sourceChain,
         sponsored: true,
         calls: [createNoopCall()],
-        signers: { type: 'experimental_session' as const, session },
+        signers: { type: 'session' as const, session },
       },
     })
 
@@ -138,7 +138,7 @@ describe.sequential('SDK integration sigmode', () => {
     const sdk = createIntegrationSDK()
     const account = await sdk.createAccount({
       owners: { type: 'ecdsa', accounts: [createOwner()] },
-      experimental_sessions: { enabled: true },
+      sessions: { enabled: true },
     })
     const session = createScopedSession({
       chain: sourceChain,
@@ -153,7 +153,7 @@ describe.sequential('SDK integration sigmode', () => {
         chain: sourceChain,
         sponsored: true,
         calls: [createNoopCall()],
-        signers: { type: 'experimental_session' as const, session },
+        signers: { type: 'session' as const, session },
       }),
     })
 
@@ -170,9 +170,8 @@ async function withEnableData<T extends { signers: { type: string } }>(
   session: Session,
   transaction: T,
 ): Promise<T> {
-  const sessionDetails = await account.experimental_getSessionDetails([session])
-  const userSignature =
-    await account.experimental_signEnableSession(sessionDetails)
+  const sessionDetails = await account.getSessionDetails([session])
+  const userSignature = await account.signEnableSession(sessionDetails)
 
   return {
     ...transaction,

--- a/test/integration/scenarios/smoke.itest.ts
+++ b/test/integration/scenarios/smoke.itest.ts
@@ -85,17 +85,14 @@ describe.sequential('SDK integration smoke', () => {
     const sessionOwner = createOwner()
     const account = await sdk.createAccount({
       owners: { type: 'ecdsa', accounts: [owner] },
-      experimental_sessions: { enabled: true },
+      sessions: { enabled: true },
     })
     const session = createScopedSession({
       chain: sourceChain,
       owner: sessionOwner,
     })
-    const sessionDetails = await account.experimental_getSessionDetails([
-      session,
-    ])
-    const enableSignature =
-      await account.experimental_signEnableSession(sessionDetails)
+    const sessionDetails = await account.getSessionDetails([session])
+    const enableSignature = await account.signEnableSession(sessionDetails)
 
     await expectSessionDisabled(account, session)
 
@@ -107,7 +104,7 @@ describe.sequential('SDK integration smoke', () => {
         sponsored: true,
         calls: [createNoopCall()],
         signers: {
-          type: 'experimental_session',
+          type: 'session',
           session,
           enableData: {
             userSignature: enableSignature,

--- a/test/integration/scenarios/ssx-policies.itest.ts
+++ b/test/integration/scenarios/ssx-policies.itest.ts
@@ -115,7 +115,7 @@ describe.sequential('SDK integration ssx policies', () => {
 async function createFundedSessionAccount(): Promise<RhinestoneAccount> {
   const account = await createIntegrationSDK().createAccount({
     owners: { type: 'ecdsa', accounts: [createOwner()] },
-    experimental_sessions: { enabled: true },
+    sessions: { enabled: true },
   })
   await ensureFunded(account.getAddress(), sourceChain, { usdc: FUNDING })
   await waitForOrchestratorUsdc(account, sourceChain, FUNDING)
@@ -163,16 +163,15 @@ async function sessionTransfer(
   session: Session,
   call: ReturnType<typeof usdcTransfer>,
 ) {
-  const sessionDetails = await account.experimental_getSessionDetails([session])
-  const userSignature =
-    await account.experimental_signEnableSession(sessionDetails)
+  const sessionDetails = await account.getSessionDetails([session])
+  const userSignature = await account.signEnableSession(sessionDetails)
 
   return {
     chain: sourceChain,
     sponsored: true as const,
     calls: [call],
     signers: {
-      type: 'experimental_session' as const,
+      type: 'session' as const,
       session,
       enableData: {
         userSignature,

--- a/test/integration/scenarios/ssx.itest.ts
+++ b/test/integration/scenarios/ssx.itest.ts
@@ -1,6 +1,6 @@
 import type { Chain } from 'viem/chains'
 import { describe, test } from 'vitest'
-import { experimental_disableSession } from '../../../src/actions/smart-sessions'
+import { disableSession } from '../../../src/actions/smart-sessions'
 import { SimulationFailedError } from '../../../src/errors/index'
 import type {
   RhinestoneAccount,
@@ -112,7 +112,7 @@ describe.sequential('SDK integration ssx', () => {
   }
 
   // DISABLE: enable a session for real, then disable it via
-  // experimental_disableSession. The account executes removeConfig itself, so
+  // disableSession. The account executes removeConfig itself, so
   // the disable needs no separate user signature — only the outer (owner) tx.
   for (const chainMode of chainModes) {
     test(`disables a session on a ${chainMode}-chain account`, async () => {
@@ -175,7 +175,7 @@ async function expectScopedCallRejected(
       chain: sourceChain,
       sponsored: true,
       calls: [call],
-      signers: { type: 'experimental_session', session },
+      signers: { type: 'session', session },
     }),
   })
 
@@ -190,7 +190,7 @@ async function expectScopedCallRejected(
 function createSessionAccount() {
   return createIntegrationSDK().createAccount({
     owners: { type: 'ecdsa', accounts: [createOwner()] },
-    experimental_sessions: { enabled: true },
+    sessions: { enabled: true },
   })
 }
 
@@ -215,7 +215,7 @@ function createSessionTransaction(
   const base = {
     sponsored: true,
     calls: [createNoopCall()],
-    signers: { type: 'experimental_session' as const, session },
+    signers: { type: 'session' as const, session },
   }
 
   if (chainMode === 'cross') {
@@ -233,9 +233,7 @@ function createDisableTransaction(
   return {
     chain: getExecutionChain(chainMode),
     sponsored: true,
-    calls: [
-      experimental_disableSession(session, new Date(Date.now() + 60 * 60_000)),
-    ],
+    calls: [disableSession(session, new Date(Date.now() + 60 * 60_000))],
   }
 }
 
@@ -244,9 +242,8 @@ async function addEnableData(
   session: Session,
   transaction: ReturnType<typeof createSessionTransaction>,
 ): Promise<SessionTransaction> {
-  const sessionDetails = await account.experimental_getSessionDetails([session])
-  const enableSignature =
-    await account.experimental_signEnableSession(sessionDetails)
+  const sessionDetails = await account.getSessionDetails([session])
+  const enableSignature = await account.signEnableSession(sessionDetails)
 
   return {
     ...transaction,

--- a/test/types/public-boundary.ts
+++ b/test/types/public-boundary.ts
@@ -56,10 +56,7 @@ declare const account: RhinestoneAccount
 declare const prepared: PreparedTransactionData
 declare const signData: SignData
 declare const typedData: HashTypedDataParameters
-declare const sessionSigners: Extract<
-  SignerSet,
-  { type: 'experimental_session' }
->
+declare const sessionSigners: Extract<SignerSet, { type: 'session' }>
 
 const ownerSigners = {
   type: 'owner',


### PR DESCRIPTION
Drops the `experimental_` prefix from the now-stable smart-session API.

- Config `experimental_sessions` → `sessions`
- Signer set `type: 'experimental_session'` → `type: 'session'`
- Account methods `experimental_getSessionDetails` / `experimental_isSessionEnabled` / `experimental_signEnableSession` → unprefixed
- `@rhinestone/sdk/actions/smart-sessions` `experimental_enable` / `experimental_disable` / `experimental_enableSession` / `experimental_disableSession` → unprefixed
- Adds a `major` changeset and updates the SDK Reference manifest

**Contract gate:** the `release-package-contract` job asserts a byte-identical public surface vs the PR base, which would block this intentional rename. Made the strict "no drift" assertions changeset-aware — a declared `minor`/`major` `@rhinestone/sdk` bump relaxes them to well-formedness checks; patch-only (or no changeset) keeps the strict gate so accidental, undocumented breaks still fail. `bun run test:contract` passes locally.

Docs companion: rhinestonewtf/docs#175 (RHI-4965).

Closes [RHI-4960](https://linear.app/rhinestone/issue/RHI-4960)