### PR TITLE
refactor(accounts)!: clean up account versions

### DIFF
--- a/.changeset/trim-account-versions.md
+++ b/.changeset/trim-account-versions.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': major
+---
+
+Trim the selectable account `version` values to the supported set. Nexus keeps `1.2.0` and `1.2.1` (default `1.2.1`); Kernel keeps `3.3`. Removed Nexus `1.0.2`, `rhinestone-1.0.0-beta`, and `rhinestone-1.0.0`, and Kernel `3.1` and `3.2`. If you pinned a removed version, omit `version` to use the default or pin a supported one.

--- a/src/accounts/adapters/contract.test.ts
+++ b/src/accounts/adapters/contract.test.ts
@@ -25,11 +25,7 @@ import {
   kernelInstallData,
   wrapKernelMessageHash,
 } from './kernel'
-import {
-  createNexusAdapter,
-  nexusDefaultValidator,
-  nexusMaterial,
-} from './nexus'
+import { createNexusAdapter, nexusMaterial } from './nexus'
 import { createSafeAdapter, safeV0FactoryMaterial } from './safe'
 import {
   encodeAddressEnvelope,
@@ -180,18 +176,6 @@ describe('account adapter contract', () => {
     // Only the implementation + factory differ; the bootstrap is identical.
     expect(previous.factoryData).toBe(current.factoryData)
     expect(previous.initializationCallData).toBe(current.initializationCallData)
-
-    for (const version of [
-      '1.0.2',
-      'rhinestone-1.0.0-beta',
-      'rhinestone-1.0.0',
-    ] as const) {
-      const legacy = nexusMaterial(
-        construction({ account: { type: 'nexus', version }, owners: ecdsa }),
-      )
-      expect(legacy.factory).toBe(previous.factory)
-      expect(legacy.implementation).toBe(previous.implementation)
-    }
   })
 
   test('EOA enforces its required account and unsupported operations', () => {
@@ -278,19 +262,6 @@ describe('account adapter contract', () => {
       owners: ecdsa,
     })
     expect(nexusMaterial(nexus).salt).toBe(zeroHash)
-    expect(nexusDefaultValidator('1.0.2')).not.toBe(
-      nexusDefaultValidator('1.2.0'),
-    )
-    // 1.2.0 and 1.2.1 both hardwire the Ownable (default) validator.
-    expect(nexusDefaultValidator('1.2.0')).toBe(
-      nexusDefaultValidator(undefined),
-    )
-    expect(nexusDefaultValidator('1.2.1')).toBe(
-      nexusDefaultValidator(undefined),
-    )
-    expect(nexusDefaultValidator('rhinestone-1.0.0-beta')).not.toBe(
-      nexusDefaultValidator(undefined),
-    )
     const adoptedNexus = construction({ ...inputs.nexus, eoa: accountB })
     expect(
       createNexusAdapter(adoptedNexus).getEip7702AdoptionPlan?.(adoptedNexus),

--- a/src/accounts/adapters/nexus.ts
+++ b/src/accounts/adapters/nexus.ts
@@ -39,23 +39,10 @@ const NEXUS_BOOTSTRAP_ADDRESS =
 const NEXUS_CREATION_CODE =
   '0x60806040526102aa803803806100148161018c565b92833981016040828203126101885781516001600160a01b03811692909190838303610188576020810151906001600160401b03821161018857019281601f8501121561018857835161006e610069826101c5565b61018c565b9481865260208601936020838301011161018857815f926020809301865e8601015260017f90b772c2cb8a51aa7a8a65fc23543c6d022d5b3f8e2b92eed79fba7eef8293005d823b15610176577f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc80546001600160a01b031916821790557fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b5f80a282511561015e575f8091610146945190845af43d15610156573d91610137610069846101c5565b9283523d5f602085013e6101e0565b505b604051606b908161023f8239f35b6060916101e0565b50505034156101485763b398979f60e01b5f5260045ffd5b634c9c8ce360e01b5f5260045260245ffd5b5f80fd5b6040519190601f01601f191682016001600160401b038111838210176101b157604052565b634e487b7160e01b5f52604160045260245ffd5b6001600160401b0381116101b157601f01601f191660200190565b9061020457508051156101f557805190602001fd5b63d6bda27560e01b5f5260045ffd5b81511580610235575b610215575090565b639996b31560e01b5f9081526001600160a01b0391909116600452602490fd5b50803b1561020d56fe60806040523615605c575f8073ffffffffffffffffffffffffffffffffffffffff7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5416368280378136915af43d5f803e156058573d5ff35b3d5ffd5b00fea164736f6c634300081b000a' as const
 
-export function nexusDefaultValidator(version: string | undefined): Address {
-  switch (version) {
-    case '1.0.2':
-      return '0x0000002d6db27c52e3c11c1cf24072004ac75cba'
-    case 'rhinestone-1.0.0-beta':
-      return '0x0000000000e9e6e96bcaa3c113187cdb7e38aed9'
-    default:
-      // 1.2.0 and 1.2.1 both hardwire the Ownable validator; unset and
-      // rhinestone-1.0.0 resolve to it as well.
-      return OWNABLE_VALIDATOR_ADDRESS
-  }
-}
-
 // Resolves the implementation + factory a fresh account deploys against. Only
 // the default (unset) and an explicit '1.2.1' deploy the current contracts;
-// '1.2.0' and the legacy pins keep the previous implementation + factory so
-// their counterfactual addresses don't change.
+// '1.2.0' keeps the previous implementation + factory so its counterfactual
+// address doesn't change.
 function getNexusDeployment(version: string | undefined): {
   implementation: Address
   factory: Address
@@ -259,10 +246,6 @@ export function createNexusAdapter(
   if (construction.account.kind !== 'nexus') {
     throw new Error('Expected Nexus account')
   }
-  const version =
-    construction.account.version.source === 'explicit'
-      ? construction.account.version.value
-      : undefined
   const validator = construction.setup.validators[0]?.address ?? zeroAddress
   return {
     account: construction.account,
@@ -291,7 +274,7 @@ export function createNexusAdapter(
       return encodeAddressEnvelope(
         envelope.validator,
         validatorContribution,
-        nexusDefaultValidator(version),
+        OWNABLE_VALIDATOR_ADDRESS,
       )
     },
   }

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -29,17 +29,12 @@ export type AccountInput =
     }
   | {
       type: 'nexus'
-      version?:
-        | '1.0.2'
-        | '1.2.0'
-        | '1.2.1'
-        | 'rhinestone-1.0.0-beta'
-        | 'rhinestone-1.0.0'
+      version?: '1.2.0' | '1.2.1'
       salt?: Hex
     }
   | {
       type: 'kernel'
-      version?: '3.1' | '3.2' | '3.3'
+      version?: '3.3'
       salt?: Hex
     }
   | { type: 'startale'; salt?: Hex }
@@ -63,21 +58,14 @@ export type AccountDefinition =
   | {
       readonly kind: 'nexus'
       readonly version: AccountValueSelection<
-        | '1.0.2'
-        | '1.2.0'
-        | '1.2.1'
-        | 'rhinestone-1.0.0-beta'
-        | 'rhinestone-1.0.0',
+        '1.2.0' | '1.2.1',
         'nexus-current-version'
       >
       readonly salt: AccountValueSelection<Hex, 'nexus-empty-calldata-salt'>
     }
   | {
       readonly kind: 'kernel'
-      readonly version: AccountValueSelection<
-        '3.1' | '3.2' | '3.3',
-        'kernel-current-version'
-      >
+      readonly version: AccountValueSelection<'3.3', 'kernel-current-version'>
       readonly salt: AccountValueSelection<Hex, 'kernel-zero-salt'>
     }
   | {

--- a/src/actions/runtime.ts
+++ b/src/actions/runtime.ts
@@ -1,5 +1,4 @@
 import { encodeFunctionData, maxUint256, size } from 'viem'
-import { nexusDefaultValidator } from '../accounts/adapters/nexus'
 import { createAccountConstruction } from '../accounts/construction'
 import { DefaultValidatorAlreadyInitializedError } from '../accounts/error'
 import { createAccountAdapter } from '../accounts/registry'
@@ -17,6 +16,7 @@ import {
   readValidatorInitialized,
 } from '../modules/read-core'
 import type { ResolvedModule } from '../modules/types'
+import { OWNABLE_VALIDATOR_ADDRESS } from '../modules/validators/ownable'
 import { SESSION_LOCK_TAG } from '../modules/validators/smart-sessions/authorization'
 import { encodeDisableSessionCall } from '../modules/validators/smart-sessions/calls'
 import { readSessionNonce } from '../modules/validators/smart-sessions/state'
@@ -94,11 +94,7 @@ export async function resolveValidatorInstallation(
 ): Promise<CalldataInput[]> {
   const runtime = actionContext(context)
   if (runtime.construction.account.kind === 'nexus') {
-    const version =
-      runtime.construction.account.version.source === 'explicit'
-        ? runtime.construction.account.version.value
-        : undefined
-    const defaultValidator = nexusDefaultValidator(version)
+    const defaultValidator = OWNABLE_VALIDATOR_ADDRESS
     if (module.address.toLowerCase() === defaultValidator.toLowerCase()) {
       let initialized = defaultValidatorConfigured(runtime, defaultValidator)
       if (!initialized) {

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -45,18 +45,13 @@ interface SafeAccount {
 
 interface NexusAccount {
   type: 'nexus'
-  version?:
-    | '1.0.2'
-    | '1.2.0'
-    | '1.2.1'
-    | 'rhinestone-1.0.0-beta'
-    | 'rhinestone-1.0.0'
+  version?: '1.2.0' | '1.2.1'
   salt?: Hex
 }
 
 interface KernelAccount {
   type: 'kernel'
-  version?: '3.1' | '3.2' | '3.3'
+  version?: '3.3'
   salt?: Hex
 }
 

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -43,19 +43,16 @@ const accountInputArbitrary: fc.Arbitrary<AccountInput> = fc
           ...(choice % 2 === 0 ? { adapter: '1.0.0' } : {}),
         }
       case 'nexus': {
-        const versions = [
-          '1.0.2',
-          '1.2.0',
-          'rhinestone-1.0.0-beta',
-          'rhinestone-1.0.0',
-        ] as const
+        const versions = ['1.2.0', '1.2.1'] as const
         return {
           type: 'nexus',
-          ...(explicit ? { version: versions[choice], salt } : {}),
+          ...(explicit
+            ? { version: versions[choice % versions.length], salt }
+            : {}),
         }
       }
       case 'kernel': {
-        const versions = ['3.1', '3.2', '3.3'] as const
+        const versions = ['3.3'] as const
         return {
           type: 'kernel',
           ...(explicit
@@ -417,13 +414,13 @@ describe('SDK config resolution', () => {
       input: {
         account: {
           type: 'nexus' as const,
-          version: '1.0.2' as const,
+          version: '1.2.0' as const,
           salt: `0x${'33'.repeat(32)}` as const,
         },
       },
       expected: {
         kind: 'nexus',
-        version: { source: 'explicit', value: '1.0.2' },
+        version: { source: 'explicit', value: '1.2.0' },
         salt: { source: 'explicit', value: `0x${'33'.repeat(32)}` },
       },
     },

--- a/src/transactions/user-operations/prepare.ts
+++ b/src/transactions/user-operations/prepare.ts
@@ -1,11 +1,11 @@
 import type { Hex } from 'viem'
-import { nexusDefaultValidator } from '../../accounts/adapters/nexus'
 import { K1_DEFAULT_VALIDATOR_ADDRESS } from '../../accounts/adapters/startale'
 import type { AccountConstruction } from '../../accounts/types'
 import { resolveCalls } from '../../calls/resolve'
 import type { EvmChainReference } from '../../chains/types'
 import type { BundlerUserOperation } from '../../clients/bundler/port'
 import { ENS_HCA_MODULE } from '../../modules/validators/ens'
+import { OWNABLE_VALIDATOR_ADDRESS } from '../../modules/validators/ownable'
 import {
   createAccountSigningContext,
   getSigningValidatorCodec,
@@ -130,11 +130,7 @@ export async function prepareUserOperation<CompatibilityConfig>(
 function defaultUserOperationValidator(construction: AccountConstruction) {
   switch (construction.account.kind) {
     case 'nexus':
-      return nexusDefaultValidator(
-        construction.account.version.source === 'explicit'
-          ? construction.account.version.value
-          : undefined,
-      )
+      return OWNABLE_VALIDATOR_ADDRESS
     case 'startale':
       return K1_DEFAULT_VALIDATOR_ADDRESS
     case 'hca':

--- a/test/vectors/accounts/account-deployment.json
+++ b/test/vectors/accounts/account-deployment.json
@@ -19,40 +19,10 @@
       "factoryDataHash": "0x061b5a8e2cdebe61392e9ef0295fcda20c3ef9a1e5e16f364d26adbdaf725403"
     },
     {
-      "id": "nexus-1.0.2",
-      "address": "0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0",
-      "factory": "0x0000000000679a258c64d2f20f310e12b64b7375",
-      "factoryDataHash": "0xd5636e66ad18a8ae07464cf12e1ae63bcc9873f62bfaeda238eca1dc3df3597e"
-    },
-    {
       "id": "nexus-1.2.0",
       "address": "0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0",
       "factory": "0x0000000000679a258c64d2f20f310e12b64b7375",
       "factoryDataHash": "0xd5636e66ad18a8ae07464cf12e1ae63bcc9873f62bfaeda238eca1dc3df3597e"
-    },
-    {
-      "id": "nexus-rhinestone-beta",
-      "address": "0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0",
-      "factory": "0x0000000000679a258c64d2f20f310e12b64b7375",
-      "factoryDataHash": "0xd5636e66ad18a8ae07464cf12e1ae63bcc9873f62bfaeda238eca1dc3df3597e"
-    },
-    {
-      "id": "nexus-rhinestone-release",
-      "address": "0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0",
-      "factory": "0x0000000000679a258c64d2f20f310e12b64b7375",
-      "factoryDataHash": "0xd5636e66ad18a8ae07464cf12e1ae63bcc9873f62bfaeda238eca1dc3df3597e"
-    },
-    {
-      "id": "kernel-3.1",
-      "address": "0xef76F1eDB9C4918415d5d0aC3Cb4818335Ca68e9",
-      "factory": "0xd703aae79538628d27099b8c4f621be4ccd142d5",
-      "factoryDataHash": "0xef21b650a250e0f92957625337bc22ecc292d2dfba3c0906420503320fcb9150"
-    },
-    {
-      "id": "kernel-3.2",
-      "address": "0xef76F1eDB9C4918415d5d0aC3Cb4818335Ca68e9",
-      "factory": "0xd703aae79538628d27099b8c4f621be4ccd142d5",
-      "factoryDataHash": "0xef21b650a250e0f92957625337bc22ecc292d2dfba3c0906420503320fcb9150"
     },
     {
       "id": "kernel-3.3",

--- a/test/vectors/accounts/account-deployment.test.ts
+++ b/test/vectors/accounts/account-deployment.test.ts
@@ -21,28 +21,8 @@ const configurations: Record<string, () => RhinestoneAccountConfig> = {
     account: { type: 'safe', version: '1.4.1', adapter: '2.0.0' },
     owners: { type: 'ecdsa', accounts: [accountA] },
   }),
-  'nexus-1.0.2': () => ({
-    account: { type: 'nexus', version: '1.0.2' },
-    owners: { type: 'ecdsa', accounts: [accountA] },
-  }),
   'nexus-1.2.0': () => ({
     account: { type: 'nexus', version: '1.2.0' },
-    owners: { type: 'ecdsa', accounts: [accountA] },
-  }),
-  'nexus-rhinestone-beta': () => ({
-    account: { type: 'nexus', version: 'rhinestone-1.0.0-beta' },
-    owners: { type: 'ecdsa', accounts: [accountA] },
-  }),
-  'nexus-rhinestone-release': () => ({
-    account: { type: 'nexus', version: 'rhinestone-1.0.0' },
-    owners: { type: 'ecdsa', accounts: [accountA] },
-  }),
-  'kernel-3.1': () => ({
-    account: { type: 'kernel', version: '3.1' },
-    owners: { type: 'ecdsa', accounts: [accountA] },
-  }),
-  'kernel-3.2': () => ({
-    account: { type: 'kernel', version: '3.2' },
     owners: { type: 'ecdsa', accounts: [accountA] },
   }),
   'kernel-3.3': () => ({


### PR DESCRIPTION
Trim the selectable account `version` values to the versions we actively support.

- **Nexus**: keep `1.2.0` and `1.2.1` (default `1.2.1`); remove `1.0.2`, `rhinestone-1.0.0-beta`, `rhinestone-1.0.0`.
- **Kernel**: keep `3.3` only; remove `3.1`/`3.2`.
- **Safe / Startale / HCA**: unchanged.
- Collapse the now-constant Nexus default-validator resolution and drop the dead `version` plumbing that only fed it.
- Update unit tests + deployment vectors; add a `major` changeset.

**Safe is intentionally out of scope here.** The ticket's "keep 1.4.0" was a typo for the version the SDK actually exposes/deploys today (`1.4.1`), which this PR keeps. Adding `1.5.1` as the default needs real deployment wiring (a distinct singleton / proxy factory / launchpad / 7579 adapter, like Nexus 1.2.0/1.2.1) whose addresses aren't available yet — deferred to a follow-up. RHI-4928 has been updated to match.

Docs companion: rhinestone migration-guide update (separate PR in the docs repo).

Relates to [RHI-4928](https://linear.app/rhinestone/issue/RHI-4928)