### PR TITLE
chore(release): exit prerelease mode and tidy changelog for v2.0.0

### DIFF
--- a/.changeset/avalanche-43114.md
+++ b/.changeset/avalanche-43114.md
@@ -1,5 +1,0 @@
----
-"@rhinestone/sdk": patch
----
-
-Bump @rhinestone/shared-configs to 1.7.15 to add Avalanche C-Chain (43114) support.

--- a/.changeset/bump-shared-configs-1-6-7.md
+++ b/.changeset/bump-shared-configs-1-6-7.md
@@ -1,5 +1,0 @@
----
-'@rhinestone/sdk': patch
----
-
-Bump `@rhinestone/shared-configs` to 1.6.7.

--- a/.changeset/bump-shared-configs.md
+++ b/.changeset/bump-shared-configs.md
@@ -1,5 +1,0 @@
----
-'@rhinestone/sdk': patch
----
-
-Bump `@rhinestone/shared-configs` to 1.5.1.

--- a/.changeset/hypercore-caip2-mainnet.md
+++ b/.changeset/hypercore-caip2-mainnet.md
@@ -2,11 +2,7 @@
 "@rhinestone/sdk": minor
 ---
 
-Use `hypercore:mainnet` as the canonical CAIP-2 id for the HyperCore destination instead of `eip155:1337` (RHI-4560), and source the CAIP-2 ↔ chain-id mapping from `@rhinestone/shared-configs`.
+Use `hypercore:mainnet` as the canonical CAIP-2 id for the HyperCore destination instead of `eip155:1337` (RHI-4560). `eip155:1337` was semantically wrong — 1337 is the Hardhat/Ganache local chain id — and the orchestrator now emits `hypercore:mainnet`.
 
-The orchestrator (shared-configs ≥ 1.6.14) now emits `hypercore:mainnet` for HyperCore — `eip155:1337` was semantically wrong (1337 is the Hardhat/Ganache local chain id). Changes:
-
-- `hyperCoreMainnet.caip2` is `'hypercore:mainnet'`.
-- `caip2.ts` now delegates `toCaip2` / `fromCaip2` / `isNonEvmChainId` to the shared-configs registry instead of maintaining its own hardcoded namespace tables. This removes the SDK↔orchestrator drift risk (both now read the same source) and means new chains are a shared-configs registry entry, not a hand-maintained table in each repo. `fromCaip2` still accepts legacy `eip155:1337` for back-compat.
-
-HyperCore stays EVM-addressed: it's a `virtual` (`vmType: 'evm'`) registry entry, so `isNonEvmChainId(1337) === false` and its EVM token/recipient handling is unchanged. Bumps `@rhinestone/shared-configs` to 1.6.15.
+- `hyperCoreMainnet.caip2` is `'hypercore:mainnet'`. `fromCaip2` still accepts legacy `eip155:1337` for back-compat.
+- HyperCore stays EVM-addressed: it's a `virtual` (`vmType: 'evm'`) entry, so `isNonEvmChainId(1337) === false` and its EVM token/recipient handling is unchanged.

--- a/.changeset/poll-until-intent-expiry.md
+++ b/.changeset/poll-until-intent-expiry.md
@@ -1,6 +1,0 @@
----
-'@rhinestone/sdk': major
----
-
-- `account.waitForExecution` now polls until the intent's quote `expiresAt`, replacing the previous hardcoded 3.5-minute cap. The orchestrator's `EXPIRED` status is treated as terminal.
-- Renamed `IntentStatusTimeoutError` to `IntentExpiredError`. Update any `catch` / `instanceof` checks accordingly.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@rhinestone/sdk": "1.5.0"

--- a/.changeset/robinhood-chain.md
+++ b/.changeset/robinhood-chain.md
@@ -1,8 +1,0 @@
----
-"@rhinestone/sdk": patch
----
-
-Bump @rhinestone/shared-configs to 1.7.8 to add Robinhood Chain (4663). Raise the
-`viem` peer floor to ^2.55.0 — shared-configs 1.7.8's generated networks import
-`robinhood` from `viem/chains`, which was added in viem 2.55.0; on older viem the
-package crashes at module load.

--- a/.changeset/tron-caip2-mainnet.md
+++ b/.changeset/tron-caip2-mainnet.md
@@ -2,6 +2,4 @@
 '@rhinestone/sdk': patch
 ---
 
-Use `tron:mainnet` as Tron's canonical CAIP-2 (was `tron:0x2b6653dc`).
-
-Updates the hardcoded `tronMainnet` destination descriptor and bumps `@rhinestone/shared-configs` to `^1.7.0`, so `toCaip2(728126428)` / `fromCaip2('tron:mainnet')` resolve via the registry. Hard cutover: `tron:0x2b6653dc` no longer resolves. Requires shared-configs ≥ 1.7.0.
+Use `tron:mainnet` as Tron's canonical CAIP-2 (was `tron:0x2b6653dc`). Updates the hardcoded `tronMainnet` destination descriptor so `toCaip2(728126428)` and `fromCaip2('tron:mainnet')` resolve. Hard cutover: `tron:0x2b6653dc` no longer resolves.

--- a/.changeset/wait-for-terminal-state.md
+++ b/.changeset/wait-for-terminal-state.md
@@ -2,7 +2,7 @@
 '@rhinestone/sdk': major
 ---
 
-- `account.waitForExecution` now polls until the intent reaches a terminal state (`COMPLETED` or `FAILED`), without an SDK-side deadline. The previous `expiresAt`-based timeout was unreliable for some flows (e.g. intent executor); the orchestrator handles expiry internally and surfaces it as `FAILED`.
-- Removed the `IntentExpiredError` class — expiry now surfaces as `IntentFailedError` (inspect `operations[].failureReason` for the cause).
+- `account.waitForExecution` now polls until the intent reaches a terminal state (`COMPLETED` or `FAILED`), with no SDK-side deadline (previously capped at 3.5 minutes). The orchestrator handles expiry internally and surfaces it as `FAILED`.
+- Removed the `IntentStatusTimeoutError` class — expiry now surfaces as `IntentFailedError` (inspect `operations[].failureReason` for the cause).
 - Removed the `expiresAt` field from `TransactionResult`.
 - Narrowed `SettlementLayerFilter` to `CrossChainSettlementLayer[]` (`ACROSS | ECO | RELAY | OFT | NEAR | RHINO | CCTP`) — `SAME_CHAIN` and `INTENT_EXECUTOR` are picked by the orchestrator and were never accepted in the filter at runtime.


### PR DESCRIPTION
Exits changeset pre-release mode so the next `changeset version` run folds all accumulated v2 changesets into a clean, non-beta **`2.0.0`**. Verified locally (`pre exit` + `changeset version` → `2.0.0`, all changesets consumed, no orphans).

Also tidies the aggregate 2.0.0 changelog (only visible once pre mode exits — the earlier per-changeset polish couldn't see it):

- Drop three pure `@rhinestone/shared-configs` dependency-bump notes (`1.5.1`, `1.6.7`, `1.7.15`) — noise that contradicts the headline change that v2 no longer depends on shared-configs.
- Drop the Robinhood-chain note: its only stable-relevant fact was the `viem` `^2.55.0` peer floor, but v1 (`1.12.0`) is already on `^2.55.0`, so it is a no-op for 2.0.0.
- Reconcile the superseded `waitForExecution` timeout narrative into a single entry stated against the v1 baseline (3.5-minute cap, `IntentStatusTimeoutError`).
- Trim stale shared-configs internals from the HyperCore and Tron CAIP-2 notes (v2 src has no shared-configs import) while keeping the real canonical-id changes.

### On merge
The Release workflow runs `changeset version` (now out of pre mode) and opens a **Release PR** proposing `2.0.0`. Merging *that* PR publishes `2.0.0` to npm and flips the `@latest` tag from v1 (`1.12.0`) to v2. v2 requires a prod orchestrator that returns `wrappedNativeToken` on `/chains`.

Relates to [RHI-4729](https://linear.app/rhinestone/issue/RHI-4729/release-v2)