### PR TITLE
chore(release): finalize the v2 branch model

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "updateInternalDependencies": "patch",
   "linked": [],
   "access": "public",
-  "baseBranch": "release",
+  "baseBranch": "main",
   "ignore": [],
   "changelog": "@changesets/cli/changelog"
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,9 +101,9 @@ jobs:
 
       # Regenerate the SDK reference and open/update a PR in the docs repo, but
       # only when a real publish happened (not when the Release PR is merely
-      # opened/updated). Gated to the v2 line — flip `release` to `main` when v2
-      # graduates. v1 publishes are intentionally excluded so they can't clobber
-      # the v2 reference the docs site tracks.
+      # opened/updated). Gated to `release` (v2 prod publishes to `@latest`);
+      # `main` only cuts `@dev` snapshots, and v1 publishes are excluded so they
+      # can't clobber the v2 reference the docs site tracks.
       - name: Mint docs-repo token
         if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
         id: docs-token

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,18 +55,18 @@ Keep these in sync with the code — update the relevant doc in the same PR as a
 
 ## Branching
 
-The SDK uses three long-lived branches while v2 stabilizes:
+The SDK uses three long-lived branches:
 
-- `main` — dev releases for **v1** SDK
-- `release` — beta releases for **v2** SDK
-- `v1` — prod releases for **v1** SDK
+- `main` — dev releases for **v2** SDK (snapshots published under the `@dev` tag)
+- `release` — prod releases for **v2** SDK (published to `@latest`)
+- `v1` — prod releases for the legacy **v1** SDK
 
 Where to open PRs:
 
-- **v2 changes** → target `release`
-- **Bug fixes for existing users** → target `main` (will be ported to v1/v2 as needed)
+- **v2 changes** (features and fixes) → target `main`
+- **v1 fixes** → target `v1`
 
-Once v2 is stable, we'll switch back to the standard `main` (dev) / `release` (prod) flow.
+The release process: push `main` for a v2 dev release, `release` for a v2 release, `v1` for a v1 release.
 
 ## Patterns
 


### PR DESCRIPTION
Now that v2 is a stable `2.0.0` on npm `@latest` and `main` carries v2, finalize the branch model to the standard `main` (dev) / `release` (prod) / `v1` (legacy) flow.

- `.changeset/config.json`: `baseBranch` `release` → `main`.
- `AGENTS.md`: rewrite the Branching section — `main` is v2 dev (`@dev` snapshots), `release` is v2 prod (`@latest`), `v1` is legacy; v2 PRs target `main`, v1 fixes target `v1`.
- `release.yaml`: correct the SDK-reference docs-sync comment. The step **stays gated to `release`** (that's where the changesets `published` output fires); the old comment said to flip it to `main`, which we deliberately are not doing.

Relates to [RHI-4729](https://linear.app/rhinestone/issue/RHI-4729/release-v2)