### PR TITLE
ci(integration): run live integration tests on PRs

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,6 +19,12 @@ on:
         options:
           - prod
           - dev
+  # On PRs the suite is picked by the base branch: the full suite gates
+  # `release` (v2 prod) PRs, smoke gates `main` (v2 dev) PRs — both against prod.
+  pull_request:
+    branches:
+      - main
+      - release
 
 concurrency:
   group: live-integration-tests
@@ -29,32 +35,48 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # When target=dev, point the SDK at the dev orchestrator. The SDK then
-      # auto-enables dev contract addresses (see createIntegrationSDK), so
-      # bundles simulate against the matching dev deployment. Empty for prod
-      # falls back to the SDK's built-in prod URL + prod contracts.
-      INTEGRATION_ORCHESTRATOR_URL: ${{ inputs.target == 'dev' && 'https://dev.v1.orchestrator.rhinestone.dev' || '' }}
       # Funder for the funded specs in the `all` suite (smoke needs none). The
       # address must hold testnet native + USDC; same testnet key for prod/dev.
       INTEGRATION_FUNDER_PRIVATE_KEY: ${{ secrets.INTEGRATION_FUNDER_PRIVATE_KEY }}
 
     steps:
-      # Resolve the API key explicitly per target. A ternary like
-      # `target == 'dev' && DEV || PROD` would silently fall back to the prod
-      # key when the dev secret is unset (empty is falsy), sending the wrong
-      # credential to the dev endpoint. Fail fast instead.
-      - name: Resolve integration API key
+      # Resolve suite + target. workflow_dispatch honors the chosen inputs; PRs
+      # derive them from the base branch — `release` runs the full suite, `main`
+      # runs smoke — always against prod. The API key is resolved explicitly per
+      # target: a ternary like `target == 'dev' && DEV || PROD` would silently
+      # fall back to the prod key when the dev secret is unset (empty is falsy),
+      # sending the wrong credential to the dev endpoint. Fail fast instead. When
+      # target=dev, point the SDK at the dev orchestrator so it auto-enables dev
+      # contract addresses (see createIntegrationSDK); prod leaves the URL empty
+      # and falls back to the SDK's built-in prod URL + prod contracts.
+      - name: Resolve run config
         env:
-          TARGET: ${{ inputs.target }}
+          EVENT: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          INPUT_SUITE: ${{ inputs.suite }}
+          INPUT_TARGET: ${{ inputs.target }}
           PROD_API_KEY: ${{ secrets.INTEGRATION_RHINESTONE_API_KEY }}
           DEV_API_KEY: ${{ secrets.INTEGRATION_RHINESTONE_API_KEY_DEV }}
         run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            SUITE="$INPUT_SUITE"
+            TARGET="$INPUT_TARGET"
+          elif [ "$BASE_REF" = "release" ]; then
+            SUITE="all"
+            TARGET="prod"
+          else
+            SUITE="smoke"
+            TARGET="prod"
+          fi
+          echo "SUITE=$SUITE" >> "$GITHUB_ENV"
+
           if [ "$TARGET" = "dev" ]; then
             if [ -z "$DEV_API_KEY" ]; then
               echo "::error::target=dev requires the INTEGRATION_RHINESTONE_API_KEY_DEV secret"
               exit 1
             fi
             echo "INTEGRATION_RHINESTONE_API_KEY=$DEV_API_KEY" >> "$GITHUB_ENV"
+            echo "INTEGRATION_ORCHESTRATOR_URL=https://dev.v1.orchestrator.rhinestone.dev" >> "$GITHUB_ENV"
           else
             if [ -z "$PROD_API_KEY" ]; then
               echo "::error::target=prod requires the INTEGRATION_RHINESTONE_API_KEY secret"
@@ -73,9 +95,9 @@ jobs:
         run: bun install
 
       - name: Run smoke integration tests
-        if: ${{ inputs.suite == 'smoke' }}
+        if: env.SUITE == 'smoke'
         run: bun run test:integration:smoke -- --run
 
       - name: Run all integration tests
-        if: ${{ inputs.suite == 'all' }}
+        if: env.SUITE == 'all'
         run: bun run test:integration -- --run

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,9 +19,11 @@ on:
         options:
           - prod
           - dev
-  # On PRs the suite is picked by the base branch: the full suite gates
-  # `release` (v2 prod) PRs, smoke gates `main` (v2 dev) PRs — both against prod.
-  pull_request:
+  # Run on push (post-merge), not pull_request: these jobs hold live credentials
+  # (a prod API key and the funder private key), so they must only ever run
+  # already-reviewed code. The suite is picked by branch — full suite on release
+  # (v2 prod), smoke on main (v2 dev) — both against prod.
+  push:
     branches:
       - main
       - release
@@ -40,9 +42,9 @@ jobs:
       INTEGRATION_FUNDER_PRIVATE_KEY: ${{ secrets.INTEGRATION_FUNDER_PRIVATE_KEY }}
 
     steps:
-      # Resolve suite + target. workflow_dispatch honors the chosen inputs; PRs
-      # derive them from the base branch — `release` runs the full suite, `main`
-      # runs smoke — always against prod. The API key is resolved explicitly per
+      # Resolve suite + target. workflow_dispatch honors the chosen inputs; pushes
+      # derive them from the branch — `release` runs the full suite, `main` runs
+      # smoke — always against prod. The API key is resolved explicitly per
       # target: a ternary like `target == 'dev' && DEV || PROD` would silently
       # fall back to the prod key when the dev secret is unset (empty is falsy),
       # sending the wrong credential to the dev endpoint. Fail fast instead. When
@@ -52,7 +54,7 @@ jobs:
       - name: Resolve run config
         env:
           EVENT: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref_name }}
           INPUT_SUITE: ${{ inputs.suite }}
           INPUT_TARGET: ${{ inputs.target }}
           PROD_API_KEY: ${{ secrets.INTEGRATION_RHINESTONE_API_KEY }}
@@ -61,7 +63,7 @@ jobs:
           if [ "$EVENT" = "workflow_dispatch" ]; then
             SUITE="$INPUT_SUITE"
             TARGET="$INPUT_TARGET"
-          elif [ "$BASE_REF" = "release" ]; then
+          elif [ "$REF_NAME" = "release" ]; then
             SUITE="all"
             TARGET="prod"
           else


### PR DESCRIPTION
Makes the live integration suite run on PRs, gated by base branch:

- PRs to **`release`** (v2 prod) → **full** `all` suite
- PRs to **`main`** (v2 dev) → **smoke** suite
- both against **prod**

`workflow_dispatch` still works as before (explicit `suite`/`target` inputs). Suite/target resolution and the fail-fast API-key check moved into one "Resolve run config" step.

Notes:
- Lands on `main`; propagates to `release` on the next `main`→`release` promotion, and the full-suite gate already fires on those promotion PRs (head is `main`).
- These are live testnet runs serialized by the existing `live-integration-tests` concurrency group, so PRs queue — worth watching for a backlog; tune the group/triggers if it bites.
- Fork PRs have no secrets, so the resolve step fails fast by design; expected to be internal-only PRs.

Relates to [RHI-4729](https://linear.app/rhinestone/issue/RHI-4729/release-v2)