### PR TITLE
ci(shared-configs): target the v1 line for auto-bumps

### DIFF
--- a/.github/workflows/update-shared-configs.yaml
+++ b/.github/workflows/update-shared-configs.yaml
@@ -12,7 +12,11 @@ jobs:
   upgrade-shared-configs:
     runs-on: ubuntu-latest
     steps:
+      # v2 (on `main`) no longer bundles `@rhinestone/shared-configs`, so the
+      # auto-bump only applies to the legacy v1 line — check out and PR v1.
       - uses: actions/checkout@v4
+        with:
+          ref: v1
 
       - name: Detect package manager
         id: pm
@@ -133,4 +137,5 @@ jobs:
 
           ---
           *Created automatically by [yeet](https://github.com/rhinestonewtf/yeet) publish workflow.*" \
+            --base v1 \
             --head "${{ steps.vars.outputs.branch }}"


### PR DESCRIPTION
v2 (now on `main`) dropped the `@rhinestone/shared-configs` dependency and reads chain data from the orchestrator at runtime, so shared-configs bumps only make sense for the legacy **v1** SDK.

The `update-shared-configs` workflow runs from the default branch (`main`) on `repository_dispatch`, but now checks out **`v1`** and opens its bump PR against **`v1`** instead of `main`.

(The original ticket note said "main and v1", but that predated v2 dropping the dependency — v2 needs no shared-configs bump.)

Relates to [RHI-4729](https://linear.app/rhinestone/issue/RHI-4729/release-v2)