### PR TITLE
ci(compat): fix package-compat smoke tests for ESM-only v2

### DIFF
--- a/.github/scripts/test-node-esm.sh
+++ b/.github/scripts/test-node-esm.sh
@@ -15,16 +15,17 @@ npm pkg set type=module
 # Install the packed SDK using absolute path
 npm install $GITHUB_WORKSPACE/rhinestone-sdk-*.tgz
 
-# Create test script
+# Create test script. The SDK is ESM-only with named exports (no default
+# export), so use a namespace import.
 cat > index.js << 'EOF'
-import sdk from '@rhinestone/sdk';
+import * as sdk from '@rhinestone/sdk';
 console.info('✓ SDK imported successfully');
 
-// Basic smoke test - just try to access main exports
-if (typeof sdk === 'object' && sdk !== null) {
-  console.info('✓ SDK is an object');
+// Basic smoke test - the namespace should expose the public exports.
+if (typeof sdk === 'object' && sdk !== null && typeof sdk.RhinestoneSDK === 'function') {
+  console.info('✓ SDK exposes RhinestoneSDK');
 } else {
-  console.error('✗ SDK import failed - not an object');
+  console.error('✗ SDK import failed - RhinestoneSDK export missing');
   process.exit(1);
 }
 

--- a/.github/scripts/test-react-native.sh
+++ b/.github/scripts/test-react-native.sh
@@ -24,7 +24,7 @@ npm install $GITHUB_WORKSPACE/rhinestone-sdk-*.tgz
 cat > App.tsx << 'EOF'
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import sdk from '@rhinestone/sdk';
+import * as sdk from '@rhinestone/sdk';
 
 export default function App() {
   const [testResult, setTestResult] = React.useState<string>('Testing...');
@@ -64,16 +64,18 @@ const styles = StyleSheet.create({
 });
 EOF
 
-# Create a simple Node.js test to verify the SDK can be imported in a React Native context
-cat > test-import.js << 'EOF'
-const sdk = require('@rhinestone/sdk');
+# Create a simple Node.js test to verify the SDK can be imported in a React Native
+# context. The SDK is ESM-only with named exports, so use an ESM namespace import
+# from a .mjs file (independent of the project's package type).
+cat > test-import.mjs << 'EOF'
+import * as sdk from '@rhinestone/sdk';
 console.info('✓ SDK imported successfully in React Native project');
 
-// Basic smoke test - just try to access main exports
-if (typeof sdk === 'object' && sdk !== null) {
-  console.info('✓ SDK is an object');
+// Basic smoke test - the namespace should expose the public exports.
+if (typeof sdk === 'object' && sdk !== null && typeof sdk.RhinestoneSDK === 'function') {
+  console.info('✓ SDK exposes RhinestoneSDK');
 } else {
-  console.error('✗ SDK import failed - not an object');
+  console.error('✗ SDK import failed - RhinestoneSDK export missing');
   process.exit(1);
 }
 
@@ -81,4 +83,4 @@ console.info('✓ React Native integration test passed');
 EOF
 
 # Run the import test
-node test-import.js
+node test-import.mjs


### PR DESCRIPTION
The package-compat smoke tests were written for v1 (CJS + default export). v2 is **ESM-only with named exports**, so:

- `test-node-esm.sh` used `import sdk from '@rhinestone/sdk'` → `SyntaxError: does not provide an export named 'default'`.
- `test-react-native.sh`'s executed check (`test-import.js`) used `require('@rhinestone/sdk')` → fails on the ESM-only package.

Both now use an ESM **namespace** import (`import * as sdk`) and assert the `RhinestoneSDK` named export. The react-native check moves to a `.mjs` file so it's ESM regardless of the Expo project's package type.

These never actually ran on v2 before — the compat workflow was `startup_failure`ing on a non-allow-listed action (`actions/upload-artifact@v4`, now allow-listed), so this is the first time the matrix executes against v2. Needed so the `test (node-esm)` / `test (react-native)` required checks pass on `main` PRs.

Relates to [RHI-4729](https://linear.app/rhinestone/issue/RHI-4729/release-v2)