### PR TITLE
chore(release): add protocolFees changeset, publish v1 under `v1` tag

### DIFF
--- a/.changeset/protocol-fees.md
+++ b/.changeset/protocol-fees.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add the `protocolFees` transaction option to configure the Rhinestone protocol fee, and support sponsoring it via `sponsored.protocolFees`.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,10 @@
 name: Release
 
 # Push to main publishes a snapshot (@dev tag); push to release or v1
-# runs changesets/action to open a Release PR or publish to npm.
-# Publishes use OIDC trusted publishing; release PRs are opened by the
-# rhinestone-automations GitHub App.
+# runs changesets/action to open a Release PR or publish to npm. On this
+# v1 line, publishes target the `v1` dist-tag so they don't move `latest`
+# (which tracks the v2 line). Publishes use OIDC trusted publishing;
+# release PRs are opened by the rhinestone-automations GitHub App.
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,18 +35,18 @@ Docs: https://docs.rhinestone.dev/smart-wallet
 
 ## Branching
 
-The SDK uses three long-lived branches while v2 stabilizes:
+The SDK uses three long-lived branches:
 
-- `main` — dev releases for **v1** SDK
-- `release` — beta releases for **v2** SDK
-- `v1` — prod releases for **v1** SDK
+- `main` — dev releases for **v2** SDK (snapshots published under the `@dev` tag)
+- `release` — prod releases for **v2** SDK (published to `@latest`)
+- `v1` — prod releases for the legacy **v1** SDK (published under the `@v1` tag)
 
 Where to open PRs:
 
-- **v2 changes** → target `release`
-- **Bug fixes for existing users** → target `main` (will be ported to v1/v2 as needed)
+- **v2 changes** (features and fixes) → target `main`
+- **v1 fixes** → target `v1`
 
-Once v2 is stable, we'll switch back to the standard `main` (dev) / `release` (prod) flow.
+The release process: push `main` for a v2 dev release, `release` for a v2 release, `v1` for a v1 release.
 
 ## Patterns
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check": "biome check",
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",
-    "changeset:release": "bun run build && changeset publish",
+    "changeset:release": "bun run build && changeset publish --tag v1",
     "changeset:version": "changeset version && bun run scripts/sync-version.ts",
     "size": "size-limit"
   },


### PR DESCRIPTION
The protocolFees feature (RHI-4904) was merged onto the `v1` line (via #684) **without a changeset**, so it was never versioned or published on the v1.x line.

- Adds a **minor** changeset for `protocolFees` → next v1 release is `1.13.0`.
- Changes the v1 publish to `changeset publish --tag v1`, so v1.x releases go to the **`v1` npm dist-tag** and **don't move `latest`** — which now tracks the v2 line (`2.0.0`).
- Reconciles the stale `## Branching` note in `AGENTS.md` (it still described the old "while v2 stabilizes" model) to match `main`/`release`, and documents the `@v1` publish tag.

### Release flow after merge
1. Merging this into `v1` triggers changesets/action → opens the **Release** PR (bumps to `1.13.0`).
2. Merging that Release PR publishes `@rhinestone/sdk@1.13.0` under `npm dist-tag v1` (installable via `@rhinestone/sdk@v1`).

Note: the feature is already shipped for v2 users in `2.0.0` on `latest`; this only backfills the v1.x line.