### PR TITLE
fix(release): publish v1 line under `v1-latest` dist-tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ The SDK uses three long-lived branches:
 
 - `main` — dev releases for **v2** SDK (snapshots published under the `@dev` tag)
 - `release` — prod releases for **v2** SDK (published to `@latest`)
-- `v1` — prod releases for the legacy **v1** SDK (published under the `@v1` tag)
+- `v1` — prod releases for the legacy **v1** SDK (published under the `@v1-latest` tag)
 
 Where to open PRs:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check": "biome check",
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",
-    "changeset:release": "bun run build && changeset publish --tag v1",
+    "changeset:release": "bun run build && changeset publish --tag v1-latest",
     "changeset:version": "changeset version && bun run scripts/sync-version.ts",
     "size": "size-limit"
   },


### PR DESCRIPTION
The `1.13.0` publish (#693) failed: npm rejects `v1` as a dist-tag because it parses as a valid SemVer range (`Tag name must not be a valid SemVer range: v1`).

- Switches the v1 publish to `changeset publish --tag v1-latest` (not a valid semver range, so npm accepts it).
- Updates the `AGENTS.md` branching note accordingly.

Nothing was published under the bad tag — the publish aborted before upload, so `latest` still points at `2.0.0`. Merging this re-triggers the workflow, which publishes the already-bumped `1.13.0` under `@v1-latest` (installable via `@rhinestone/sdk@v1-latest`).