### PR TITLE
ci: pin all GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Check out the repo
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install the npm dependencies
         run: bun install
@@ -53,12 +53,12 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Check out the repo
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install the npm dependencies
         run: bun install

--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -17,10 +17,10 @@ jobs:
     steps:
       # Setup and Build
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload contract result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sdk-package-contract
           path: ${{ runner.temp }}/sdk-contract-results/contract-result.json

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -88,10 +88,10 @@ jobs:
           fi
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install the npm dependencies
         run: bun install
@@ -52,18 +52,18 @@ jobs:
       - name: Mint release-bot token
         if: github.ref == 'refs/heads/release' || github.ref == 'refs/heads/v1'
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check out the repo
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Use OIDC-capable npm
         run: sudo npm install -g npm@11
@@ -84,7 +84,7 @@ jobs:
       - name: Create Release Pull Request or Publish
         if: github.ref == 'refs/heads/release' || github.ref == 'refs/heads/v1'
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           commit: "chore: release"
           title: "Release"
@@ -107,7 +107,7 @@ jobs:
       - name: Mint docs-repo token
         if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
         id: docs-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Checkout docs repo
         if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
-        uses: "actions/checkout@v4"
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ${{ github.repository_owner }}/docs
           ref: main

--- a/.github/workflows/sync-wire-types.yaml
+++ b/.github/workflows/sync-wire-types.yaml
@@ -35,7 +35,7 @@ jobs:
           repositories: sdk
 
       - name: Check out the repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-shared-configs.yaml
+++ b/.github/workflows/update-shared-configs.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # v2 (on `main`) no longer bundles `@rhinestone/shared-configs`, so the
       # auto-bump only applies to the legacy v1 line — check out and PR v1.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: v1
 
@@ -46,17 +46,17 @@ jobs:
 
       - name: Setup Bun
         if: steps.pm.outputs.name == 'bun'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Setup Node
         if: steps.pm.outputs.name != 'bun'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 
       - name: Setup pnpm
         if: steps.pm.outputs.name == 'pnpm'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Resolve version
         id: resolve


### PR DESCRIPTION
Pins every action `uses:` ref to a full-length commit SHA, with the version as a trailing comment.

- 23 previously-unpinned refs across `ci`, `compatibility-tests`, `integration-tests`, `release`, `update-shared-configs`
- Re-pins `sync-wire-types.yaml` from checkout v4.3.1 to v4.4.0 so one SHA per action holds repo-wide
- Every SHA is the newest patch **within the major already in use** — no major bumps. `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` stay on v4 despite v7 being current upstream.
- All pins are byte-identical to what CI resolves today, except `pnpm/action-setup`: its floating `v4` tag still points at v4.3.0 because upstream never moved it to v4.4.0.

The repo action allowlist has already been switched to `owner/repo@*` patterns, so these SHAs are permitted. Once this and the `release` / `v1` counterparts land, "Require actions to be pinned to a full-length commit SHA" can be enabled — the wildcard allowlist gates *which* actions run while the toggle enforces the SHA form, so future bumps need no allowlist edit.

Ports: #698 (`release`), #699 (`v1`)