### PR TITLE
ci: unblock release PRs and scope main-only automation

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -7,7 +7,10 @@ on:
       - release
 
 jobs:
-  test:
+  # Distinct from the `test` job in ci.yaml: a shared job name produces two check
+  # runs with the same context, which a required-status-check rule can't tell
+  # apart.
+  package-compat:
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/sync-wire-types.yaml
+++ b/.github/workflows/sync-wire-types.yaml
@@ -23,6 +23,10 @@ concurrency:
 jobs:
   sync:
     name: Bump the openapi pin and open a PR
+    # `schedule` only ever fires on the default branch, but this file also rides
+    # the main -> release merge, so a manual dispatch from `release` would bump
+    # the pin against release's tree and open a nonsense PR into `main`.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Mint rhinestone-automations token


### PR DESCRIPTION
Main → release PRs were unmergeable: `test (node-esm)` and `test (react-native)` sat permanently on *"Expected — Waiting for status to be reported"*.

Cause: the compat matrix job in `compatibility-tests.yaml` is gated on `if: github.base_ref == 'main'`. A false job-level `if` skips the job **before** matrix expansion, so GitHub emits a single check run named `test` (skipped) and the matrix-suffixed contexts are never created. The `release` ruleset required exactly those two contexts, so it waited forever.

- Ruleset (applied out-of-band, id `19675329`) now requires `build`, `test`, `release-package-contract` — the last being the job that actually runs on release-targeted PRs. Also renamed from `main` to `release`, since its condition only ever matched `refs/heads/release`.
- Renamed the compat job `test` → `package-compat`. Both `ci.yaml` and `compatibility-tests.yaml` had a job named `test`, so the required `test` context matched two check runs.
- Gated `sync-wire-types` to `main`. `schedule` only fires on the default branch, but the file rides the main → release merge, so a manual dispatch from `release` would have bumped the openapi pin against release's tree and opened a nonsense PR into `main`.

No source changes; workflow YAML only.