### PR TITLE
test(contract): make the package gate bump-aware

### DIFF
--- a/.size-limit.ts
+++ b/.size-limit.ts
@@ -40,6 +40,13 @@ const limits = [
     ignore: viem,
   },
   {
+    name: '@rhinestone/sdk/actions/recovery',
+    path: `${packageRoot}/actions/recovery.js`,
+    limit: '25 kB',
+    import: '*',
+    ignore: viem,
+  },
+  {
     name: '@rhinestone/sdk/signing/passkeys',
     path: `${packageRoot}/signing/passkeys.js`,
     limit: '1 kB',

--- a/scripts/contract/shared.ts
+++ b/scripts/contract/shared.ts
@@ -101,7 +101,10 @@ function changesetNamesInRef(ref: string, cwd: string): Set<string> | null {
 // unreleased changesets — and, in changeset pre mode, released ones too until
 // pre exit — so diffing against the base is the only reliable signal for what
 // this PR changes. Returns null when the base tree can't be read.
-function declaredSdkBump(baseSha: string, cwd: string): SemverBump | null {
+export function declaredSdkBump(
+  baseSha: string,
+  cwd: string,
+): SemverBump | null {
   const changesetDirectory = join(cwd, '.changeset')
   if (!existsSync(changesetDirectory)) return null
   const baseChangesets = changesetNamesInRef(baseSha, cwd)

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import sizeLimits from '../../.size-limit.ts'
 import type { ApiReport } from '../../scripts/contract/api-report.ts'
 import {
-  declaresSurfaceChange,
+  declaredSdkBump,
   type PackageManifest,
 } from '../../scripts/contract/shared.ts'
 
@@ -89,12 +89,14 @@ function normalizeExportTargets(
   )
 }
 
-function publicManifestContract(manifest: PackageManifest) {
+// Publish metadata only, deliberately excluding `exports`: adding an entry
+// point is the one manifest change a declared surface change may make, so the
+// export map is compared separately and this stays strict either way.
+function publishMetadataContract(manifest: PackageManifest) {
   return {
     name: manifest.name,
     type: manifest.type,
     types: manifest.types,
-    exports: normalizeExportTargets(manifest.exports),
     files: manifest.files,
     peerDependencies: manifest.peerDependencies,
     peerDependenciesMeta: manifest.peerDependenciesMeta,
@@ -159,12 +161,21 @@ function privateSourceImports(packageDirectory: string): string[] {
   return violations
 }
 
-// When the PR declares an intentional surface change (a minor/major changeset),
-// the strict "no drift" assertions are relaxed to well-formedness checks. The
-// strict gate stays on for patch-only PRs so accidental, undocumented breaks
-// still fail. `run.ts` gates the bidirectional assignability fixture on the same
-// signal, so the whole contract suite relaxes together.
-const intentionalSurfaceChange = declaresSurfaceChange(baseSha, process.cwd())
+// Strictness follows the declared bump:
+//
+// - patch (or no new changeset, or an unreadable base): exact equality, so
+//   accidental undocumented drift fails.
+// - minor: additive only. New entry points, exports, and symbols are allowed,
+//   but everything the base published must still be there. Shapes may widen —
+//   adding a union member changes a symbol's report while staying compatible —
+//   so existing symbols are checked for presence, not equality.
+// - major: well-formedness only. Removals are the point of a major.
+//
+// `run.ts` gates the bidirectional assignability fixture on the same signal.
+const declaredBump = declaredSdkBump(baseSha, process.cwd())
+const intentionalSurfaceChange =
+  declaredBump === 'minor' || declaredBump === 'major'
+const additiveOnly = declaredBump === 'minor'
 
 describe('packed package contract', () => {
   it('uses a concrete release commit as the base subject', () => {
@@ -179,13 +190,25 @@ describe('packed package contract', () => {
       join(currentPackageDirectory, 'package.json'),
     )
 
-    expect(currentManifest.name).toBe(baseManifest.name)
-    expect(normalizeExportTargets(currentManifest.exports)).toEqual(
-      normalizeExportTargets(baseManifest.exports),
+    // Publish metadata must never drift, declared surface change or not.
+    expect(publishMetadataContract(currentManifest)).toEqual(
+      publishMetadataContract(baseManifest),
     )
-    expect(publicManifestContract(currentManifest)).toEqual(
-      publicManifestContract(baseManifest),
-    )
+    const baseTargets = normalizeExportTargets(baseManifest.exports)
+    const currentTargets = normalizeExportTargets(currentManifest.exports)
+    if (!intentionalSurfaceChange) {
+      // The export map is the one part a declared surface change may alter.
+      // Adding a subpath export is otherwise unshippable, since the base
+      // manifest is packed from `release` and can never contain it.
+      expect(currentTargets).toEqual(baseTargets)
+    } else if (additiveOnly) {
+      for (const [entrypoint, target] of Object.entries(baseTargets)) {
+        expect(
+          currentTargets[entrypoint],
+          `minor dropped or retargeted entry point ${entrypoint}`,
+        ).toEqual(target)
+      }
+    }
 
     for (const manifestDirectory of [
       basePackageDirectory,
@@ -202,14 +225,17 @@ describe('packed package contract', () => {
   })
 
   it('keeps a size gate for every published entry point', () => {
-    const baseManifest = readJson<PackageManifest>(
-      join(basePackageDirectory, 'package.json'),
+    // Derived from the current manifest, not the base: a newly added entry
+    // point has to carry a size gate in the same PR, and a base-derived
+    // expectation would instead demand the gate be absent until release.
+    const currentManifest = readJson<PackageManifest>(
+      join(currentPackageDirectory, 'package.json'),
     )
-    const entrypoints = Object.entries(baseManifest.exports)
+    const entrypoints = Object.entries(currentManifest.exports)
     const expectedNames = entrypoints.map(([entrypoint]) =>
       entrypoint === '.'
-        ? baseManifest.name
-        : `${baseManifest.name}/${entrypoint.slice(2)}`,
+        ? currentManifest.name
+        : `${currentManifest.name}/${entrypoint.slice(2)}`,
     )
     const flattenPath = (path: string): string =>
       path.replace(/^(\.\/src\/dist\/src\/).*\/([^/]+)$/, '$1$2')
@@ -242,6 +268,21 @@ describe('packed package contract', () => {
           `entry point ${entrypoint} exports nothing`,
         ).toBeGreaterThan(0)
       }
+      if (additiveOnly) {
+        for (const [entrypoint, names] of Object.entries(baseExports)) {
+          const current = currentExports[entrypoint]
+          expect(
+            current,
+            `minor dropped entry point ${entrypoint}`,
+          ).toBeDefined()
+          for (const name of names) {
+            expect(
+              current,
+              `minor dropped runtime export ${entrypoint}:${name}`,
+            ).toContain(name)
+          }
+        }
+      }
       return
     }
 
@@ -269,6 +310,41 @@ describe('packed package contract', () => {
       expect(Object.keys(currentApiReport.entrypoints).length).toBeGreaterThan(
         0,
       )
+      if (additiveOnly) {
+        // Declaration text may widen under a minor, so shapes aren't compared —
+        // that's the assignability fixture's job. What must survive is the
+        // symbol and its type/value nature: swapping a type-only export for a
+        // value of the same name breaks `import type { X }` consumers, and
+        // gaining a nature is additive.
+        for (const [entrypoint, symbols] of Object.entries(
+          baseApiReport.entrypoints,
+        )) {
+          const current = currentApiReport.entrypoints[entrypoint]
+          expect(
+            current,
+            `minor dropped declaration entry point ${entrypoint}`,
+          ).toBeDefined()
+          for (const [symbol, report] of Object.entries(symbols)) {
+            const currentReport = current?.[symbol]
+            expect(
+              currentReport,
+              `minor dropped declared export ${entrypoint}:${symbol}`,
+            ).toBeDefined()
+            if (report.hasType) {
+              expect(
+                currentReport?.hasType,
+                `minor stopped exporting ${entrypoint}:${symbol} as a type`,
+              ).toBe(true)
+            }
+            if (report.hasValue) {
+              expect(
+                currentReport?.hasValue,
+                `minor stopped exporting ${entrypoint}:${symbol} as a value`,
+              ).toBe(true)
+            }
+          }
+        }
+      }
       return
     }
     expect(currentApiReport).toEqual(baseApiReport)
@@ -321,9 +397,22 @@ describe('packed package contract', () => {
 
   it('imports the root without optional server peers', () => {
     const baseResult = runProbe<string[]>(baseNoOptionalDirectory, 'root')
-    expect(runProbe<string[]>(currentNoOptionalDirectory, 'root')).toEqual(
-      baseResult,
-    )
+    const currentResult = runProbe<string[]>(currentNoOptionalDirectory, 'root')
+
+    // Follows the same bump-aware strictness as the other surface assertions,
+    // so a minor may add a root export without tripping this, and may not drop
+    // one. The root must always import cleanly without the optional peers.
+    expect(currentResult.length).toBeGreaterThan(0)
+    if (!intentionalSurfaceChange) {
+      expect(currentResult).toEqual(baseResult)
+    } else if (additiveOnly) {
+      for (const name of baseResult) {
+        expect(
+          currentResult,
+          `minor dropped root export ${name} in the no-optional-peers install`,
+        ).toContain(name)
+      }
+    }
   })
 
   it('preserves optional-peer behavior for the JWT server entry point', () => {


### PR DESCRIPTION
Unblocks the `main → release` promotion (#705), where `release-package-contract` fails on the new `./actions/recovery` subpath export — and fixes the reason that check had nothing useful to say about it.

### The gate wasn't semver-aware

It treated any minor/major changeset as "anything goes". A declared minor turned four surface assertions off entirely, which inverts the point of a package contract test: a minor is *by definition* additive, so it's the case where "nothing was removed" is both checkable and worth checking. Meanwhile the manifest export map was strict even for a minor, so adding a subpath export was unshippable — the base is packed from `origin/release` and can never contain it.

Strictness now follows the declared bump:

| bump | behavior |
| --- | --- |
| patch / none | exact equality, unchanged |
| minor | additive only — additions allowed, anything the base published must still be there |
| major | well-formedness only, unchanged |

For a minor, existing symbols are checked for **presence**, not equality: a minor may legitimately widen a type (adding a union member changes a symbol's report while staying backward-compatible), and the assignability fixture is the right tool for shape compatibility.

Applied to all four surface assertions — including `imports the root without optional server peers`, which was unconditionally strict and would have blocked any minor that adds a root runtime export. Recovery only added *type* exports, so it happened to slip past that one.

### Publish metadata stays strict

Per review: `publicManifestContract` bundled `exports` with `type`, `types`, `files`, peer metadata, and `publishConfig`, so relaxing it wholesale hid unrelated publish drift. Split into `publishMetadataContract` (no `exports`), compared unconditionally.

### Size gate derived from the current manifest

It built expectations from the base manifest, inverting its own intent: a new entry point was required to have *no* size limit until it shipped, then required to have one after — so one release cycle fails either way. Added the missing `actions/recovery` limit (9.88 kB against 25 kB).

### Verification

The gate only runs where `origin/release` is an ancestor of HEAD, so I reproduced #705's merge in a worktree and ran the matrix:

| scenario | expected | result |
| --- | --- | --- |
| minor + added subpath (the real case) | pass | **11/11 pass** |
| no changeset + added subpath | fail | **3 failures** |
| minor + dropped root export | fail | **3 failures**, named assertions |
| major + dropped root export | pass | **11/11 pass** |
| `files` drift + minor | fail | **fails** on metadata |

The dropped-export case is the one that matters: `MULTI_FACTOR_VALIDATOR_ADDRESS` isn't referenced by the consumer fixture, so before this change removing it under a minor would have shipped silently. Entry-point removals were already caught earlier by the consumer fixture failing to compile; named-export removals were not.

### Deferred

`run.ts` still skips the assignability fixture wholesale on any declared surface change. The fixture already separates the two directions — `ReleaseToCurrent` (existing consumer code still compiles) and `CurrentToRelease` (breaks on widening) — so a minor could run the first and skip the second, rather than skipping both. That needs fixture restructuring and changes behavior for every future release, so it's tracked on the ticket rather than bundled here.

Closes [RHI-5121](https://linear.app/rhinestone/issue/RHI-5121)

🤖 Generated with [Claude Code](https://claude.com/claude-code)