### PR TITLE
fix: derive passkey recovery coordinates through the shared parser

### DIFF
--- a/.changeset/fix-passkey-recovery-pubkey-prefix.md
+++ b/.changeset/fix-passkey-recovery-pubkey-prefix.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix `recoverPasskeyOwnership` deriving the wrong coordinates from an uncompressed public key. Keys in the 65-byte SEC1 form carry an `0x04` prefix, and slicing from byte 0 shifted both `pubKeyX` and `pubKeyY`, so recovery installed an unusable credential and then removed the working one. Coordinates now come from the shared WebAuthn parser.

--- a/src/actions/recovery.test.ts
+++ b/src/actions/recovery.test.ts
@@ -377,6 +377,37 @@ describe('Recovery Actions', () => {
       ])
     })
 
+    test('derives coordinates from a prefixed uncompressed public key', async () => {
+      const rhinestoneAccount = await accountPromise
+      // Uncompressed SEC1 keys are 65 bytes with an 0x04 prefix. Slicing from
+      // byte 0 shifts both coordinates, so recovery would install an unusable
+      // credential and then remove the working one.
+      const x = 'aa'.repeat(32)
+      const y = 'bb'.repeat(32)
+      const prefixed = toWebAuthnAccount({
+        credential: { id: 'prefixed', publicKey: `0x04${x}${y}` },
+      })
+      rpcReadContract.mockResolvedValueOnce(1n)
+      const { passkeyAccount } = await import('../../test/consts')
+      const oldCredential = credentialOf(passkeyAccount)
+
+      const calls = await recoverPasskeyOwnership({
+        accountAddress,
+        chain: base,
+        config: rhinestoneAccount.config as never,
+        currentCredentials: [oldCredential],
+        newOwners: { type: 'passkey', accounts: [prefixed] },
+      })
+
+      expect(calls[0]).toEqual(
+        passkeyCall('addCredential', [
+          BigInt(`0x${x}`),
+          BigInt(`0x${y}`),
+          false,
+        ]),
+      )
+    })
+
     test('does not re-add a kept credential when replacing one of several', async () => {
       const rhinestoneAccount = await accountPromise
       // `currentCredentials` is the full installed set, so a credential kept in

--- a/src/actions/recovery.ts
+++ b/src/actions/recovery.ts
@@ -8,7 +8,10 @@ import type {
 } from '../config/account'
 import { OWNABLE_VALIDATOR_ADDRESS } from '../modules/validators/ownable'
 import { resolveSocialRecoveryValidator } from '../modules/validators/social-recovery'
-import { WEBAUTHN_VALIDATOR_ADDRESS } from '../modules/validators/webauthn'
+import {
+  parseWebauthnPublicKey,
+  WEBAUTHN_VALIDATOR_ADDRESS,
+} from '../modules/validators/webauthn'
 import { addOwner, changeThreshold, removeOwner } from './ecdsa'
 import {
   addOwner as addPasskeyOwner,
@@ -151,14 +154,10 @@ async function recoverPasskeyOwnership(
   )
 
   const newCredentials = options.newOwners.accounts.map((account) => {
-    const publicKey = account.publicKey.startsWith('0x')
-      ? account.publicKey.slice(2)
-      : account.publicKey
-    return {
-      pubKeyX: BigInt(`0x${publicKey.slice(0, 64)}`),
-      pubKeyY: BigInt(`0x${publicKey.slice(64, 128)}`),
-      requireUV: false,
-    }
+    // Must go through the shared parser: uncompressed SEC1 keys are 65 bytes
+    // with an 0x04 prefix, and slicing from byte 0 shifts both coordinates.
+    const { x, y } = parseWebauthnPublicKey(account.publicKey)
+    return { pubKeyX: x, pubKeyY: y, requireUV: false }
   })
   const newThreshold = options.newOwners.threshold ?? 1
 


### PR DESCRIPTION
Blocker found by review on #705. Real bug in merged code, not a stale finding — I initially assumed it was stale and was wrong.

### What breaks

`recoverPasskeyOwnership` derived the coordinates by stripping `0x` and slicing from byte 0:

```ts
const publicKey = account.publicKey.slice(2)
pubKeyX: BigInt(`0x${publicKey.slice(0, 64)}`)
pubKeyY: BigInt(`0x${publicKey.slice(64, 128)}`)
```

WebAuthn public keys in the uncompressed SEC1 form are **65 bytes with an `0x04` prefix**, so both coordinates shift by a byte. For `0x04` + 32-byte X + 32-byte Y:

| | value |
| --- | --- |
| expected X | `aaaa…` |
| actual X | `04aaaa…` (prefix + first 31 bytes) |
| Y | shifted one byte |

Recovery then emits `addCredential` for a credential that cannot authenticate, followed by `removeCredential` for the working one. Each is its own user operation and both are authorized by the recovery validator, so an account recovering to a prefixed passkey ends up with **no usable credential**.

### Fix

Use `parseWebauthnPublicKey`, which already handles this (`offset = bytes.length === 65 ? 1 : 0`). Added a regression test with a 65-byte prefixed key and confirmed it fails without the change — reverting the fix turns that test red and nothing else.

### Notes

The parsing was carried over verbatim from the pre-removal implementation, so **v1 is affected too**, as is any earlier v2 beta that shipped this action.

The published docs snippet has the same flaw (`BigInt(slice(publicKey, 0, 32))`), so anyone copying it hits the same corruption. It should use `parsePublicKey` from `@rhinestone/sdk/signing/passkeys`, which is already a public subpath export. Filed separately for the docs repo.

Closes [RHI-5124](https://linear.app/rhinestone/issue/RHI-5124)

🤖 Generated with [Claude Code](https://claude.com/claude-code)