### PR TITLE
fix: honor configured owner validator during recovery

### DIFF
--- a/.changeset/fix-custom-ownable-recovery.md
+++ b/.changeset/fix-custom-ownable-recovery.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Make ECDSA recovery and owner reads use the configured Ownable validator instead of always targeting the canonical deployment.

--- a/src/actions/ecdsa.ts
+++ b/src/actions/ecdsa.ts
@@ -1,9 +1,14 @@
-import { type Address, encodeFunctionData } from 'viem'
+import type { Address } from 'viem'
 import type { CalldataInput, LazyCallInput } from '../config/account'
 import {
   OWNABLE_VALIDATOR_ADDRESS,
   resolveOwnableAddresses,
 } from '../modules/validators/ownable'
+import {
+  addOwnableOwner,
+  changeOwnableThreshold,
+  removeOwnableOwner,
+} from './ownable'
 import {
   resolveModuleUninstallation,
   resolveValidatorInstallation,
@@ -43,23 +48,7 @@ function disable(): LazyCallInput {
  * @returns Call to add the owner
  */
 function addOwner(owner: Address): CalldataInput {
-  return {
-    to: OWNABLE_VALIDATOR_ADDRESS,
-    value: 0n,
-    data: encodeFunctionData({
-      abi: [
-        {
-          inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
-          name: 'addOwner',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        },
-      ],
-      functionName: 'addOwner',
-      args: [owner],
-    }),
-  }
+  return addOwnableOwner(OWNABLE_VALIDATOR_ADDRESS, owner)
 }
 
 /**
@@ -72,26 +61,7 @@ function removeOwner(
   prevOwner: Address,
   ownerToRemove: Address,
 ): CalldataInput {
-  return {
-    to: OWNABLE_VALIDATOR_ADDRESS,
-    value: 0n,
-    data: encodeFunctionData({
-      abi: [
-        {
-          inputs: [
-            { internalType: 'address', name: 'prevOwner', type: 'address' },
-            { internalType: 'address', name: 'owner', type: 'address' },
-          ],
-          name: 'removeOwner',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        },
-      ],
-      functionName: 'removeOwner',
-      args: [prevOwner, ownerToRemove],
-    }),
-  }
+  return removeOwnableOwner(OWNABLE_VALIDATOR_ADDRESS, prevOwner, ownerToRemove)
 }
 
 /**
@@ -100,25 +70,7 @@ function removeOwner(
  * @returns Call to change the threshold
  */
 function changeThreshold(newThreshold: number): CalldataInput {
-  return {
-    to: OWNABLE_VALIDATOR_ADDRESS,
-    value: 0n,
-    data: encodeFunctionData({
-      abi: [
-        {
-          inputs: [
-            { internalType: 'uint256', name: '_threshold', type: 'uint256' },
-          ],
-          name: 'setThreshold',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        },
-      ],
-      functionName: 'setThreshold',
-      args: [BigInt(newThreshold)],
-    }),
-  }
+  return changeOwnableThreshold(OWNABLE_VALIDATOR_ADDRESS, newThreshold)
 }
 
 export { addOwner, removeOwner, changeThreshold, disable, enable }

--- a/src/actions/ownable.ts
+++ b/src/actions/ownable.ts
@@ -1,0 +1,77 @@
+import { type Address, encodeFunctionData } from 'viem'
+import type { CalldataInput } from '../config/account'
+
+export function addOwnableOwner(
+  validator: Address,
+  owner: Address,
+): CalldataInput {
+  return {
+    to: validator,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: [
+        {
+          inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],
+          name: 'addOwner',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      functionName: 'addOwner',
+      args: [owner],
+    }),
+  }
+}
+
+export function removeOwnableOwner(
+  validator: Address,
+  prevOwner: Address,
+  ownerToRemove: Address,
+): CalldataInput {
+  return {
+    to: validator,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            { internalType: 'address', name: 'prevOwner', type: 'address' },
+            { internalType: 'address', name: 'owner', type: 'address' },
+          ],
+          name: 'removeOwner',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      functionName: 'removeOwner',
+      args: [prevOwner, ownerToRemove],
+    }),
+  }
+}
+
+export function changeOwnableThreshold(
+  validator: Address,
+  newThreshold: number,
+): CalldataInput {
+  return {
+    to: validator,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            { internalType: 'uint256', name: '_threshold', type: 'uint256' },
+          ],
+          name: 'setThreshold',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      functionName: 'setThreshold',
+      args: [BigInt(newThreshold)],
+    }),
+  }
+}

--- a/src/actions/recovery.test.ts
+++ b/src/actions/recovery.test.ts
@@ -249,6 +249,24 @@ describe('Recovery Actions', () => {
       expect(rpcMulticall).not.toHaveBeenCalled()
     })
 
+    test('accepts a matching recovery owner validator', async () => {
+      const rhinestoneAccount = await rhinestone.createAccount({
+        owners: {
+          type: 'ecdsa',
+          accounts: [accountA],
+          module: alternateOwnable,
+        },
+      })
+      ownershipIs([accountA.address.toLowerCase() as Address], 1)
+
+      await expect(
+        ecdsaRecovery(rhinestoneAccount.config, {
+          accounts: [accountA],
+          module: alternateOwnable,
+        }),
+      ).resolves.toEqual([])
+    })
+
     test('raises the threshold only after the new owners exist', async () => {
       const rhinestoneAccount = await accountPromise
       // 1-of-1 -> 2-of-2. setThreshold(2) reverts with InvalidThreshold while

--- a/src/actions/recovery.test.ts
+++ b/src/actions/recovery.test.ts
@@ -38,6 +38,7 @@ import {
 } from './recovery'
 
 const accountAddress: Address = '0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0'
+const alternateOwnable: Address = '0x2483da3a338895199e5e538530213157e931bf06'
 const SENTINEL: Address = '0x0000000000000000000000000000000000000001'
 
 // Extra passkeys, so rotation tests have distinct credentials to move between.
@@ -77,6 +78,7 @@ async function resolveCallInputs(
 function ownableCall(
   functionName: 'addOwner' | 'removeOwner' | 'setThreshold',
   args: readonly unknown[],
+  validator: Address = OWNABLE_VALIDATOR_ADDRESS,
 ) {
   const abi = {
     addOwner: [{ name: 'owner', type: 'address' }],
@@ -87,7 +89,7 @@ function ownableCall(
     setThreshold: [{ name: '_threshold', type: 'uint256' }],
   }[functionName]
   return {
-    to: OWNABLE_VALIDATOR_ADDRESS,
+    to: validator,
     value: 0n,
     data: encodeFunctionData({
       abi: [
@@ -114,7 +116,11 @@ function ownershipIs(owners: readonly Address[], threshold: number) {
 
 async function ecdsaRecovery(
   config: unknown,
-  newOwners: { accounts: (typeof accountA)[]; threshold?: number },
+  newOwners: {
+    accounts: (typeof accountA)[]
+    threshold?: number
+    module?: Address
+  },
 ) {
   return recoverEcdsaOwnership({
     accountAddress,
@@ -192,6 +198,35 @@ describe('Recovery Actions', () => {
           accountB.address.toLowerCase(),
           accountA.address.toLowerCase(),
         ]),
+      ])
+    })
+
+    test('reads and mutates the explicitly configured owner validator', async () => {
+      const rhinestoneAccount = await accountPromise
+      ownershipIs([accountA.address.toLowerCase() as Address], 1)
+
+      const calls = await ecdsaRecovery(rhinestoneAccount.config, {
+        accounts: [accountB],
+        module: alternateOwnable,
+      })
+
+      expect(rpcMulticall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining([
+          expect.objectContaining({ address: alternateOwnable }),
+        ]),
+      )
+      expect(calls).toEqual([
+        ownableCall(
+          'addOwner',
+          [accountB.address.toLowerCase()],
+          alternateOwnable,
+        ),
+        ownableCall(
+          'removeOwner',
+          [accountB.address.toLowerCase(), accountA.address.toLowerCase()],
+          alternateOwnable,
+        ),
       ])
     })
 

--- a/src/actions/recovery.test.ts
+++ b/src/actions/recovery.test.ts
@@ -202,12 +202,17 @@ describe('Recovery Actions', () => {
     })
 
     test('reads and mutates the explicitly configured owner validator', async () => {
-      const rhinestoneAccount = await accountPromise
+      const rhinestoneAccount = await rhinestone.createAccount({
+        owners: {
+          type: 'ecdsa',
+          accounts: [accountA],
+          module: alternateOwnable,
+        },
+      })
       ownershipIs([accountA.address.toLowerCase() as Address], 1)
 
       const calls = await ecdsaRecovery(rhinestoneAccount.config, {
         accounts: [accountB],
-        module: alternateOwnable,
       })
 
       expect(rpcMulticall).toHaveBeenCalledWith(
@@ -228,6 +233,20 @@ describe('Recovery Actions', () => {
           alternateOwnable,
         ),
       ])
+    })
+
+    test('rejects a recovery owner validator that differs from the account config', async () => {
+      const rhinestoneAccount = await accountPromise
+
+      await expect(
+        ecdsaRecovery(rhinestoneAccount.config, {
+          accounts: [accountB],
+          module: alternateOwnable,
+        }),
+      ).rejects.toThrow(
+        'Recovery owner validator must match the configured owner validator',
+      )
+      expect(rpcMulticall).not.toHaveBeenCalled()
     })
 
     test('raises the threshold only after the new owners exist', async () => {

--- a/src/actions/recovery.ts
+++ b/src/actions/recovery.ts
@@ -12,7 +12,11 @@ import {
   parseWebauthnPublicKey,
   WEBAUTHN_VALIDATOR_ADDRESS,
 } from '../modules/validators/webauthn'
-import { addOwner, changeThreshold, removeOwner } from './ecdsa'
+import {
+  addOwnableOwner,
+  changeOwnableThreshold,
+  removeOwnableOwner,
+} from './ownable'
 import {
   addOwner as addPasskeyOwner,
   changeThreshold as changePasskeyThreshold,
@@ -87,10 +91,11 @@ function enable(guardians: Account[], threshold = 1): LazyCallInput {
 async function recoverEcdsaOwnership(
   options: RecoverEcdsaOwnershipOptions,
 ): Promise<CalldataInput[]> {
+  const validator = options.newOwners.module ?? OWNABLE_VALIDATOR_ADDRESS
   const existing = await readOwnershipFor(
     options,
     options.accountAddress,
-    OWNABLE_VALIDATOR_ADDRESS,
+    validator,
   )
 
   const newOwners = options.newOwners.accounts
@@ -113,19 +118,19 @@ async function recoverEcdsaOwnership(
   // to the threshold.
   let currentOwners = [...existing.owners]
   for (const owner of ownersToAdd) {
-    calls.push(addOwner(owner))
+    calls.push(addOwnableOwner(validator, owner))
     // The validator pushes new owners onto the front of the linked list.
     currentOwners.unshift(owner)
   }
 
   if (existing.threshold !== newThreshold) {
-    calls.push(changeThreshold(newThreshold))
+    calls.push(changeOwnableThreshold(validator, newThreshold))
   }
 
   for (const owner of ownersToRemove) {
     const index = currentOwners.indexOf(owner)
     const prevOwner = index <= 0 ? SENTINEL_OWNER : currentOwners[index - 1]
-    calls.push(removeOwner(prevOwner, owner))
+    calls.push(removeOwnableOwner(validator, prevOwner, owner))
     currentOwners = currentOwners.filter((entry) => entry !== owner)
   }
 

--- a/src/actions/recovery.ts
+++ b/src/actions/recovery.ts
@@ -37,7 +37,10 @@ interface PasskeyCredential {
 }
 
 export interface RecoverEcdsaOwnershipOptions extends CallResolveContext {
-  /** Target owner set. Existing owners not listed here are removed. */
+  /**
+   * Target owner set. Existing owners not listed here are removed. If supplied,
+   * `module` must match the account's configured owner validator.
+   */
   newOwners: OwnableValidatorConfig
 }
 

--- a/src/actions/recovery.ts
+++ b/src/actions/recovery.ts
@@ -1,4 +1,4 @@
-import type { Account, Address } from 'viem'
+import { type Account, type Address, isAddressEqual } from 'viem'
 import type {
   CalldataInput,
   CallResolveContext,
@@ -91,7 +91,22 @@ function enable(guardians: Account[], threshold = 1): LazyCallInput {
 async function recoverEcdsaOwnership(
   options: RecoverEcdsaOwnershipOptions,
 ): Promise<CalldataInput[]> {
-  const validator = options.newOwners.module ?? OWNABLE_VALIDATOR_ADDRESS
+  const configuredValidator =
+    options.config.owners?.type === 'ecdsa'
+      ? (options.config.owners.module ?? OWNABLE_VALIDATOR_ADDRESS)
+      : undefined
+  const requestedValidator = options.newOwners.module
+  if (
+    configuredValidator &&
+    requestedValidator &&
+    !isAddressEqual(configuredValidator, requestedValidator)
+  ) {
+    throw new Error(
+      'Recovery owner validator must match the configured owner validator',
+    )
+  }
+  const validator =
+    configuredValidator ?? requestedValidator ?? OWNABLE_VALIDATOR_ADDRESS
   const existing = await readOwnershipFor(
     options,
     options.accountAddress,

--- a/src/api/compose.test.ts
+++ b/src/api/compose.test.ts
@@ -233,6 +233,48 @@ describe('internal core composition', () => {
     )
   })
 
+  test('reads ECDSA owners through the configured validator', async () => {
+    const base = fixture()
+    const validator = `0x${'66'.repeat(20)}` as const
+    const multicall = vi.fn(async () => [
+      { result: [owner.address] },
+      { result: 1n },
+    ])
+    const dependencies = {
+      ...base.dependencies,
+      rpc: {
+        forChain: () => ({
+          getCode: vi.fn(async () => ({ code: undefined })),
+          getTransactionCount: vi.fn(async () => 0n),
+          readContract: vi.fn() as RpcReadPort['readContract'],
+          multicall: multicall as RpcReadPort['multicall'],
+        }),
+      },
+    } satisfies CoreDependencies
+    const context = {
+      ...base.context,
+      method: 'get-owners' as const,
+      account: resolveAccountConfig(base.context.sdk, {
+        account: { type: 'nexus', version: '1.2.1' },
+        owners: { type: 'ecdsa', accounts: [owner], module: validator },
+        initData: { address: target },
+      }),
+    }
+    const workflows = createCoreComposition(
+      base.context.sdk,
+      dependencies,
+    ).createAccount(context).workflows
+
+    await expect(workflows.getOwners(context, chain)).resolves.toEqual({
+      accounts: [owner.address],
+      threshold: 1,
+    })
+    expect(multicall).toHaveBeenCalledWith(
+      { chain },
+      expect.arrayContaining([expect.objectContaining({ address: validator })]),
+    )
+  })
+
   test('signs messages and typed data with Smart Session owners', async () => {
     const { composition, context } = fixture()
     const workflows = composition.createAccount(context).workflows

--- a/src/api/compose.ts
+++ b/src/api/compose.ts
@@ -26,6 +26,7 @@ import {
 } from '../modules/read-core'
 import { defineValidator } from '../modules/validators/definition'
 import { K1_DEFAULT_VALIDATOR_ADDRESS } from '../modules/validators/k1'
+import { resolveValidator } from '../modules/validators/resolve'
 import { ecdsaSignerId } from '../modules/validators/signer-id'
 import {
   getSessionDetails as buildSessionDetails,
@@ -362,6 +363,11 @@ function createAccountComposition<CompatibilityConfig>(
         accountKind: context.account.account.kind,
         account: createStaticAccountRuntime(context.account, chain, false)
           .identity.address,
+        ...(context.account.owners?.kind === 'ecdsa'
+          ? {
+              ownerValidator: resolveValidator(context.account.owners).address,
+            }
+          : {}),
         ...(hcaFactory(context.account)
           ? { hcaFactory: hcaFactory(context.account) as Address }
           : {}),

--- a/src/modules/read-core.test.ts
+++ b/src/modules/read-core.test.ts
@@ -6,6 +6,7 @@ import {
   encodeAccountModuleDeInitData,
   readInstalledModules,
   readModuleInstallations,
+  readOwners,
   readValidatorInitialized,
 } from './read-core'
 import type { ResolvedModule } from './types'
@@ -61,6 +62,34 @@ describe('module reads', () => {
         validator,
       }),
     ).resolves.toBe(false)
+  })
+
+  test('reads owners from an explicitly configured validator', async () => {
+    const ownerValidator =
+      '0x0000000000000000000000000000000000000004' as Address
+    const owner = '0x0000000000000000000000000000000000000005'
+    const requests: ContractRead[] = []
+    const rpc: RpcReadPort = {
+      ...fakeReader([]).rpc,
+      multicall: async (_context, input) => {
+        requests.push(...input)
+        return [{ result: [owner] }, { result: 1n }] as never
+      },
+    }
+
+    await expect(
+      readOwners({
+        rpc,
+        chain,
+        accountKind: 'nexus',
+        account,
+        ownerValidator,
+      }),
+    ).resolves.toEqual({ accounts: [owner], threshold: 1 })
+    expect(requests).toEqual([
+      expect.objectContaining({ address: ownerValidator }),
+      expect.objectContaining({ address: ownerValidator }),
+    ])
   })
 
   test('checks installation state for every ERC-7579 module kind', async () => {

--- a/src/modules/read-core.ts
+++ b/src/modules/read-core.ts
@@ -201,12 +201,13 @@ export async function readOwners(input: {
   readonly chain: EvmChainReference
   readonly accountKind: string
   readonly account: Address
+  readonly ownerValidator?: Address
   readonly hcaFactory?: Address
 }): Promise<{
   readonly accounts: readonly Address[]
   readonly threshold: number
 } | null> {
-  let validator: Address = OWNABLE_VALIDATOR_ADDRESS
+  let validator: Address = input.ownerValidator ?? OWNABLE_VALIDATOR_ADDRESS
   if (input.accountKind === 'hca') {
     validator = input.hcaFactory
       ? await input.rpc.readContract<Address>(


### PR DESCRIPTION
- make ECDSA recovery mutations target the configured Ownable validator instead of the canonical deployment
- read account owners from the configured ECDSA validator
- keep validator-targeted calldata construction internal without changing the public action API
- add regression coverage and a patch changeset

Validated with the full 534-test unit suite, type checks, Biome, architecture checks, build, and a live Nexus recovery run on Base Sepolia.

Closes [RHI-5129](https://linear.app/rhinestone/issue/RHI-5129)