### PR TITLE
fix: honor configured passkey validator during recovery

### DIFF
--- a/.changeset/fix-custom-webauthn-recovery.md
+++ b/.changeset/fix-custom-webauthn-recovery.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Make passkey recovery read and update the account's configured WebAuthn validator.

--- a/src/actions/passkeys.ts
+++ b/src/actions/passkeys.ts
@@ -1,4 +1,3 @@
-import { encodeFunctionData } from 'viem'
 import type { CalldataInput, LazyCallInput } from '../config/account'
 import {
   resolveWebauthnCredentials,
@@ -9,6 +8,11 @@ import {
   resolveModuleInstallation,
   resolveModuleUninstallation,
 } from './runtime'
+import {
+  addWebauthnCredential,
+  changeWebauthnThreshold,
+  removeWebauthnCredential,
+} from './webauthn'
 
 /**
  * Enable passkeys authentication
@@ -62,30 +66,12 @@ function addOwner(
   pubKeyY: bigint,
   requireUserVerification: boolean,
 ): CalldataInput {
-  return {
-    to: WEBAUTHN_VALIDATOR_ADDRESS,
-    value: 0n,
-    data: encodeFunctionData({
-      abi: [
-        {
-          inputs: [
-            { name: 'pubKeyX', type: 'uint256' },
-            { name: 'pubKeyY', type: 'uint256' },
-            {
-              name: 'requireUserVerification',
-              type: 'bool',
-            },
-          ],
-          name: 'addCredential',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        },
-      ],
-      functionName: 'addCredential',
-      args: [pubKeyX, pubKeyY, requireUserVerification],
-    }),
-  }
+  return addWebauthnCredential(
+    WEBAUTHN_VALIDATOR_ADDRESS,
+    pubKeyX,
+    pubKeyY,
+    requireUserVerification,
+  )
 }
 
 /**
@@ -95,26 +81,7 @@ function addOwner(
  * @returns Call to remove the passkey owner
  */
 function removeOwner(pubKeyX: bigint, pubKeyY: bigint): CalldataInput {
-  return {
-    to: WEBAUTHN_VALIDATOR_ADDRESS,
-    value: 0n,
-    data: encodeFunctionData({
-      abi: [
-        {
-          inputs: [
-            { name: 'pubKeyX', type: 'uint256' },
-            { name: 'pubKeyY', type: 'uint256' },
-          ],
-          name: 'removeCredential',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        },
-      ],
-      functionName: 'removeCredential',
-      args: [pubKeyX, pubKeyY],
-    }),
-  }
+  return removeWebauthnCredential(WEBAUTHN_VALIDATOR_ADDRESS, pubKeyX, pubKeyY)
 }
 
 /**
@@ -123,25 +90,7 @@ function removeOwner(pubKeyX: bigint, pubKeyY: bigint): CalldataInput {
  * @returns Call to change the threshold
  */
 function changeThreshold(newThreshold: number): CalldataInput {
-  return {
-    to: WEBAUTHN_VALIDATOR_ADDRESS,
-    value: 0n,
-    data: encodeFunctionData({
-      abi: [
-        {
-          inputs: [
-            { internalType: 'uint256', name: '_threshold', type: 'uint256' },
-          ],
-          name: 'setThreshold',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        },
-      ],
-      functionName: 'setThreshold',
-      args: [BigInt(newThreshold)],
-    }),
-  }
+  return changeWebauthnThreshold(WEBAUTHN_VALIDATOR_ADDRESS, newThreshold)
 }
 
 export { addOwner, removeOwner, changeThreshold, disable, enable }

--- a/src/actions/recovery.test.ts
+++ b/src/actions/recovery.test.ts
@@ -5,7 +5,13 @@ import {
 } from 'viem/account-abstraction'
 import { base } from 'viem/chains'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { accountA, accountB, accountC, accountD } from '../../test/consts'
+import {
+  accountA,
+  accountB,
+  accountC,
+  accountD,
+  passkeyAccount,
+} from '../../test/consts'
 import { RhinestoneSDK } from '..'
 import { resolveCalls } from '../calls/resolve'
 import { toEvmChainReference } from '../chains/caip2'
@@ -39,6 +45,7 @@ import {
 
 const accountAddress: Address = '0x36C03e7D593F7B2C6b06fC18B5f4E9a4A29C99b0'
 const alternateOwnable: Address = '0x2483da3a338895199e5e538530213157e931bf06'
+const alternateWebauthn: Address = '0x0000000000000000000000000000000000000006'
 const SENTINEL: Address = '0x0000000000000000000000000000000000000001'
 
 // Extra passkeys, so rotation tests have distinct credentials to move between.
@@ -358,6 +365,7 @@ describe('Recovery Actions', () => {
     function passkeyCall(
       functionName: 'addCredential' | 'removeCredential' | 'setThreshold',
       args: readonly unknown[],
+      validator: Address = WEBAUTHN_VALIDATOR_ADDRESS,
     ) {
       const abi = {
         addCredential: [
@@ -372,7 +380,7 @@ describe('Recovery Actions', () => {
         setThreshold: [{ name: '_threshold', type: 'uint256' }],
       }[functionName]
       return {
-        to: WEBAUTHN_VALIDATOR_ADDRESS,
+        to: validator,
         value: 0n,
         data: encodeFunctionData({
           abi: [
@@ -396,7 +404,6 @@ describe('Recovery Actions', () => {
       // removeCredential reverts with CannotRemoveCredential while
       // `credentials <= threshold`, so the add has to land first.
       rpcReadContract.mockResolvedValueOnce(1n)
-      const { passkeyAccount } = await import('../../test/consts')
       const oldCredential = credentialOf(passkeyAccount)
       const newCredential = credentialOf(passkeyAccountB)
 
@@ -421,10 +428,74 @@ describe('Recovery Actions', () => {
       ])
     })
 
+    test('reads and mutates the explicitly configured passkey validator', async () => {
+      const rhinestoneAccount = await rhinestone.createAccount({
+        owners: {
+          type: 'passkey',
+          accounts: [passkeyAccount],
+          module: alternateWebauthn,
+        },
+      })
+      rpcReadContract.mockResolvedValueOnce(1n)
+      const oldCredential = credentialOf(passkeyAccount)
+      const newCredential = credentialOf(passkeyAccountB)
+
+      const calls = await recoverPasskeyOwnership({
+        accountAddress,
+        chain: base,
+        config: rhinestoneAccount.config as never,
+        currentCredentials: [oldCredential],
+        newOwners: { type: 'passkey', accounts: [passkeyAccountB] },
+      })
+
+      expect(rpcReadContract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ address: alternateWebauthn }),
+      )
+      expect(calls).toEqual([
+        passkeyCall(
+          'addCredential',
+          [newCredential.pubKeyX, newCredential.pubKeyY, false],
+          alternateWebauthn,
+        ),
+        passkeyCall(
+          'removeCredential',
+          [oldCredential.pubKeyX, oldCredential.pubKeyY],
+          alternateWebauthn,
+        ),
+      ])
+    })
+
+    test('rejects a passkey validator that differs from the account config', async () => {
+      const rhinestoneAccount = await rhinestone.createAccount({
+        owners: {
+          type: 'passkey',
+          accounts: [passkeyAccount],
+          module: alternateWebauthn,
+        },
+      })
+
+      await expect(
+        recoverPasskeyOwnership({
+          accountAddress,
+          chain: base,
+          config: rhinestoneAccount.config as never,
+          currentCredentials: [credentialOf(passkeyAccount)],
+          newOwners: {
+            type: 'passkey',
+            accounts: [passkeyAccountB],
+            module: WEBAUTHN_VALIDATOR_ADDRESS,
+          },
+        }),
+      ).rejects.toThrow(
+        'Recovery owner validator must match the configured owner validator',
+      )
+      expect(rpcReadContract).not.toHaveBeenCalled()
+    })
+
     test('raises the threshold only after the new credential exists', async () => {
       const rhinestoneAccount = await accountPromise
       rpcReadContract.mockResolvedValueOnce(1n)
-      const { passkeyAccount } = await import('../../test/consts')
       const newCredential = credentialOf(passkeyAccountB)
 
       const calls = await recoverPasskeyOwnership({
@@ -460,7 +531,6 @@ describe('Recovery Actions', () => {
         credential: { id: 'prefixed', publicKey: `0x04${x}${y}` },
       })
       rpcReadContract.mockResolvedValueOnce(1n)
-      const { passkeyAccount } = await import('../../test/consts')
       const oldCredential = credentialOf(passkeyAccount)
 
       const calls = await recoverPasskeyOwnership({
@@ -486,7 +556,6 @@ describe('Recovery Actions', () => {
       // `newOwners` must not be added again — addCredential reverts with
       // CredentialAlreadyExists.
       rpcReadContract.mockResolvedValueOnce(1n)
-      const { passkeyAccount } = await import('../../test/consts')
       const kept = credentialOf(passkeyAccount)
       const replaced = credentialOf(passkeyAccountC)
       const added = credentialOf(passkeyAccountB)

--- a/src/actions/recovery.ts
+++ b/src/actions/recovery.ts
@@ -18,15 +18,15 @@ import {
   removeOwnableOwner,
 } from './ownable'
 import {
-  addOwner as addPasskeyOwner,
-  changeThreshold as changePasskeyThreshold,
-  removeOwner as removePasskeyOwner,
-} from './passkeys'
-import {
   readOwnershipFor,
   readThresholdFor,
   resolveValidatorInstallation,
 } from './runtime'
+import {
+  addWebauthnCredential,
+  changeWebauthnThreshold,
+  removeWebauthnCredential,
+} from './webauthn'
 
 /** Sentinel head of the validator's owner linked list. */
 const SENTINEL_OWNER: Address = '0x0000000000000000000000000000000000000001'
@@ -56,7 +56,10 @@ export interface RecoverPasskeyOwnershipOptions extends CallResolveContext {
    * id, so their coordinates cannot be read back onchain.
    */
   currentCredentials: readonly PasskeyCredential[]
-  /** Target passkey owner set. */
+  /**
+   * Target passkey owner set. If supplied, `module` must match the account's
+   * configured owner validator.
+   */
   newOwners: WebauthnValidatorConfig
 }
 
@@ -170,10 +173,26 @@ async function recoverEcdsaOwnership(
 async function recoverPasskeyOwnership(
   options: RecoverPasskeyOwnershipOptions,
 ): Promise<CalldataInput[]> {
+  const configuredValidator =
+    options.config.owners?.type === 'passkey'
+      ? (options.config.owners.module ?? WEBAUTHN_VALIDATOR_ADDRESS)
+      : undefined
+  const requestedValidator = options.newOwners.module
+  if (
+    configuredValidator &&
+    requestedValidator &&
+    !isAddressEqual(configuredValidator, requestedValidator)
+  ) {
+    throw new Error(
+      'Recovery owner validator must match the configured owner validator',
+    )
+  }
+  const validator =
+    configuredValidator ?? requestedValidator ?? WEBAUTHN_VALIDATOR_ADDRESS
   const existingThreshold = await readThresholdFor(
     options,
     options.accountAddress,
-    WEBAUTHN_VALIDATOR_ADDRESS,
+    validator,
   )
 
   const newCredentials = options.newOwners.accounts.map((account) => {
@@ -201,7 +220,8 @@ async function recoverPasskeyOwnership(
   // Rotating the sole credential of a 1-of-1 account is impossible otherwise.
   for (const credential of credentialsToAdd) {
     calls.push(
-      addPasskeyOwner(
+      addWebauthnCredential(
+        validator,
         credential.pubKeyX,
         credential.pubKeyY,
         credential.requireUV,
@@ -210,11 +230,17 @@ async function recoverPasskeyOwnership(
   }
 
   if (existingThreshold !== newThreshold) {
-    calls.push(changePasskeyThreshold(newThreshold))
+    calls.push(changeWebauthnThreshold(validator, newThreshold))
   }
 
   for (const credential of credentialsToRemove) {
-    calls.push(removePasskeyOwner(credential.pubKeyX, credential.pubKeyY))
+    calls.push(
+      removeWebauthnCredential(
+        validator,
+        credential.pubKeyX,
+        credential.pubKeyY,
+      ),
+    )
   }
 
   return calls

--- a/src/actions/webauthn.ts
+++ b/src/actions/webauthn.ts
@@ -1,0 +1,83 @@
+import { type Address, encodeFunctionData } from 'viem'
+import type { CalldataInput } from '../config/account'
+
+export function addWebauthnCredential(
+  validator: Address,
+  pubKeyX: bigint,
+  pubKeyY: bigint,
+  requireUserVerification: boolean,
+): CalldataInput {
+  return {
+    to: validator,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            { name: 'pubKeyX', type: 'uint256' },
+            { name: 'pubKeyY', type: 'uint256' },
+            { name: 'requireUserVerification', type: 'bool' },
+          ],
+          name: 'addCredential',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      functionName: 'addCredential',
+      args: [pubKeyX, pubKeyY, requireUserVerification],
+    }),
+  }
+}
+
+export function removeWebauthnCredential(
+  validator: Address,
+  pubKeyX: bigint,
+  pubKeyY: bigint,
+): CalldataInput {
+  return {
+    to: validator,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            { name: 'pubKeyX', type: 'uint256' },
+            { name: 'pubKeyY', type: 'uint256' },
+          ],
+          name: 'removeCredential',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      functionName: 'removeCredential',
+      args: [pubKeyX, pubKeyY],
+    }),
+  }
+}
+
+export function changeWebauthnThreshold(
+  validator: Address,
+  newThreshold: number,
+): CalldataInput {
+  return {
+    to: validator,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            { internalType: 'uint256', name: '_threshold', type: 'uint256' },
+          ],
+          name: 'setThreshold',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      functionName: 'setThreshold',
+      args: [BigInt(newThreshold)],
+    }),
+  }
+}


### PR DESCRIPTION
- derive the passkey recovery validator from the account configuration
- target threshold reads and credential mutations at the configured WebAuthn module
- reject conflicting module overrides before RPC access
- keep the public passkey action signatures unchanged through internal calldata builders
- add regression coverage and a patch changeset

Validated with 538 unit tests, type checks, Biome, architecture checks, and a production build.

Closes [RHI-5144](https://linear.app/rhinestone/issue/RHI-5144)

Unblocks [sdk#705](https://github.com/rhinestonewtf/sdk/pull/705)