### PR TITLE
test: request target-chain USDC in the preclaim source-call spec

### DIFF
--- a/test/integration/scenarios/preclaim-ops.itest.ts
+++ b/test/integration/scenarios/preclaim-ops.itest.ts
@@ -124,7 +124,10 @@ describe.sequential('SDK integration preclaim-ops', () => {
 
     const recipient = createOwner().address
     const sourceCallAmount = 5_000n
-    const usdc = getTokenAddress('USDC', sourceChain.id)
+    // Token requests are denominated on the target chain, source calls run on
+    // the source chain — the two USDC addresses differ.
+    const sourceUsdc = getTokenAddress('USDC', sourceChain.id)
+    const targetUsdc = getTokenAddress('USDC', targetChain.id)
 
     const execution = await executeIntent({
       account,
@@ -134,11 +137,11 @@ describe.sequential('SDK integration preclaim-ops', () => {
         targetChain,
         sponsored: true,
         calls: [],
-        tokenRequests: [{ address: usdc, amount: 10_000n }],
+        tokenRequests: [{ address: targetUsdc, amount: 10_000n }],
         sourceCalls: {
           [sourceChain.id]: [
             {
-              to: usdc,
+              to: sourceUsdc,
               value: 0n,
               data: encodeFunctionData({
                 abi: erc20Abi,


### PR DESCRIPTION
Fixes the failing `preclaim-ops` integration spec ([run](https://github.com/rhinestonewtf/sdk/actions/runs/30401082088/job/90415769588)): `executes a user source call on-chain` failed at prepare with `MISSING_TOKEN_METADATA` / 422 — `Token 0x036cbd… on chain 421614 is not a valid ERC-20 or is not supported`.

- `tokenRequests` are denominated on the **destination** chain (`adaptTransaction` normalizes against `destinationChainId`, and the address is sent as the destination `tokenAddress`), but the spec passed Base Sepolia USDC while the target chain is Arbitrum Sepolia.
- Use the target-chain USDC address for the token request, keep the source-chain one for the source call.
- Regressed in `209e849f`, which replaced `address: 'USDC'` — a symbol the SDK resolved per-chain — with a single literal address reused for both legs.

Test-only, so no changeset. The `Integration Tests` workflow doesn't run on PRs (it holds live credentials); a push to `main` runs the smoke suite only, so confirming this spec needs a manual `suite=all` dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)