### PR TITLE
feat(sdk): expose SerializedIntentInput

### DIFF
--- a/.changeset/expose-serialized-intent-input.md
+++ b/.changeset/expose-serialized-intent-input.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Expose `SerializedIntentInput`, the wire form of `IntentInput` with `bigint` fields as decimal strings. Sponsorship servers can type their request body with it instead of re-deriving the mapping, and it now types `PreparedTransactionData.intentInput` and the JWT auth `getIntentExtensionToken` callback in place of `unknown`.

--- a/scripts/architecture/check.ts
+++ b/scripts/architecture/check.ts
@@ -35,6 +35,14 @@ const publishedBarrels = new Set([
 ])
 
 const workflowLayers = new Set(['intents', 'user-operations'])
+// Config modules allowed a type-only edge to the orchestrator public types: the
+// public config surface plus the input/resolved mirrors that carry the same
+// values through resolution.
+const configOrchestratorTypeConsumers = new Set([
+  'src/config/account.ts',
+  'src/config/input.ts',
+  'src/config/resolved.ts',
+])
 const concreteClientFiles = new Set([
   'auth.ts',
   'client.ts',
@@ -309,11 +317,14 @@ function edgeViolation(
       (edge.from === 'src/transactions/intents/types.ts' ||
         edge.from === 'src/transactions/user-operations/types.ts')) ||
     // The public `Transaction` options (`appFees`, `settlementLayers`,
-    // `auxiliaryFunds`) are typed with orchestrator public types, so the config
-    // input surface has a type-only dependency on the orchestrator public-type
-    // module that cannot be removed without changing the public surface.
+    // `auxiliaryFunds`) and the JWT auth `getIntentExtensionToken` parameter
+    // (`SerializedIntentInput`) are typed with orchestrator public types, so the
+    // config surface — the public config and the input/resolved mirrors that
+    // carry the same values — has a type-only dependency on the orchestrator
+    // public-type module that cannot be removed without either changing the
+    // public surface or widening internal types back to `unknown`.
     (edge.typeOnly &&
-      edge.from === 'src/config/account.ts' &&
+      configOrchestratorTypeConsumers.has(edge.from) &&
       edge.to === 'src/clients/orchestrator/public.ts')
 
   if (forbiddenByLayer[fromLayer]?.has(toLayer) && !publicInputTypeEdge) {

--- a/src/api/account.test.ts
+++ b/src/api/account.test.ts
@@ -2,6 +2,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet, optimism } from 'viem/chains'
 import { describe, expect, test, vi } from 'vitest'
 import { toEvmChainReference } from '../chains/caip2'
+import type { SerializedIntentInput } from '../clients/orchestrator/public'
 import type { LegacyAccountConfig } from '../config/legacy'
 import { resolveAccountConfig, resolveSdkConfig } from '../config/resolve'
 import type { AccountInvocationContext } from '../config/resolved'
@@ -28,6 +29,13 @@ import type { AdaptedSignerSelection } from './signer-selection'
 const owner = privateKeyToAccount(`0x${'02'.repeat(32)}`)
 const guardian = privateKeyToAccount(`0x${'03'.repeat(32)}`)
 const recipientAddress = '0x0000000000000000000000000000000000000010' as const
+const serializedIntentInput = {
+  account: { address: recipientAddress, accountType: 'ERC7579' },
+  destinationChainId: mainnet.id,
+  destinationExecutions: [],
+  tokenRequests: [],
+  options: {},
+} satisfies SerializedIntentInput
 
 function invocationContext(): AccountInvocationContext<
   LegacyAccountConfig<unknown>
@@ -308,7 +316,7 @@ describe('account boundary adapters', () => {
         best,
         all: [best, alternate],
       },
-      intentInput: {},
+      intentInput: serializedIntentInput,
       transaction: { chain: mainnet, calls: [] },
     } satisfies PreparedTransactionData
     await facade.signTransaction(prepared, {
@@ -394,7 +402,7 @@ describe('account boundary adapters', () => {
     }
     const prepared = {
       quotes: { traceId: 'trace', best: quote, all: [quote] },
-      intentInput: {},
+      intentInput: serializedIntentInput,
       transaction: { chain: mainnet, calls: [] },
     } satisfies PreparedTransactionData
 
@@ -432,7 +440,7 @@ describe('account boundary adapters', () => {
     const alternate = quoteFixture('alternate')
     const signed = {
       quotes: { traceId: 'trace', best, all: [best, alternate] },
-      intentInput: {},
+      intentInput: serializedIntentInput,
       transaction: { chain: mainnet, calls: [] },
       quote: alternate,
       originSignatures: [],

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -446,7 +446,13 @@ function reconstructInput(
         ? quote
         : normalizeIntentQuote(candidate as OrchestratorQuote),
     ),
-    request: prepared.intentInput as PreparedIntent<Compat>['request'],
+    // The public prepared data only carries the serialized request, so the
+    // reconstructed request holds decimal strings where the internal type
+    // declares bigints. Sound because submission only re-serializes it (a no-op
+    // on strings, keeping the sponsorship digest stable) and reads
+    // `options.sponsorSettings`.
+    request:
+      prepared.intentInput as unknown as PreparedIntent<Compat>['request'],
     intentInput: adaptTransaction(context, prepared.transaction),
   }
 }

--- a/src/clients/orchestrator/auth.ts
+++ b/src/clients/orchestrator/auth.ts
@@ -1,9 +1,10 @@
 import type { ResolvedAuth } from '../../config/resolved'
+import type { SerializedIntentInput } from './public'
 
 export interface OrchestratorAuthPort {
   readonly getHeaders: () => Promise<Readonly<Record<string, string>>>
   readonly getSubmitHeaders: (
-    intentInput: unknown,
+    intentInput: SerializedIntentInput,
     sponsored: boolean,
   ) => Promise<Readonly<Record<string, string>>>
 }

--- a/src/clients/orchestrator/client.test.ts
+++ b/src/clients/orchestrator/client.test.ts
@@ -2,8 +2,16 @@ import { describe, expect, test, vi } from 'vitest'
 import { createOrchestratorAuth } from './auth'
 import { createOrchestratorClient } from './client'
 import type { RateLimitedError } from './errors'
+import type { SerializedIntentInput } from './public'
 
 const address = '0x0000000000000000000000000000000000000001' as const
+const serializedIntentInput = {
+  account: { address, accountType: 'ERC7579' },
+  destinationChainId: 1,
+  destinationExecutions: [],
+  tokenRequests: [],
+  options: {},
+} satisfies SerializedIntentInput
 
 describe('orchestrator client', () => {
   test('maps quote requests and preserves auth, custom headers, and trace ids', async () => {
@@ -159,11 +167,11 @@ describe('orchestrator client', () => {
         intentId: 'intent-1',
         signatures: { origin: [], destination: '0x' },
       },
-      { intentInput: { request: true }, sponsored: true },
+      { intentInput: serializedIntentInput, sponsored: true },
     )
 
     expect(accessToken).toHaveBeenCalledOnce()
-    expect(extension).toHaveBeenCalledWith({ request: true })
+    expect(extension).toHaveBeenCalledWith(serializedIntentInput)
   })
 
   test('maps error envelope metadata', async () => {

--- a/src/clients/orchestrator/client.ts
+++ b/src/clients/orchestrator/client.ts
@@ -14,6 +14,7 @@ import {
   mapSplitResultFromWire,
 } from './mappers'
 import type { OrchestratorPort } from './port'
+import type { OrchestratorIntentSubmissionContext } from './types'
 import type { WireChainsResponse } from './wire'
 
 const SDK_VERSION = '2.0.0'
@@ -34,10 +35,7 @@ export function createOrchestratorClient(
     readonly path: string
     readonly method?: 'GET' | 'POST'
     readonly body?: unknown
-    readonly submitContext?: {
-      readonly intentInput: unknown
-      readonly sponsored: boolean
-    }
+    readonly submitContext?: OrchestratorIntentSubmissionContext
   }): Promise<unknown> => {
     const authHeaders = input.submitContext
       ? await options.auth.getSubmitHeaders(

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -206,6 +206,32 @@ interface IntentInput {
   preClaimExecutions?: Record<number, Execution[]>
 }
 
+// Transport projection: `bigint` becomes a decimal string, every other type
+// keeps its shape (template-literal `Address`/`Hex`, optionality, index
+// signatures). Internal — only the `IntentInput` projection below is published.
+type Serialized<T> = T extends bigint
+  ? string
+  : T extends string | number | boolean | null | undefined
+    ? T
+    : T extends object
+      ? { [K in keyof T]: Serialized<T[K]> }
+      : T
+
+/**
+ * {@link IntentInput} as it crosses the transport boundary: the same shape, with
+ * every `bigint` field serialized to a decimal string.
+ *
+ * This is the canonical form the SDK exposes as
+ * `PreparedTransactionData.intentInput` and passes to a JWT auth
+ * `getIntentExtensionToken` callback, and the form a sponsorship JWT's digest
+ * commits to. Type a sponsorship endpoint's request body with it instead of
+ * re-deriving the mapping locally.
+ *
+ * Compile-time shape only: an untrusted request body still needs runtime
+ * validation.
+ */
+type SerializedIntentInput = Serialized<IntentInput>
+
 interface UsdAmount {
   usd: number
 }
@@ -460,6 +486,7 @@ export type {
   SettlementLayerFilter,
   SignatureMode,
   IntentInput,
+  SerializedIntentInput,
   BridgeFill,
   Quote,
   QuoteResponse,

--- a/src/clients/orchestrator/types.ts
+++ b/src/clients/orchestrator/types.ts
@@ -9,6 +9,7 @@ import type {
   ChainOperation,
   Cost,
   IntentStatus,
+  SerializedIntentInput,
   SettlementLayer,
   TokenRequirements,
 } from './public'
@@ -113,7 +114,7 @@ export interface OrchestratorSignedIntent {
 }
 
 export interface OrchestratorIntentSubmissionContext {
-  readonly intentInput: unknown
+  readonly intentInput: SerializedIntentInput
   readonly sponsored: boolean
 }
 

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -10,6 +10,7 @@ import type {
   AppFeeRate,
   AuxiliaryFunds,
   ProtocolFeeRate,
+  SerializedIntentInput,
   SettlementLayerFilter,
 } from '../clients/orchestrator/public'
 
@@ -31,7 +32,7 @@ type ModuleType =
 interface AuthProvider {
   getHeaders(): Promise<Record<string, string>>
   getSubmitHeaders(
-    intentInput: unknown,
+    intentInput: SerializedIntentInput,
     isSponsored: boolean,
   ): Promise<Record<string, string>>
 }
@@ -643,10 +644,13 @@ interface JwtAuth {
   /** Static access token, or async getter for refreshable tokens. */
   accessToken: string | (() => Promise<string>)
   /**
-   * Called when submitting a sponsored intent. Receives the raw intent
-   * input object and must return a signed intent_extension_token JWT.
+   * Called when submitting a sponsored intent. Receives the canonical
+   * serialized intent input and must return a signed intent_extension_token
+   * JWT whose sponsorship digest covers it.
    */
-  getIntentExtensionToken?: (intentInput: unknown) => Promise<string>
+  getIntentExtensionToken?: (
+    intentInput: SerializedIntentInput,
+  ) => Promise<string>
 }
 
 type AuthConfig = ApiKeyAuth | JwtAuth

--- a/src/config/input.ts
+++ b/src/config/input.ts
@@ -1,5 +1,6 @@
 import type { Account, Address } from 'viem'
 import type { AccountInitData, AccountInput } from '../accounts/types'
+import type { SerializedIntentInput } from '../clients/orchestrator/public'
 import type { ModuleInput } from '../modules/types'
 import type { ValidatorInput } from '../modules/validators/types'
 
@@ -8,7 +9,9 @@ export type SdkAuthInput =
   | {
       mode: 'experimental_jwt'
       accessToken: string | (() => Promise<string>)
-      getIntentExtensionToken?: (intentInput: unknown) => Promise<string>
+      getIntentExtensionToken?: (
+        intentInput: SerializedIntentInput,
+      ) => Promise<string>
     }
 
 export type ProviderInput = {

--- a/src/config/resolved.ts
+++ b/src/config/resolved.ts
@@ -1,5 +1,6 @@
 import type { Account, Address } from 'viem'
 import type { AccountDefinition, AccountInitData } from '../accounts/types'
+import type { SerializedIntentInput } from '../clients/orchestrator/public'
 import type { ConfiguredModule } from '../modules/types'
 import type { ResolvedValidatorDefinition } from '../modules/validators/types'
 
@@ -11,7 +12,7 @@ export type ResolvedAuth =
       readonly kind: 'jwt'
       readonly accessToken: string | (() => Promise<string>)
       readonly getIntentExtensionToken?: (
-        intentInput: unknown,
+        intentInput: SerializedIntentInput,
       ) => Promise<string>
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export type {
   Portfolio,
   ProtocolFeeRate,
   Quote,
+  SerializedIntentInput,
   SettlementLayer,
   SettlementLayerFilter,
   SignData,

--- a/src/transactions/intents/compatibility.ts
+++ b/src/transactions/intents/compatibility.ts
@@ -1,12 +1,16 @@
+import type { SerializedIntentInput } from '../../clients/orchestrator/public'
 import type {
   OrchestratorIntentRequest,
   OrchestratorQuote,
 } from '../../clients/orchestrator/types'
 
+// The request is structurally the public `IntentInput` with `readonly`
+// modifiers, so the serialized value is a `SerializedIntentInput` — the cast
+// only re-attaches the type `serializeBigInts` erases.
 export function projectCompatibleIntentInput(
   input: OrchestratorIntentRequest,
-): unknown {
-  return serializeBigInts(input)
+): SerializedIntentInput {
+  return serializeBigInts(input) as SerializedIntentInput
 }
 
 export function projectCompatibleQuote(

--- a/src/transactions/intents/types.ts
+++ b/src/transactions/intents/types.ts
@@ -158,6 +158,11 @@ export interface PreparedQuotes {
 export interface PreparedTransactionData {
   quotes: PreparedQuotes
   /** Canonical serialized intent input; the shape a sponsorship digest covers. */
+  // Deliberately narrowed from the `unknown` this field used to carry. Prepared
+  // data produced by `prepareTransaction` and passed straight back to
+  // `signTransaction` / `submitTransaction` is unaffected; a value typed against
+  // an earlier release — a mocked or persisted prepared object — needs an
+  // annotation.
   intentInput: SerializedIntentInput
   transaction: Transaction
 }

--- a/src/transactions/intents/types.ts
+++ b/src/transactions/intents/types.ts
@@ -11,6 +11,7 @@ import type {
   IntentOpStatus,
   OriginSignature,
   Quote,
+  SerializedIntentInput,
 } from '../../clients/orchestrator/public'
 import type {
   OrchestratorAccount,
@@ -156,7 +157,8 @@ export interface PreparedQuotes {
 
 export interface PreparedTransactionData {
   quotes: PreparedQuotes
-  intentInput: unknown
+  /** Canonical serialized intent input; the shape a sponsorship digest covers. */
+  intentInput: SerializedIntentInput
   transaction: Transaction
 }
 

--- a/test/integration/framework/signatures.ts
+++ b/test/integration/framework/signatures.ts
@@ -9,16 +9,10 @@ import type {
   SignedTransactionData,
 } from '../../../src/index'
 
-// `signatureMode` lives on the prepared intent input, which the public type
-// keeps as `unknown`. Read it through a narrow cast rather than widening the
-// SDK type — tests assert on it, they don't depend on it being public.
 export function readSignatureMode(
   prepared: PreparedTransactionData,
 ): number | undefined {
-  const input = prepared.intentInput as
-    | { options?: { signatureMode?: number } }
-    | undefined
-  return input?.options?.signatureMode
+  return prepared.intentInput.options.signatureMode
 }
 
 // Single hex => ERC-1271 path; { preClaimSig, notarizedClaimSig } => the dual

--- a/test/integration/scenarios/preclaim-ops.itest.ts
+++ b/test/integration/scenarios/preclaim-ops.itest.ts
@@ -1,10 +1,6 @@
 import { encodeFunctionData, erc20Abi } from 'viem'
 import { describe, expect, test } from 'vitest'
-import type {
-  PreparedTransactionData,
-  RhinestoneAccount,
-  Session,
-} from '../../../src/index'
+import type { RhinestoneAccount, Session } from '../../../src/index'
 import {
   DUMMY_PRECLAIMOP_SELECTOR,
   DUMMY_PRECLAIMOP_TARGET,
@@ -29,17 +25,6 @@ import {
   expectOutcome,
 } from '../framework/runner'
 import { getTokenAddress } from '../framework/tokens'
-
-type Execution = { to: string; value: bigint; data: string }
-
-function readPreClaimExecutions(
-  prepared: PreparedTransactionData,
-): Record<number, Execution[]> | undefined {
-  const input = prepared.intentInput as
-    | { preClaimExecutions?: Record<number, Execution[]> }
-    | undefined
-  return input?.preClaimExecutions
-}
 
 describe.sequential('SDK integration preclaim-ops', () => {
   // A fresh session needs enabling, so the SDK injects the dummy enable op as
@@ -73,8 +58,8 @@ describe.sequential('SDK integration preclaim-ops', () => {
     expectOutcome(execution, { kind: 'success' })
     if (execution.phase !== 'success') return
 
-    const preClaim = readPreClaimExecutions(execution.prepared)
-    const ops = preClaim?.[sourceChain.id]
+    const ops =
+      execution.prepared.intentInput.preClaimExecutions?.[sourceChain.id]
     expect(ops?.length).toBe(2)
     expect(ops?.[0].to.toLowerCase()).toBe(
       DUMMY_PRECLAIMOP_TARGET.toLowerCase(),
@@ -107,7 +92,7 @@ describe.sequential('SDK integration preclaim-ops', () => {
     expectOutcome(execution, { kind: 'success' })
     if (execution.phase !== 'success') return
 
-    expect(readPreClaimExecutions(execution.prepared)).toBeUndefined()
+    expect(execution.prepared.intentInput.preClaimExecutions).toBeUndefined()
   })
 
   // Source calls aren't just encoded — they run on-chain. A cross-chain intent

--- a/test/types/public-boundary.ts
+++ b/test/types/public-boundary.ts
@@ -1,4 +1,4 @@
-import type { HashTypedDataParameters, Hex } from 'viem'
+import type { Address, HashTypedDataParameters, Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 import * as ecdsaActions from '../../src/actions/ecdsa'
@@ -14,6 +14,7 @@ import {
   type RhinestoneAccount,
   type RhinestoneAccountConfig,
   RhinestoneSDK,
+  type SerializedIntentInput,
   type SignData,
   type SignedIntentData,
   type SignedTransactionData,
@@ -92,6 +93,28 @@ const crossChainNonEvmWithDeadline = {
   targetChain: tronMainnet,
   customDeadline: 9_999_999_999,
 } as const satisfies Transaction
+// A sponsorship server types its request body with the serialized input and
+// reads it without casts; bigint fields arrive as decimal strings.
+declare const sponsorshipBody: SerializedIntentInput
+const sponsoredAccount: Address | string = sponsorshipBody.account.address
+const sponsoredChainId: number = sponsorshipBody.destinationChainId
+const sponsoredCallValue: string =
+  sponsorshipBody.destinationExecutions[0].value
+const sponsoredGasUnits: string | undefined =
+  sponsorshipBody.destinationGasUnits
+const sponsoredTokenAmount: string | undefined =
+  sponsorshipBody.tokenRequests[0].amount
+const preparedIntentInput: SerializedIntentInput = prepared.intentInput
+
+new RhinestoneSDK({
+  auth: {
+    mode: 'experimental_jwt',
+    accessToken: 'access-token',
+    getIntentExtensionToken: async (intentInput: SerializedIntentInput) =>
+      `token-${intentInput.destinationChainId}`,
+  },
+})
+
 const sponsorLimitKey: SponsorLimitKey = 'perIntentUSD'
 const bridgeSponsored: boolean = quote.cost.fees.breakdown.bridge.sponsored
 const sponsorSurchargeUsd: number =
@@ -136,6 +159,12 @@ void crossChainNonEvmWithDeadline
 void sponsorLimitKey
 void bridgeSponsored
 void sponsorSurchargeUsd
+void sponsoredAccount
+void sponsoredChainId
+void sponsoredCallValue
+void sponsoredGasUnits
+void sponsoredTokenAmount
+void preparedIntentInput
 void actions
 void ecdsaActions
 void mfaActions


### PR DESCRIPTION
- Add `SerializedIntentInput`, the transport form of `IntentInput` with every `bigint` field as a decimal string. Derived from `IntentInput` via an internal mapped type, so it tracks the canonical shape instead of drifting from it.
- Type `PreparedTransactionData.intentInput` and the JWT auth `getIntentExtensionToken` callback (public `JwtAuth` plus the `SdkAuthInput` / `ResolvedAuth` mirrors) with it in place of `unknown`. Narrowing a callback parameter is source-compatible: an existing `(intentInput: unknown) => …` callback stays assignable.
- Drop the two local casts in the integration tests that reconstructed this shape by hand.

This is the object the SDK produces in `projectCompatibleIntentInput` and hands to a sponsorship endpoint; downstream (1auth) currently re-derives the bigint→string mapping locally to type its request body. Compile-time shape only — untrusted request bodies still need runtime validation.

`check:architecture` forbids `config → clients`, with a type-only exemption for the public config types that reference orchestrator public types. The auth callback carries exactly one shape end to end, so the exemption now covers `config/input.ts` and `config/resolved.ts` too rather than leaving those declarations at `unknown`.

`api/account.ts` gains one `as unknown as` where the public prepared data is reconstructed into the internal request — that path already relied on strings standing in for bigints; submission only re-serializes the value (a no-op on strings, so the sponsorship digest is unchanged) and reads `options.sponsorSettings`.

### On narrowing `PreparedTransactionData.intentInput`

Accepted deliberately, not overlooked. The narrowing does make the released `PreparedTransactionData` non-assignable to the current one, so `test/contract/fixtures/assignability.ts` would fail under the strict gate — the suite gates that fixture off for a declared minor (`test/contract/package.ctest.ts:174-178`), which is the policy this repo already encodes for an intentional additive surface change.

The field is produced by `prepareTransaction` and read back by `signTransaction` / `submitTransaction`, so consumers that pass SDK-returned values through are unaffected. The one case that needs an annotation is a value typed against the previous release — a mocked or persisted prepared object — where `intentInput` was `unknown`. `bun run test:contract` against this PR's base passes (11/11).

Closes [RHI-5251](https://linear.app/rhinestone/issue/RHI-5251)
Relates to [RHI-5369](https://linear.app/rhinestone/issue/RHI-5369)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
