### PR TITLE
fix(sdk): normalize WebAuthn assertions

### DIFF
--- a/.changeset/normalize-webauthn-assertions.md
+++ b/.changeset/normalize-webauthn-assertions.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Prevent unusable WebAuthn signatures by deriving client-data offsets and normalizing P-256 signatures to low-s before packing. Supplied `challengeIndex` and `typeIndex` values remain accepted for compatibility but no longer override the values derived from `clientDataJSON`.

--- a/src/modules/validators/contribution.test.ts
+++ b/src/modules/validators/contribution.test.ts
@@ -16,6 +16,9 @@ const validator = {
   address: '0x1111111111111111111111111111111111111111' as const,
 }
 const account = '0x2222222222222222222222222222222222222222' as const
+const p256CurveOrder =
+  0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n
+const p256HalfCurveOrder = p256CurveOrder / 2n
 const raw = (byte: string, recovery = '00') =>
   `0x${byte.repeat(64)}${recovery}` as Hex
 
@@ -111,7 +114,7 @@ describe('validator contribution codecs', () => {
       publicKey,
       signature: raw(index === 0 ? '55' : '66').slice(0, -2) as Hex,
       authenticatorData: `0x${'77'.repeat(37)}` as Hex,
-      clientDataJSON: `{"index":${index}}`,
+      clientDataJSON: `{"type":"webauthn.get","challenge":"value-${index}"}`,
       challengeIndex: index,
       typeIndex: index + 1,
     }))
@@ -144,24 +147,60 @@ describe('validator contribution codecs', () => {
     expect(usePrecompile).toBe(true)
     expect(credentialIds).toEqual([...credentialIds].sort())
     expect(assertions).toHaveLength(2)
+    expect(assertions.map((assertion) => assertion.slice(2, 4))).toEqual([
+      [23n, 1n],
+      [23n, 1n],
+    ])
   })
 
-  test('validates WebAuthn low-level and V0 shapes', () => {
+  test('normalizes WebAuthn low-level and V0 shapes', () => {
     const signature = {
       authenticatorData: '0x1234' as Hex,
-      clientDataJSON: '{}',
+      clientDataJSON: '{"note":"é","type":"webauthn.get","challenge":"value"}',
       challengeIndex: 0n,
-      typeIndex: 1n,
+      typeIndex: 0n,
       r: 2n,
-      s: 3n,
+      s: p256HalfCurveOrder + 1n,
     }
-    expect(encodeWebauthnSignatures([], false, [signature])).toMatch(/^0x/)
+    const [, , assertions] = decodeAbiParameters(
+      [
+        { type: 'bytes32[]' },
+        { type: 'bool' },
+        {
+          type: 'tuple[]',
+          components: [
+            { type: 'bytes' },
+            { type: 'string' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+          ],
+        },
+      ],
+      encodeWebauthnSignatures([`0x${'11'.repeat(32)}`], false, [signature]),
+    )
+    expect(assertions[0].slice(2)).toEqual([35n, 13n, 2n, p256HalfCurveOrder])
+
+    const [, , typeIndex, , s] = decodeAbiParameters(
+      [
+        { type: 'bytes' },
+        { type: 'string' },
+        { type: 'uint256' },
+        { type: 'uint256' },
+        { type: 'uint256' },
+        { type: 'bool' },
+      ],
+      encodeWebauthnSignatureV0(signature, false),
+    )
+    expect(typeIndex).toBe(13n)
+    expect(s).toBe(p256HalfCurveOrder)
+
     expect(() => parseWebauthnSignature('0x12')).toThrow()
     expect(parseWebauthnSignature(raw('11'))).toEqual({
       r: BigInt(`0x${'11'.repeat(32)}`),
       s: BigInt(`0x${'11'.repeat(32)}`),
     })
-    expect(encodeWebauthnSignatureV0(signature, false)).toMatch(/^0x/)
     expect(generateWebauthnCredentialId(1n, 2n, account)).toHaveLength(66)
   })
 

--- a/src/modules/validators/webauthn.ts
+++ b/src/modules/validators/webauthn.ts
@@ -5,6 +5,7 @@ import {
   type Hex,
   hexToBytes,
   keccak256,
+  stringToBytes,
 } from 'viem'
 import type { ResolvedModule } from '../types'
 import type { AtomicValidatorDefinition } from './types'
@@ -34,6 +35,64 @@ export interface WebAuthnSignature {
   typeIndex: bigint
   r: bigint
   s: bigint
+}
+
+type NormalizedWebAuthnSignature = WebAuthnSignature & {
+  challengeIndex: bigint
+  typeIndex: bigint
+}
+
+const P256_CURVE_ORDER =
+  0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n
+const P256_HALF_CURVE_ORDER = P256_CURVE_ORDER / 2n
+const WEBAUTHN_TYPE_LITERAL = stringToBytes('"type":"webauthn.get"')
+const WEBAUTHN_CHALLENGE_LITERAL = stringToBytes('"challenge":"')
+
+function findClientDataLiteral(
+  clientData: Uint8Array,
+  literal: Uint8Array,
+  name: 'type' | 'challenge',
+): bigint {
+  const lastStart = clientData.length - literal.length
+  for (let start = 0; start <= lastStart; start++) {
+    if (literal.every((byte, offset) => clientData[start + offset] === byte)) {
+      return BigInt(start)
+    }
+  }
+  throw new Error(
+    `WebAuthn clientDataJSON is missing the required ${name} field`,
+  )
+}
+
+function normalizeP256S(s: bigint): bigint {
+  return s > P256_HALF_CURVE_ORDER ? P256_CURVE_ORDER - s : s
+}
+
+function normalizeWebauthnSignature(
+  signature: WebAuthnSignature,
+): NormalizedWebAuthnSignature {
+  const clientData = stringToBytes(signature.clientDataJSON)
+  return {
+    ...signature,
+    challengeIndex: findClientDataLiteral(
+      clientData,
+      WEBAUTHN_CHALLENGE_LITERAL,
+      'challenge',
+    ),
+    typeIndex: findClientDataLiteral(clientData, WEBAUTHN_TYPE_LITERAL, 'type'),
+    s: normalizeP256S(signature.s),
+  }
+}
+
+function normalizeWebauthnSignatureV0(
+  signature: Omit<WebAuthnSignature, 'challengeIndex'>,
+): Omit<NormalizedWebAuthnSignature, 'challengeIndex'> {
+  const clientData = stringToBytes(signature.clientDataJSON)
+  return {
+    ...signature,
+    typeIndex: findClientDataLiteral(clientData, WEBAUTHN_TYPE_LITERAL, 'type'),
+    s: normalizeP256S(signature.s),
+  }
 }
 
 export function parseWebauthnPublicKey(publicKey: Hex | Uint8Array): PublicKey {
@@ -81,7 +140,7 @@ export function encodeWebauthnSignatures(
   const ordered = credentialIds
     .map((credentialId, index) => ({
       credentialId,
-      signature: signatures[index],
+      signature: normalizeWebauthnSignature(signatures[index]),
     }))
     .sort((left, right) => left.credentialId.localeCompare(right.credentialId))
   return encodeAbiParameters(
@@ -113,6 +172,7 @@ export function encodeWebauthnSignatureV0(
   signature: Omit<WebAuthnSignature, 'challengeIndex'>,
   usePrecompile: boolean,
 ): Hex {
+  const normalized = normalizeWebauthnSignatureV0(signature)
   return encodeAbiParameters(
     [
       { type: 'bytes', name: 'authenticatorData' },
@@ -123,11 +183,11 @@ export function encodeWebauthnSignatureV0(
       { type: 'bool', name: 'usePrecompiled' },
     ],
     [
-      signature.authenticatorData,
-      signature.clientDataJSON,
-      signature.typeIndex,
-      signature.r,
-      signature.s,
+      normalized.authenticatorData,
+      normalized.clientDataJSON,
+      normalized.typeIndex,
+      normalized.r,
+      normalized.s,
       usePrecompile,
     ],
   )

--- a/src/signing/intent-plans/intent.test.ts
+++ b/src/signing/intent-plans/intent.test.ts
@@ -286,7 +286,7 @@ describe('intent signing plans', () => {
     const assertion = {
       signature: passkeySignature,
       authenticatorData: `0x${'99'.repeat(37)}` as Hex,
-      clientDataJSON: '{}',
+      clientDataJSON: '{"type":"webauthn.get","challenge":"value"}',
       challengeIndex: 0,
       typeIndex: 1,
       userVerificationRequired: false,

--- a/src/signing/passkeys.test.ts
+++ b/src/signing/passkeys.test.ts
@@ -1,4 +1,5 @@
 import type { Hex } from 'viem'
+import { decodeAbiParameters, stringToBytes } from 'viem'
 import { describe, expect, test } from 'vitest'
 import {
   generateCredentialId,
@@ -8,8 +9,45 @@ import {
   parseSignature,
 } from './passkeys'
 
-describe('rewritten passkey compatibility surface', () => {
-  test('preserves parsing, credential, and packing shapes', () => {
+const P256_CURVE_ORDER =
+  0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551n
+const P256_HALF_CURVE_ORDER = P256_CURVE_ORDER / 2n
+const clientDataJSON =
+  '{"note":"é","type":"webauthn.get","challenge":"abc","origin":"https://example.com"}'
+const credentialId = `0x${'11'.repeat(32)}` as Hex
+
+const currentSignatureParameters = [
+  { type: 'bytes32[]', name: 'credIds' },
+  { type: 'bool', name: 'usePrecompile' },
+  {
+    type: 'tuple[]',
+    name: 'webAuthns',
+    components: [
+      { type: 'bytes', name: 'authenticatorData' },
+      { type: 'string', name: 'clientDataJSON' },
+      { type: 'uint256', name: 'challengeIndex' },
+      { type: 'uint256', name: 'typeIndex' },
+      { type: 'uint256', name: 'r' },
+      { type: 'uint256', name: 's' },
+    ],
+  },
+] as const
+
+const v0SignatureParameters = [
+  { type: 'bytes', name: 'authenticatorData' },
+  { type: 'string', name: 'clientDataJSON' },
+  { type: 'uint256', name: 'responseTypeLocation' },
+  { type: 'uint256', name: 'r' },
+  { type: 'uint256', name: 's' },
+  { type: 'bool', name: 'usePrecompiled' },
+] as const
+
+function byteIndex(value: string, literal: string): bigint {
+  return BigInt(stringToBytes(value.slice(0, value.indexOf(literal))).length)
+}
+
+describe('passkey compatibility surface', () => {
+  test('preserves parsing and credential generation', () => {
     const publicKey = `0x04${'11'.repeat(32)}${'22'.repeat(32)}` as Hex
     const signature = `0x${'33'.repeat(32)}${'44'.repeat(32)}` as Hex
     expect(parsePublicKey(publicKey)).toEqual({
@@ -20,19 +58,86 @@ describe('rewritten passkey compatibility surface', () => {
       r: BigInt(`0x${'33'.repeat(32)}`),
       s: BigInt(`0x${'44'.repeat(32)}`),
     })
-    const credentialId = generateCredentialId(
-      parsePublicKey(publicKey).x,
-      parsePublicKey(publicKey).y,
-      '0x1111111111111111111111111111111111111111',
+    expect(
+      generateCredentialId(
+        parsePublicKey(publicKey).x,
+        parsePublicKey(publicKey).y,
+        '0x1111111111111111111111111111111111111111',
+      ),
+    ).toHaveLength(66)
+  })
+
+  test('derives current byte offsets and normalizes high-s assertions', () => {
+    const encoded = packSignature([credentialId], true, [
+      {
+        authenticatorData: '0x1234',
+        clientDataJSON,
+        challengeIndex: 0n,
+        typeIndex: 0n,
+        r: 2n,
+        s: P256_HALF_CURVE_ORDER + 1n,
+      },
+    ])
+    const [, usePrecompile, assertions] = decodeAbiParameters(
+      currentSignatureParameters,
+      encoded,
     )
-    const assertion = {
-      authenticatorData: '0x1234' as Hex,
-      clientDataJSON: '{}',
-      challengeIndex: 0n,
-      typeIndex: 1n,
-      ...parseSignature(signature),
-    }
-    expect(packSignature([credentialId], true, [assertion])).toMatch(/^0x/)
-    expect(packSignatureV0(assertion, false)).toMatch(/^0x/)
+
+    expect(usePrecompile).toBe(true)
+    expect(assertions[0]).toMatchObject({
+      challengeIndex: byteIndex(clientDataJSON, '"challenge":"'),
+      typeIndex: byteIndex(clientDataJSON, '"type":"webauthn.get"'),
+      r: 2n,
+      s: P256_HALF_CURVE_ORDER,
+    })
+  })
+
+  test('derives the V0 type index and preserves low-s', () => {
+    const encoded = packSignatureV0(
+      {
+        authenticatorData: '0x1234',
+        clientDataJSON,
+        typeIndex: 0,
+        r: 2n,
+        s: 3n,
+      },
+      false,
+    )
+    const [, , typeIndex, , s, usePrecompile] = decodeAbiParameters(
+      v0SignatureParameters,
+      encoded,
+    )
+
+    const expectedTypeIndex = byteIndex(clientDataJSON, '"type":"webauthn.get"')
+    expect(typeIndex).toBe(expectedTypeIndex)
+    expect(s).toBe(3n)
+    expect(usePrecompile).toBe(false)
+  })
+
+  test('rejects client data without required literals', () => {
+    expect(() =>
+      packSignature([credentialId], false, [
+        {
+          authenticatorData: '0x1234',
+          clientDataJSON: '{"type":"webauthn.get"}',
+          challengeIndex: 0n,
+          typeIndex: 0n,
+          r: 2n,
+          s: 3n,
+        },
+      ]),
+    ).toThrow('required challenge field')
+    expect(() =>
+      packSignatureV0(
+        {
+          authenticatorData: '0x1234',
+          clientDataJSON: '{"type": "webauthn.get"}',
+          typeIndex: 0,
+          r: 2n,
+          s: 3n,
+        },
+        false,
+      ),
+    ).toThrow('required type field')
   })
 })

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -36,7 +36,7 @@ const passkeyResult = {
   signature: `0x${'33'.repeat(64)}` as const,
   webauthn: {
     authenticatorData: '0x1234' as const,
-    clientDataJSON: '{}',
+    clientDataJSON: '{"type":"webauthn.get","challenge":"value"}',
     challengeIndex: 0,
     typeIndex: 0,
     userVerificationRequired: false,


### PR DESCRIPTION
- Derive contract-compatible WebAuthn client-data offsets from the original UTF-8 payload and reject missing required fields.
- Normalize P-256 signatures to low-s across current and V0 encoding paths.
- Preserve the existing required offset fields for patch-level declaration compatibility; supplied values are ignored in favor of derived offsets. Making them optional remains a separate public-surface change.

Closes [RHI-5294](https://linear.app/rhinestone/issue/RHI-5294)