### PR TITLE
Drop Solady runtime dependency

### DIFF
--- a/.changeset/light-fastlz.md
+++ b/.changeset/light-fastlz.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Remove the Solady runtime dependency while preserving byte-compatible FastLZ encoding for Smart Sessions enable signatures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Docs: https://docs.rhinestone.dev/smart-wallet
 - Language: TypeScript (strict mode)
 - Testing: Vitest
 - Linting: Biome
-- Dependencies: viem (peer), solady, jose (optional peer, for `jwt-server`)
+- Dependencies: viem (peer), jose and express (optional peers for `jwt-server`); the published package has no runtime dependencies
 
 ## Structure
 

--- a/bun.lock
+++ b/bun.lock
@@ -28,10 +28,7 @@
     },
     "src": {
       "name": "@rhinestone/sdk",
-      "version": "2.0.0-beta.43",
-      "dependencies": {
-        "solady": "^0.1.26",
-      },
+      "version": "2.1.0",
       "peerDependencies": {
         "express": ">=4",
         "jose": ">=5.0.0",
@@ -661,8 +658,6 @@
     "size-limit": ["size-limit@11.2.0", "", { "dependencies": { "bytes-iec": "^3.1.1", "chokidar": "^4.0.3", "jiti": "^2.4.2", "lilconfig": "^3.1.3", "nanospinner": "^1.2.2", "picocolors": "^1.1.1", "tinyglobby": "^0.2.11" }, "bin": { "size-limit": "bin.js" } }, "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
-
-    "solady": ["solady@0.1.26", "", {}, "sha512-dhGr/ptJFdea/1KE6xgqgwEdbMhUiSfRc6A+jLeltPe16zyt9qtED3PElIBVRnzEmUO5aZTjKVAr6SlqXBBcIw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/src/modules/validators/smart-sessions.test.ts
+++ b/src/modules/validators/smart-sessions.test.ts
@@ -16,6 +16,7 @@ import { accountA, accountB } from '../../../test/consts'
 import type { ArgPolicyExpression } from '../../config/account'
 import { PERMIT2_CLAIM_POLICY_ADDRESS } from './policies/claim/permit2'
 import { getPermissionId, getSessionData } from './smart-sessions/digest'
+import { fastLzDecompress } from './smart-sessions/fast-lz'
 import { buildSmartSessionMockSignature } from './smart-sessions/mock-signature'
 import { SMART_SESSION_EMISSARY_ADDRESS } from './smart-sessions/module'
 import {
@@ -37,7 +38,10 @@ import {
   SMART_SESSIONS_FALLBACK_TARGET_SELECTOR_FLAG,
   toSession,
 } from './smart-sessions/resolve'
-import { encodeSmartSessionSignature as packSignature } from './smart-sessions/signature'
+import {
+  encodeSmartSessionEnablePayload,
+  encodeSmartSessionSignature as packSignature,
+} from './smart-sessions/signature'
 import type {
   ResolvedSessionSignerSet,
   Session,
@@ -1082,22 +1086,31 @@ describe('packSignature', () => {
     expect(slice(result, 0, 1)).toBe('0x01')
   })
 
-  test('verifyExecutions: true + enableData → longer output (has compressed payload)', () => {
+  test('verifyExecutions: true + enableData → compressed payload decodes to the ABI data', () => {
+    const enableData = {
+      userSignature: dummySig,
+      hashesAndChainIds: [
+        { chainId: BigInt(base.id), sessionDigest: zeroHash },
+      ],
+      sessionToEnableIndex: 0,
+    }
     const signers: ResolvedSessionSignerSet = {
       kind: 'smart-session',
       session: baseSession,
       verifyExecutions: true,
-      enableData: {
-        userSignature: dummySig,
-        hashesAndChainIds: [
-          { chainId: BigInt(base.id), sessionDigest: zeroHash },
-        ],
-        sessionToEnableIndex: 0,
-      },
+      enableData,
     }
     const result = packSignature(signers, dummySig)
-    const byteLen = (result.length - 2) / 2
-    expect(byteLen).toBeGreaterThan(33)
+    const expectedPayload = encodeSmartSessionEnablePayload({
+      permissionId: getPermissionId(baseSession),
+      signature: dummySig,
+      enableData: {
+        ...enableData,
+        session: getSessionData(baseSession),
+      },
+    })
+
+    expect(fastLzDecompress(slice(result, 1))).toBe(expectedPayload)
   })
 
   test('verifyExecutions: true, no enableData → MODE_USE (0x00) prefix', () => {
@@ -1168,7 +1181,7 @@ describe('buildMockSignature', () => {
     expect(slice(sigProd, 0, 20)).not.toBe(slice(sigDev, 0, 20))
   })
 
-  test('chainCount=2 produces valid output (LibZip may compress smaller than chainCount=1)', () => {
+  test('chainCount=2 produces a valid compressed payload', () => {
     const sig = buildMockSignature(baseSession, false, 2)
     // Must be at least emissaryAddress (20) + mode byte (1) + some payload
     const byteLen = (sig.length - 2) / 2

--- a/src/modules/validators/smart-sessions/fast-lz.test.ts
+++ b/src/modules/validators/smart-sessions/fast-lz.test.ts
@@ -1,0 +1,178 @@
+import fc from 'fast-check'
+import { bytesToHex, type Hex, keccak256, size, zeroHash } from 'viem'
+import { describe, expect, test } from 'vitest'
+import { fastLzCompress, fastLzDecompress } from './fast-lz'
+import { encodeSmartSessionEnablePayload } from './signature'
+
+const address = '0x1111111111111111111111111111111111111111' as const
+const otherAddress = '0x2222222222222222222222222222222222222222' as const
+const permissionId = `0x${'33'.repeat(32)}` as Hex
+const validatorSignature = `0x${'44'.repeat(65)}` as Hex
+
+function repeated(length: number, value = 0): Hex {
+  return bytesToHex(new Uint8Array(length).fill(value))
+}
+
+function sequence(length: number): Hex {
+  return bytesToHex(Uint8Array.from({ length }, (_, index) => index & 0xff))
+}
+
+function enablePayload(chainCount: number, withPolicies: boolean): Hex {
+  return encodeSmartSessionEnablePayload({
+    permissionId,
+    signature: validatorSignature,
+    enableData: {
+      userSignature: `0x${'55'.repeat(65)}`,
+      hashesAndChainIds: Array.from({ length: chainCount }, (_, index) => ({
+        chainId: BigInt(index + 1),
+        sessionDigest:
+          `0x${(index + 1).toString(16).padStart(2, '0').repeat(32)}` as Hex,
+      })),
+      sessionToEnableIndex: 0,
+      session: {
+        sessionValidator: address,
+        sessionValidatorInitData: '0x1234',
+        salt: zeroHash,
+        actions: withPolicies
+          ? [
+              {
+                actionTargetSelector: '0xa9059cbb',
+                actionTarget: otherAddress,
+                actionPolicies: [{ policy: address, initData: '0x01020304' }],
+              },
+            ]
+          : [],
+        claimPolicies: withPolicies
+          ? [{ policy: otherAddress, initData: '0xaabbccdd' }]
+          : [],
+        erc7739Policies: {
+          allowedERC7739Content: withPolicies
+            ? [
+                {
+                  appDomainSeparator: permissionId,
+                  contentNames: ['Transfer(address,uint256)', 'Permit'],
+                },
+              ]
+            : [],
+          erc1271Policies: withPolicies
+            ? [{ policy: address, initData: '0xdeadbeef' }]
+            : [],
+        },
+      },
+    },
+  })
+}
+
+const arbitraryHex = fc
+  .uint8Array({ maxLength: 12_000 })
+  .map((bytes) => bytesToHex(bytes))
+
+const repeatedHex = fc
+  .record({
+    chunk: fc.uint8Array({ minLength: 1, maxLength: 64 }),
+    repeats: fc.integer({ min: 1, max: 256 }),
+    suffix: fc.uint8Array({ maxLength: 64 }),
+  })
+  .map(({ chunk, repeats, suffix }) => {
+    const bytes = new Uint8Array(chunk.length * repeats + suffix.length)
+    for (let index = 0; index < repeats; index++) {
+      bytes.set(chunk, index * chunk.length)
+    }
+    bytes.set(suffix, chunk.length * repeats)
+    return bytesToHex(bytes)
+  })
+
+describe('FastLZ', () => {
+  test('matches golden boundary vectors', () => {
+    const vectors = {
+      empty: '0x' as Hex,
+      short: '0x000102' as Hex,
+      literalBlock: sequence(32),
+      literalBlockBoundary: sequence(33),
+      shortMatch: repeated(32),
+      extendedMatch: repeated(269),
+      extendedMatchBoundary: repeated(271),
+      splitMatch: repeated(272),
+    }
+
+    const compressed = Object.fromEntries(
+      Object.entries(vectors).map(([name, input]) => [
+        name,
+        fastLzCompress(input),
+      ]),
+    )
+    expect(compressed).toMatchInlineSnapshot(`
+      {
+        "empty": "0x",
+        "extendedMatch": "0x010000e0fd01040000000000",
+        "extendedMatchBoundary": "0x010000e0ff01040000000000",
+        "literalBlock": "0x1f000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "literalBlockBoundary": "0x1f000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f0020",
+        "short": "0x02000102",
+        "shortMatch": "0x010000e01001040000000000",
+        "splitMatch": "0x010000e0fd012001040000000000",
+      }
+    `)
+  })
+
+  test('matches the golden distance-window vector', () => {
+    const bytes = new Uint8Array(8_260)
+    for (let index = 0; index < bytes.length; index++) {
+      bytes[index] = (index * 131 + (index >> 3)) & 0xff
+    }
+    bytes.set(bytes.slice(0, 64), 8_190)
+    const input = bytesToHex(bytes)
+    const compressed = fastLzCompress(input)
+
+    expect({
+      bytes: size(compressed),
+      hash: keccak256(compressed),
+    }).toMatchInlineSnapshot(`
+        {
+          "bytes": 1133,
+          "hash": "0xff6866815afefb2e1817673beede5e19c5f59b1dd8c0f88c5fab5dc5b53e7cf1",
+        }
+      `)
+  })
+
+  test('matches golden realistic enable payloads', () => {
+    const payloads = {
+      singleChain: enablePayload(1, false),
+      multiChainWithPolicies: enablePayload(3, true),
+    }
+    const compressed = Object.fromEntries(
+      Object.entries(payloads).map(([name, input]) => [
+        name,
+        fastLzCompress(input),
+      ]),
+    )
+
+    expect(compressed).toMatchInlineSnapshot(`
+      {
+        "multiChainWithPolicies": "0x010000e0140100c0e0141de019000006e017220033e01600e0153f0008e0179f0080e0153f0200c0ffe016002023e01200010140e0121c400000204004e03200014155e03700e0327ce01a000060e01523e1181f0003e0153f010001e017002023e013000002e01700e0133c20000003e017002023e000000011e00a00e0001ce00d00e217bfe01600e018fee1169f0003e2179f02021234e01682e01500e017a00420a9059cbbe01542e001000022e00a00e0011de00c00e016ffe0199f2023e00000e10adee117dfe4171f040401020304e00060e02900e1185fe00352e10a3ee1173fe018bf03aabbccdde00363e02600e0165f0101a0e0164fe018ffe6165ee6165fe0179f0000e4173fe016dfe6189f19195472616e7366657228616464726573732c75696e7432353629203ce01a0006065065726d6974e01a29e00d00e1185fe00336230ee00800e0031fe00a00e1171f0404deadbeefe00a37e01f00014144e03700e01169040000000000",
+        "singleChain": "0x010000e0140100c0e0141de019000006e017220033e01600e0153f010480e0151f0000e0171f01c0ffe016002043e01200010140e0121c400000204004e03200014155e03700e0327ce01a000060e01623e2173f0001e0163f0001e01700e0033f0011e00a00e0031fe00a00e0179fe01600e0047ee00a000001e116ffe2183f02021234e00a56e06100e217dfe117ffe03700014144e03700e01181040000000000",
+      }
+    `)
+    for (const [name, input] of Object.entries(payloads)) {
+      expect(fastLzDecompress(compressed[name] as Hex)).toBe(input)
+    }
+  })
+
+  test('round-trips arbitrary byte strings', () => {
+    fc.assert(
+      fc.property(arbitraryHex, (input) => {
+        expect(fastLzDecompress(fastLzCompress(input))).toBe(input)
+      }),
+      { numRuns: 250 },
+    )
+  })
+
+  test('round-trips repetition-heavy byte strings', () => {
+    fc.assert(
+      fc.property(repeatedHex, (input) => {
+        expect(fastLzDecompress(fastLzCompress(input))).toBe(input)
+      }),
+      { numRuns: 250 },
+    )
+  })
+})

--- a/src/modules/validators/smart-sessions/fast-lz.ts
+++ b/src/modules/validators/smart-sessions/fast-lz.ts
@@ -1,0 +1,180 @@
+/*
+ * Adapted from Solady's LibZip FastLZ implementation:
+ * https://github.com/Vectorized/solady/blob/main/js/solady.js
+ * Copyright (c) 2022-2025 Solady.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { bytesToHex, type Hex, hexToBytes } from 'viem'
+
+const HASH_TABLE_SIZE = 8192
+const MAX_DISTANCE = 8192
+const MAX_LITERAL_LENGTH = 32
+const MAX_MATCH_EXTENSION = 262
+
+function readUint24(bytes: Uint8Array, index: number): number {
+  return bytes[index] | (bytes[index + 1] << 8) | (bytes[index + 2] << 16)
+}
+
+function hashUint24(value: number): number {
+  // Keep Solady's number multiplication and signed shift semantics. Math.imul
+  // changes buckets for some inputs and therefore changes compressed bytes.
+  return ((2654435769 * value) >> 19) & (HASH_TABLE_SIZE - 1)
+}
+
+function writeLiterals(
+  output: number[],
+  input: Uint8Array,
+  start: number,
+  length: number,
+): void {
+  let cursor = start
+  let remaining = length
+  while (remaining >= MAX_LITERAL_LENGTH) {
+    output.push(MAX_LITERAL_LENGTH - 1)
+    for (let index = 0; index < MAX_LITERAL_LENGTH; index++) {
+      output.push(input[cursor++])
+    }
+    remaining -= MAX_LITERAL_LENGTH
+  }
+  if (remaining === 0) return
+
+  output.push(remaining - 1)
+  while (remaining-- > 0) output.push(input[cursor++])
+}
+
+function writeMatch(
+  output: number[],
+  distance: number,
+  extensionLength: number,
+): void {
+  const encodedDistance = distance - 1
+  let remaining = extensionLength
+
+  while (remaining > MAX_MATCH_EXTENSION) {
+    output.push(0xe0 + (encodedDistance >> 8), 253, encodedDistance & 0xff)
+    remaining -= MAX_MATCH_EXTENSION
+  }
+  if (remaining < 7) {
+    output.push(
+      (remaining << 5) + (encodedDistance >> 8),
+      encodedDistance & 0xff,
+    )
+    return
+  }
+  output.push(
+    0xe0 + (encodedDistance >> 8),
+    remaining - 7,
+    encodedDistance & 0xff,
+  )
+}
+
+export function fastLzCompress(data: Hex): Hex {
+  const input = hexToBytes(data)
+  const inputBoundary = input.length - 4
+  const hashTable = new Uint32Array(HASH_TABLE_SIZE)
+  const output: number[] = []
+  let anchor = 0
+  let cursor = 2
+
+  while (cursor < inputBoundary - 9) {
+    let reference = 0
+    let distance = 0
+    let matched = false
+
+    while (cursor < inputBoundary - 9) {
+      const sequence = readUint24(input, cursor)
+      const hash = hashUint24(sequence)
+      reference = hashTable[hash] || 0
+      hashTable[hash] = cursor
+      distance = cursor - reference
+      const candidate =
+        distance < MAX_DISTANCE ? readUint24(input, reference) : 0x1000000
+      cursor++
+      if (sequence === candidate) {
+        matched = true
+        break
+      }
+    }
+
+    if (!matched || cursor >= inputBoundary - 9) break
+    cursor--
+    if (cursor > anchor) {
+      writeLiterals(output, input, anchor, cursor - anchor)
+    }
+
+    const referenceStart = reference + 3
+    const matchStart = cursor + 3
+    const comparisonLength = inputBoundary - matchStart
+    let extensionLength = 0
+    while (extensionLength < comparisonLength) {
+      const matches =
+        input[referenceStart + extensionLength] ===
+        input[matchStart + extensionLength]
+      extensionLength++
+      if (!matches) break
+    }
+
+    cursor += extensionLength
+    writeMatch(output, distance, extensionLength)
+
+    hashTable[hashUint24(readUint24(input, cursor))] = cursor++
+    hashTable[hashUint24(readUint24(input, cursor))] = cursor++
+    anchor = cursor
+  }
+
+  writeLiterals(output, input, anchor, input.length - anchor)
+  return bytesToHex(Uint8Array.from(output))
+}
+
+export function fastLzDecompress(data: Hex): Hex {
+  const input = hexToBytes(data)
+  const output: number[] = []
+  let cursor = 0
+
+  while (cursor < input.length) {
+    const control = input[cursor]
+    const matchType = control >> 5
+    if (matchType === 0) {
+      let literalLength = control + 1
+      cursor++
+      while (literalLength-- > 0) output.push(input[cursor++])
+      continue
+    }
+
+    const shortMatch = matchType < 7
+    const distance = 256 * (control & 31) + input[cursor + (shortMatch ? 1 : 2)]
+    let matchLength: number
+    if (shortMatch) {
+      matchLength = matchType + 2
+      cursor += 2
+    } else {
+      matchLength = input[cursor + 1] + 9
+      cursor += 3
+    }
+
+    let reference = output.length - distance - 1
+    while (matchLength-- > 0) output.push(output[reference++])
+  }
+
+  return bytesToHex(Uint8Array.from(output))
+}

--- a/src/modules/validators/smart-sessions/signature.ts
+++ b/src/modules/validators/smart-sessions/signature.ts
@@ -1,4 +1,3 @@
-import { LibZip } from 'solady'
 import {
   encodeAbiParameters,
   encodePacked,
@@ -10,6 +9,7 @@ import {
 } from 'viem'
 import type { SmartSessionEnableContributionData } from '../smart-session-signature-types'
 import { getPermissionId, getSessionData } from './digest'
+import { fastLzCompress } from './fast-lz'
 import type { ResolvedSessionSignerSet } from './types'
 
 const SCOPE_MULTICHAIN = 0
@@ -78,126 +78,138 @@ export function encodeSmartSessionContribution(input: {
   if (!input.enableData) {
     throw new Error('Enable-and-use signatures require enable data')
   }
-  const compressed = LibZip.flzCompress(
-    encodeAbiParameters(
-      [
-        {
-          type: 'tuple',
-          name: 'enableData',
-          components: [
-            { type: 'bytes', name: 'allocatorSig' },
-            { type: 'bytes', name: 'userSig' },
-            { type: 'uint256', name: 'expires' },
-            {
-              type: 'tuple',
-              name: 'enableSession',
-              components: [
-                { type: 'uint8', name: 'chainDigestIndex' },
-                {
-                  type: 'tuple[]',
-                  name: 'hashesAndChainIds',
-                  components: [
-                    { type: 'uint64', name: 'chainId' },
-                    { type: 'bytes32', name: 'sessionDigest' },
-                  ],
-                },
-                {
-                  type: 'tuple',
-                  name: 'session',
-                  components: [
-                    { type: 'address', name: 'sessionValidator' },
-                    { type: 'bytes', name: 'sessionValidatorInitData' },
-                    { type: 'bytes32', name: 'salt' },
-                    {
-                      type: 'tuple[]',
-                      name: 'actions',
-                      components: [
-                        { type: 'bytes4', name: 'actionTargetSelector' },
-                        { type: 'address', name: 'actionTarget' },
-                        {
-                          type: 'tuple[]',
-                          name: 'actionPolicies',
-                          components: [
-                            { type: 'address', name: 'policy' },
-                            { type: 'bytes', name: 'initData' },
-                          ],
-                        },
-                      ],
-                    },
-                    {
-                      type: 'tuple[]',
-                      name: 'claimPolicies',
-                      components: [
-                        { type: 'address', name: 'policy' },
-                        { type: 'bytes', name: 'initData' },
-                      ],
-                    },
-                    {
-                      type: 'tuple',
-                      name: 'erc7739Policies',
-                      components: [
-                        {
-                          type: 'tuple[]',
-                          name: 'allowedERC7739Content',
-                          components: [
-                            {
-                              type: 'bytes32',
-                              name: 'appDomainSeparator',
-                            },
-                            { type: 'string[]', name: 'contentNames' },
-                          ],
-                        },
-                        {
-                          type: 'tuple[]',
-                          name: 'erc1271Policies',
-                          components: [
-                            { type: 'address', name: 'policy' },
-                            { type: 'bytes', name: 'initData' },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          type: 'tuple',
-          name: 'config',
-          components: [
-            { type: 'uint8', name: 'scope' },
-            { type: 'uint8', name: 'resetPeriod' },
-            { type: 'address', name: 'allocator' },
-            { type: 'bytes32', name: 'permissionId' },
-          ],
-        },
-        { type: 'bytes' },
-      ],
-      [
-        {
-          allocatorSig: zeroHash,
-          userSig: input.enableData.userSignature,
-          expires: maxUint256,
-          enableSession: {
-            chainDigestIndex: input.enableData.sessionToEnableIndex,
-            hashesAndChainIds: [...input.enableData.hashesAndChainIds],
-            session: input.enableData.session,
-          },
-        },
-        {
-          scope: SCOPE_MULTICHAIN,
-          resetPeriod: RESET_PERIOD_ONE_WEEK,
-          allocator: zeroAddress,
-          permissionId: input.permissionId,
-        },
-        input.signature,
-      ],
-    ),
-  ) as Hex
+  const compressed = fastLzCompress(
+    encodeSmartSessionEnablePayload({
+      permissionId: input.permissionId,
+      signature: input.signature,
+      enableData: input.enableData,
+    }),
+  )
   return encodePacked(
     ['bytes1', 'bytes'],
     [SMART_SESSION_MODE_ENABLE, compressed],
+  )
+}
+
+export function encodeSmartSessionEnablePayload(input: {
+  readonly permissionId: Hex
+  readonly signature: Hex
+  readonly enableData: SmartSessionEnableContributionData
+}): Hex {
+  return encodeAbiParameters(
+    [
+      {
+        type: 'tuple',
+        name: 'enableData',
+        components: [
+          { type: 'bytes', name: 'allocatorSig' },
+          { type: 'bytes', name: 'userSig' },
+          { type: 'uint256', name: 'expires' },
+          {
+            type: 'tuple',
+            name: 'enableSession',
+            components: [
+              { type: 'uint8', name: 'chainDigestIndex' },
+              {
+                type: 'tuple[]',
+                name: 'hashesAndChainIds',
+                components: [
+                  { type: 'uint64', name: 'chainId' },
+                  { type: 'bytes32', name: 'sessionDigest' },
+                ],
+              },
+              {
+                type: 'tuple',
+                name: 'session',
+                components: [
+                  { type: 'address', name: 'sessionValidator' },
+                  { type: 'bytes', name: 'sessionValidatorInitData' },
+                  { type: 'bytes32', name: 'salt' },
+                  {
+                    type: 'tuple[]',
+                    name: 'actions',
+                    components: [
+                      { type: 'bytes4', name: 'actionTargetSelector' },
+                      { type: 'address', name: 'actionTarget' },
+                      {
+                        type: 'tuple[]',
+                        name: 'actionPolicies',
+                        components: [
+                          { type: 'address', name: 'policy' },
+                          { type: 'bytes', name: 'initData' },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: 'tuple[]',
+                    name: 'claimPolicies',
+                    components: [
+                      { type: 'address', name: 'policy' },
+                      { type: 'bytes', name: 'initData' },
+                    ],
+                  },
+                  {
+                    type: 'tuple',
+                    name: 'erc7739Policies',
+                    components: [
+                      {
+                        type: 'tuple[]',
+                        name: 'allowedERC7739Content',
+                        components: [
+                          {
+                            type: 'bytes32',
+                            name: 'appDomainSeparator',
+                          },
+                          { type: 'string[]', name: 'contentNames' },
+                        ],
+                      },
+                      {
+                        type: 'tuple[]',
+                        name: 'erc1271Policies',
+                        components: [
+                          { type: 'address', name: 'policy' },
+                          { type: 'bytes', name: 'initData' },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: 'tuple',
+        name: 'config',
+        components: [
+          { type: 'uint8', name: 'scope' },
+          { type: 'uint8', name: 'resetPeriod' },
+          { type: 'address', name: 'allocator' },
+          { type: 'bytes32', name: 'permissionId' },
+        ],
+      },
+      { type: 'bytes' },
+    ],
+    [
+      {
+        allocatorSig: zeroHash,
+        userSig: input.enableData.userSignature,
+        expires: maxUint256,
+        enableSession: {
+          chainDigestIndex: input.enableData.sessionToEnableIndex,
+          hashesAndChainIds: [...input.enableData.hashesAndChainIds],
+          session: input.enableData.session,
+        },
+      },
+      {
+        scope: SCOPE_MULTICHAIN,
+        resetPeriod: RESET_PERIOD_ONE_WEEK,
+        allocator: zeroAddress,
+        permissionId: input.permissionId,
+      },
+      input.signature,
+    ],
   )
 }

--- a/src/package.json
+++ b/src/package.json
@@ -78,9 +78,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "solady": "^0.1.26"
-  },
   "peerDependencies": {
     "viem": "^2.55.0",
     "jose": ">=5.0.0",

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -182,6 +182,14 @@ describe('packed package contract', () => {
     expect(baseSha).toMatch(/^[0-9a-f]{40}$/)
   })
 
+  it('publishes without runtime dependencies', () => {
+    const currentManifest = readJson<PackageManifest>(
+      join(currentPackageDirectory, 'package.json'),
+    )
+
+    expect(Object.keys(currentManifest.dependencies ?? {})).toEqual([])
+  })
+
   it('preserves manifest entry points and package metadata', () => {
     const baseManifest = readJson<PackageManifest>(
       join(basePackageDirectory, 'package.json'),


### PR DESCRIPTION
- Inline the FastLZ codec used by Smart Sessions while preserving Solady-compatible output through golden vectors and property tests
- Remove Solady from the published manifest and lockfile, with a package-contract guard against runtime dependencies
- Add a patch changeset and update SDK dependency guidance

Closes [RHI-5037](https://linear.app/rhinestone/issue/RHI-5037)