### PR TITLE
chore: harden npm supply-chain controls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install the npm dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Verify wire types match the published OpenAPI spec
         run: |
@@ -61,7 +61,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install the npm dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Clean
         run: bun run clean

--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build SDK
         run: bun run build

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run smoke integration tests
         if: env.SUITE == 'smoke'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install the npm dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Clean
         run: bun run clean

--- a/.github/workflows/sync-wire-types.yaml
+++ b/.github/workflows/sync-wire-types.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install the npm dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Detect openapi drift
         id: drift

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[install]
+# Only install package versions published at least 3 days ago (supply-chain mitigation).
+minimumReleaseAge = 259200
+minimumReleaseAgeExcludes = ["@rhinestone/shared-configs"]


### PR DESCRIPTION
- Add `bunfig.toml` with `minimumReleaseAge = 259200` (3 days), matching the dashboard and back-office repos. Fresh npm releases are the attack window: the 2026-08-04 keyv/cacheable compromise had malicious versions live for only hours, and this gate would have skipped them outright. `@rhinestone/shared-configs` is excluded so the automated bump workflow can still install a just-published version.
- Add `--frozen-lockfile` to every unfrozen `bun install` in `.github/workflows/` (`ci.yaml` x2, `release.yaml`, `integration-tests.yaml`, `compatibility-tests.yaml`, `sync-wire-types.yaml`). Bun does **not** imply `--frozen-lockfile` when `CI` is set — verified on bun 1.3.0: with a drifted `package.json`, `CI=true bun install` silently re-resolves, prints `Saved lockfile`, and exits 0. Without the flag, CI installs dependency versions that were never reviewed in a lockfile diff, which matters most in `release.yaml` (the npm-publishing workflow).

Verification:

- `bun install --frozen-lockfile` passes on the committed lockfile — no drift, no lockfile changes needed.
- The age gate is provably active on bun 1.3.0 and does not conflict with the lockfile: a full-lockfile install pins the locked versions untouched (resolution-time constraint only), and `bunx` still works with the gate in place.
- Audited: this repo's dependency tree contains no `keyv` / `cacheable` / `hookified` / `flat-cache` / `file-entry-cache` packages at all, so it was **not** affected by the 2026-08-04 compromise.

The remaining `npm install` calls in `.github/` are unaffected by design: two global CLI installs (`npm@11`, `@expo/cli`) and the packed-tarball installs in `.github/scripts/test-*.sh`, which scaffold throwaway consumer projects in `/tmp` with no lockfile.

Relates to [RHI-5447](https://linear.app/rhinestone/issue/RHI-5447)