### PR TITLE
fix: ignore non-EIP-155 portfolio chains

### DIFF
--- a/.changeset/filter-portfolio-chains.md
+++ b/.changeset/filter-portfolio-chains.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Exclude non-EIP-155 catalog chains from portfolio requests so EVM balance reads continue to work when the runtime catalog includes other namespaces.

--- a/src/api/compose.test.ts
+++ b/src/api/compose.test.ts
@@ -21,6 +21,10 @@ const owner = privateKeyToAccount(
 const target = '0x0000000000000000000000000000000000000010' as const
 const userOperationHash = `0x${'22'.repeat(32)}` as const
 
+function catalogChain(name: string, testnet: boolean) {
+  return { name, testnet, supportedTokens: 'all' as const }
+}
+
 function fixture() {
   const sdk = resolveSdkConfig({ apiKey: 'test' })
   const account = resolveAccountConfig(sdk, {
@@ -174,6 +178,73 @@ describe('internal core composition', () => {
     await expect(workflows.getPortfolio(context)).resolves.toEqual({
       tokens: [],
     })
+  })
+
+  test('filters portfolio chains by network and EIP-155 namespace', async () => {
+    const base = fixture()
+    const portfolio = { tokens: [] }
+    const getPortfolio = vi.fn(async () => portfolio)
+    const orchestrator: OrchestratorPort = {
+      ...base.orchestrator,
+      getPortfolio,
+      getChainCatalog: vi.fn(
+        async () =>
+          new ChainCatalog({
+            1: catalogChain('Ethereum', false),
+            1337: catalogChain('HyperCore', false),
+            42161: catalogChain('Arbitrum', false),
+            11155111: catalogChain('Sepolia', true),
+            728126428: catalogChain('Tron', false),
+            792703809: catalogChain('Solana', false),
+          }),
+      ),
+    }
+    const workflows = createCoreComposition(base.context.sdk, {
+      ...base.dependencies,
+      orchestrator,
+    }).createAccount(base.context).workflows
+
+    await expect(workflows.getPortfolio(base.context, false)).resolves.toBe(
+      portfolio,
+    )
+    await expect(workflows.getPortfolio(base.context, true)).resolves.toBe(
+      portfolio,
+    )
+    expect(getPortfolio).toHaveBeenCalledTimes(2)
+    expect(getPortfolio).toHaveBeenNthCalledWith(1, {
+      account: expect.any(String),
+      chainIds: [1, 42161],
+    })
+    expect(getPortfolio).toHaveBeenNthCalledWith(2, {
+      account: expect.any(String),
+      chainIds: [11155111],
+    })
+  })
+
+  test('rejects portfolio reads without an EIP-155 catalog chain', async () => {
+    const base = fixture()
+    const getPortfolio = vi.fn(async () => ({ tokens: [] }))
+    const orchestrator: OrchestratorPort = {
+      ...base.orchestrator,
+      getPortfolio,
+      getChainCatalog: vi.fn(
+        async () =>
+          new ChainCatalog({
+            1337: catalogChain('HyperCore', false),
+            728126428: catalogChain('Tron', false),
+            792703809: catalogChain('Solana', false),
+          }),
+      ),
+    }
+    const workflows = createCoreComposition(base.context.sdk, {
+      ...base.dependencies,
+      orchestrator,
+    }).createAccount(base.context).workflows
+
+    await expect(workflows.getPortfolio(base.context, false)).rejects.toThrow(
+      'No EVM chain is available for portfolio account resolution',
+    )
+    expect(getPortfolio).not.toHaveBeenCalled()
   })
 
   test('reads HCA owners through the explicitly configured factory', async () => {

--- a/src/api/queries/portfolio.ts
+++ b/src/api/queries/portfolio.ts
@@ -1,5 +1,9 @@
 import type { AccountRuntimePort } from '../../accounts/adapter'
-import { toEvmChainReference } from '../../chains/caip2'
+import {
+  formatCaip2,
+  isEvmCaip2,
+  toEvmChainReference,
+} from '../../chains/caip2'
 import type {
   AccountQueryPort,
   ChainCatalogPort,
@@ -11,22 +15,17 @@ export async function getPortfolio(input: {
   readonly client: AccountQueryPort & ChainCatalogPort
   readonly onTestnets: boolean
 }): Promise<OrchestratorPortfolio> {
-  // Filter on the catalog's own `testnet` flag — authoritative for every chain
-  // the orchestrator supports (incl. non-EVM and chains newer than the SDK's
-  // viem). Filtering through viem would silently drop unknown chains, so their
-  // balances would disappear until an SDK/viem bump.
+  // The catalog's `testnet` flag is authoritative even for chains newer than
+  // the SDK's viem version, while the portfolio endpoint accepts only EIP-155.
   const catalog = await input.client.getChainCatalog()
   const chainIds = catalog
     .getSupportedChainIds()
-    .filter((chainId) => catalog.isTestnet(chainId) === input.onTestnets)
-  const accountChainId = chainIds.find((chainId) => {
-    try {
-      toEvmChainReference(chainId)
-      return true
-    } catch {
-      return false
-    }
-  })
+    .filter(
+      (chainId) =>
+        catalog.isTestnet(chainId) === input.onTestnets &&
+        isEvmCaip2(formatCaip2(chainId)),
+    )
+  const accountChainId = chainIds[0]
   if (accountChainId === undefined) {
     throw new Error(
       'No EVM chain is available for portfolio account resolution',


### PR DESCRIPTION
- Filter runtime catalog chains to EIP-155 before portfolio account resolution and requests.
- Cover mixed mainnet/testnet catalogs and the no-compatible-chain failure.
- Add a patch changeset.

Closes [RHI-5453](https://linear.app/rhinestone/issue/RHI-5453)