### PR TITLE
ci: streamline release verification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:
@@ -11,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -53,7 +50,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Setup and Build
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,15 +19,6 @@ on:
         options:
           - prod
           - dev
-  # Run on push (post-merge), not pull_request: these jobs hold live credentials
-  # (a prod API key and the funder private key), so they must only ever run
-  # already-reviewed code. The suite is picked by branch — full suite on release
-  # (v2 prod), smoke on main (v2 dev) — both against prod.
-  push:
-    branches:
-      - main
-      - release
-
 concurrency:
   group: live-integration-tests
   cancel-in-progress: false
@@ -88,7 +79,7 @@ jobs:
           fi
 
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,34 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  release-mode:
+    name: Resolve release mode
+    runs-on: ubuntu-latest
+    outputs:
+      has-changesets: ${{ steps.mode.outputs.has-changesets }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Detect unreleased changesets
+        id: mode
+        run: |
+          if find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' -print -quit | grep -q .; then
+            echo "has-changesets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changesets=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-test:
     name: Build & Test
+    needs: [release-mode]
+    # release/v1 pushes with changesets only open or update a release PR. Their
+    # code has already passed the target branch's required PR checks.
+    if: github.ref == 'refs/heads/main' || needs.release-mode.outputs.has-changesets != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -41,23 +63,61 @@ jobs:
         working-directory: src
         run: bunx publint
 
+  integration-tests:
+    name: Integration Tests
+    needs: [release-mode, build-and-test]
+    if: needs.build-and-test.result == 'success' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: live-integration-tests
+      cancel-in-progress: false
+    env:
+      INTEGRATION_FUNDER_PRIVATE_KEY: ${{ secrets.INTEGRATION_FUNDER_PRIVATE_KEY }}
+      INTEGRATION_RHINESTONE_API_KEY: ${{ secrets.INTEGRATION_RHINESTONE_API_KEY }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run smoke integration tests
+        if: github.ref == 'refs/heads/main'
+        run: bun run test:integration:smoke -- --run
+
+      - name: Run all integration tests
+        if: github.ref == 'refs/heads/release'
+        run: bun run test:integration -- --run
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build-and-test]
+    needs: [release-mode, build-and-test, integration-tests]
+    if: >-
+      always() &&
+      needs.release-mode.result == 'success' &&
+      (
+        (github.ref != 'refs/heads/main' && needs.release-mode.outputs.has-changesets == 'true') ||
+        (github.ref == 'refs/heads/v1' && needs.release-mode.outputs.has-changesets != 'true' && needs.build-and-test.result == 'success') ||
+        ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release') && needs.build-and-test.result == 'success' && needs.integration-tests.result == 'success')
+      )
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Mint release-bot token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || github.token }}
@@ -66,6 +126,7 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Use OIDC-capable npm
+        if: github.ref == 'refs/heads/main' || needs.release-mode.outputs.has-changesets != 'true'
         run: sudo npm install -g npm@11
 
       - name: Install the npm dependencies
@@ -139,7 +200,7 @@ jobs:
       - name: Mint docs-repo token
         if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
         id: docs-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -148,7 +209,7 @@ jobs:
 
       - name: Checkout docs repo
         if: steps.changesets.outputs.published == 'true' && github.ref == 'refs/heads/release'
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository_owner }}/docs
           ref: main

--- a/.github/workflows/sync-wire-types.yaml
+++ b/.github/workflows/sync-wire-types.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Mint rhinestone-automations token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -39,7 +39,7 @@ jobs:
           repositories: sdk
 
       - name: Check out the repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-shared-configs.yaml
+++ b/.github/workflows/update-shared-configs.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # v2 (on `main`) no longer bundles `@rhinestone/shared-configs`, so the
       # auto-bump only applies to the legacy v1 line — check out and PR v1.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: v1
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,8 +61,9 @@ consumer staging, and size run; `vitest.config.contract.ts` only discovers the
 Integration tests exercise Base Sepolia as the source chain and Arbitrum
 Sepolia as the target chain. Unless `INTEGRATION_ORCHESTRATOR_URL` is set, they
 use the SDK's built-in production orchestrator URL and production contract
-addresses. They run manually through `vitest.config.integration.ts`, with file
-parallelism disabled and five-minute test and hook timeouts.
+addresses. They run through `vitest.config.integration.ts`, with file parallelism disabled
+and five-minute test and hook timeouts. CI retries a failed test up to twice;
+local runs fail on the first attempt.
 
 The smoke suite validates an unfunded sponsored flow. The full suite covers the
 account adapters, supported-chain queries, EIP-7702, failure behavior,
@@ -117,10 +118,15 @@ and reusable fixtures. Configuration lives in `test/integration/config/`.
 
 ### GitHub Actions
 
-The `Integration Tests` workflow is manual and serializes live runs through the
-`live-integration-tests` concurrency group. Choose `suite=smoke` or `suite=all`
-and `target=prod` or `target=dev`. The job has a 30-minute timeout and resolves
-the environment-specific API key before executing the selected suite.
+The Release workflow runs the smoke suite before a `main` snapshot publish and
+the full suite before a `release` production publish. Publishing is blocked on
+its result. The manual `Integration Tests` workflow remains available for
+ad-hoc runs. Both workflows serialize live runs through the
+`live-integration-tests` concurrency group.
+
+For a manual run, choose `suite=smoke` or `suite=all` and `target=prod` or
+`target=dev`. The job has a 30-minute timeout and resolves the
+environment-specific API key before executing the selected suite.
 
 ```bash
 gh workflow run integration-tests.yaml -f suite=all -f target=prod

--- a/scripts/reference/typedoc.json
+++ b/scripts/reference/typedoc.json
@@ -18,5 +18,8 @@
   "excludeExternals": true,
   "excludePrivate": true,
   "excludeInternal": true,
-  "skipErrorChecking": true
+  "skipErrorChecking": true,
+  "validation": {
+    "notExported": false
+  }
 }

--- a/src/actions/mfa.ts
+++ b/src/actions/mfa.ts
@@ -94,7 +94,6 @@ function changeThreshold(newThreshold: number): CalldataInput {
 
 /**
  * Disable multi-factor authentication
- * @param rhinestoneAccount Account to disable multi-factor authentication on
  * @returns Calls to disable multi-factor authentication
  */
 function disable(): LazyCallInput {

--- a/src/actions/passkeys.ts
+++ b/src/actions/passkeys.ts
@@ -16,8 +16,7 @@ import {
 
 /**
  * Enable passkeys authentication
- * @param pubKey Public key for the passkey
- * @param authenticatorId Authenticator ID for the passkey
+ * @param credential WebAuthn credential to enable
  * @returns Calls to enable passkeys authentication
  */
 function enable(credential: WebauthnCredential): LazyCallInput {

--- a/src/api/sdk.ts
+++ b/src/api/sdk.ts
@@ -120,7 +120,7 @@ class RhinestoneSDK {
    * Create a smart session, resolving the chain's wrapped-native token from the
    * orchestrator's chain catalog (`GET /chains`) so native-token wrapping is
    * permitted automatically. Project-scoped — needs the API key but no account.
-   * For a fully offline build, use the standalone {@link toSession} and pass
+   * For a fully offline build, use the standalone `toSession` and pass
    * `wrappedNativeToken` yourself.
    * @param definition The session definition
    * @returns The resolved session

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -252,7 +252,7 @@ type CrossChainSettlementLayer = 'SAME_CHAIN' | 'ECO' | 'ACROSS'
  * A high-level permit that authorises a session key to move funds
  * between two chains via Permit2 arbiter settlement. The SDK expands
  * one `CrossChainPermit` into a {@link Permit2ClaimPolicy} (claim-side)
- * plus optional {@link SpendingLimitsPolicy} / {@link TimeFramePolicy}
+ * plus optional `SpendingLimitsPolicy` / `TimeFramePolicy`
  * entries on the fallback action — the claim policy itself doesn't
  * enforce amounts or expiry on-chain, so we lift those guarantees into
  * action-level policies that do.
@@ -313,7 +313,7 @@ interface ToLeg {
  * addresses (v2 no longer accepts symbols) and the SDK resolves `Date`s to
  * on-chain deadlines, then expands
  * each entry into a {@link Permit2ClaimPolicy} (claim-side) plus optional
- * {@link SpendingLimitsPolicy} / {@link TimeFramePolicy} guardrails.
+ * `SpendingLimitsPolicy` / `TimeFramePolicy` guardrails.
  */
 interface CrossChainPermissionInput {
   /**
@@ -539,7 +539,7 @@ interface SessionDefinition<TAbis extends readonly Abi[] = readonly Abi[]> {
   /**
    * Cross-chain permits expanded by the SDK into matching
    * {@link Permit2ClaimPolicy} (claim-side) plus action-level
-   * {@link SpendingLimitsPolicy} / {@link TimeFramePolicy} guardrails.
+   * `SpendingLimitsPolicy` / `TimeFramePolicy` guardrails.
    * See {@link CrossChainPermissionInput}.
    */
   crossChainPermits?: readonly CrossChainPermissionInput[]

--- a/test/integration/framework/assertions.ts
+++ b/test/integration/framework/assertions.ts
@@ -39,10 +39,11 @@ export async function expectSessionDisabled(
   account: RhinestoneAccount,
   session: Session,
 ): Promise<void> {
-  const enabled = await account.isSessionEnabled(session)
-  expect(enabled, `Session should be disabled on ${account.getAddress()}`).toBe(
-    false,
-  )
+  const disabled = await waitForSessionDisabled(account, session)
+  expect(
+    disabled,
+    `Session should be disabled on ${account.getAddress()}`,
+  ).toBe(true)
 }
 
 async function waitForDeployment(
@@ -65,6 +66,17 @@ async function waitForSessionEnabled(
     await sleep(1_000)
   }
   return account.isSessionEnabled(session)
+}
+
+async function waitForSessionDisabled(
+  account: RhinestoneAccount,
+  session: Session,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    if (!(await account.isSessionEnabled(session))) return true
+    await sleep(1_000)
+  }
+  return !(await account.isSessionEnabled(session))
 }
 
 function sleep(ms: number): Promise<void> {

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -16,5 +16,6 @@ export default defineConfig({
     hookTimeout: 300_000,
     watch: false,
     fileParallelism: false,
+    retry: process.env.CI ? 2 : 0,
   },
 })


### PR DESCRIPTION
- Keep static CI on pull requests while removing the duplicate post-merge `main` run.
- Skip build and live integration gates when a release push only opens or updates a changesets PR.
- Gate snapshot and production publishing on live integration tests, with bounded retries and eventual-consistency polling.
- Remove TypeDoc reference noise and update Node 24-compatible action pins.

Closes [RHI-5461](https://linear.app/rhinestone/issue/RHI-5461)