### PR TITLE
feat(hypercore)!: address HyperCore by delivery venue, drop `balance` (RHI-5510)

### DIFF
--- a/.changeset/hypercore-delivery-venue.md
+++ b/.changeset/hypercore-delivery-venue.md
@@ -1,5 +1,0 @@
----
-'@rhinestone/sdk': minor
----
-
-Forward the HyperCore delivery venue on token requests. `tokenRequests[].balance` (`'spot' | 'perp'`) now reaches the orchestrator instead of being dropped while the intent is rebuilt, so a HyperCore destination can be delivered to the recipient's spot wallet rather than always landing in perp margin. Required on HyperCore destinations by the orchestrator and rejected on every other chain.

--- a/.changeset/hypercore-venue-chains.md
+++ b/.changeset/hypercore-venue-chains.md
@@ -1,7 +1,33 @@
 ---
-'@rhinestone/sdk': minor
+'@rhinestone/sdk': major
 ---
 
-Address HyperCore by delivery venue. `hyperCoreMainnet` is replaced by `hyperCoreSpot` and `hyperCorePerp`, and the `tokenRequests[].balance` flag is removed — the venue a deposit credits (the recipient's spot wallet or the default perp dex's margin account) is now the destination you pass as `targetChain`. It was an optional field that the SDK dropped while rebuilding the intent, so callers asking for spot were silently credited to perp margin. A chain id cannot be dropped that way.
+**Breaking:** HyperCore is addressed by delivery venue.
 
-Released as a minor despite removing public exports: HyperCore has never carried an external client's intent (every one in prod history came from two internal projects), so the removal is breaking on paper and inert in practice. A caller that does reference either symbol gets a compile error naming its replacement, not a silent behaviour change.
+A HyperCore deposit credits one of two accounts that are not interchangeable — the recipient's spot wallet, or the default perp dex's margin account. The wrong one is invisible: the intent completes, the fill succeeds, and only the recipient's Core state shows where the money went.
+
+The venue is therefore part of the destination, not a flag on a token request.
+
+```diff
+- import { hyperCoreMainnet } from '@rhinestone/sdk'
++ import { hyperCoreSpot } from '@rhinestone/sdk'
+
+  await account.sendTransaction({
+-   targetChain: hyperCoreMainnet,
+-   tokenRequests: [{ address: usdc, amount, balance: 'spot' }],
++   targetChain: hyperCoreSpot,
++   tokenRequests: [{ address: usdc, amount }],
+    recipient,
+  })
+```
+
+Migration:
+
+- `hyperCoreMainnet` → **`hyperCoreSpot`** (the recipient's spot wallet) or **`hyperCorePerp`** (the default perp dex's margin account). Pick deliberately; `hyperCoreMainnet` defaulted to perp, so callers who assumed spot were silently credited to perp margin — which needs an EOA signature to move back out of.
+- `tokenRequests[].balance` is **removed**. Delete it; the venue you passed there is now the `targetChain`.
+- The `HyperCoreBalance` type is **removed**, along with its root export.
+- `HyperCoreCaip2ChainId` is now `'hypercore:spot' | 'hypercore:perp'`. `'hypercore:mainnet'` is not accepted as a target: it named the Core L1 without naming an account, and aliasing it to either venue would silently pick one. Upstream it remains an origin-only chain — deposits arrive from the Core L1 without naming a venue — and the orchestrator refuses it as a destination by its declared registry role.
+
+Why the field was removed rather than forwarded: `balance` was optional, and optional was the defect. This SDK dropped it twice while rebuilding the intent (`adaptTransaction`, then `buildIntentRequest`), and `tsc` could not catch it because conditional spreads are exempt from excess-property checking. A `targetChain` cannot be dropped by a field-by-field rebuild — it is what a caller must supply to address anything at all — so the whole class of bug goes with the field.
+
+Requires `@rhinestone/shared-configs` ≥ 1.11.0.

--- a/.changeset/hypercore-venue-chains.md
+++ b/.changeset/hypercore-venue-chains.md
@@ -30,4 +30,4 @@ Migration:
 
 Why the field was removed rather than forwarded: `balance` was optional, and optional was the defect. This SDK dropped it twice while rebuilding the intent (`adaptTransaction`, then `buildIntentRequest`), and `tsc` could not catch it because conditional spreads are exempt from excess-property checking. A `targetChain` cannot be dropped by a field-by-field rebuild — it is what a caller must supply to address anything at all — so the whole class of bug goes with the field.
 
-Requires `@rhinestone/shared-configs` ≥ 1.11.0.
+Requires an orchestrator that accepts the venue ids (shared-configs ≥ 1.11.0 on the server side). That is a runtime coupling, not a dependency of this package: the SDK bundles no chain data and reads the supported-chain set from `GET /chains`, so pointing this version at an older orchestrator fails when the intent is submitted rather than at build time.

--- a/.changeset/hypercore-venue-chains.md
+++ b/.changeset/hypercore-venue-chains.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Address HyperCore by delivery venue. `hyperCoreMainnet` is replaced by `hyperCoreSpot` and `hyperCorePerp`, and the `tokenRequests[].balance` flag is removed — the venue a deposit credits (the recipient's spot wallet or the default perp dex's margin account) is now the destination you pass as `targetChain`. It was an optional field that the SDK dropped while rebuilding the intent, so callers asking for spot were silently credited to perp margin. A chain id cannot be dropped that way.
+
+Released as a minor despite removing public exports: HyperCore has never carried an external client's intent (every one in prod history came from two internal projects), so the removal is breaking on paper and inert in practice. A caller that does reference either symbol gets a compile error naming its replacement, not a silent behaviour change.

--- a/src/api/account.test.ts
+++ b/src/api/account.test.ts
@@ -662,31 +662,12 @@ describe('account boundary adapters', () => {
     expect(transaction.options?.customDeadline).toBe(customDeadline)
   })
 
-  // RHI-5510: `adaptTransaction` rebuilds each tokenRequest from named fields,
-  // so an unlisted field is silently dropped. `balance` used to be dropped
-  // here, which left every SDK caller on the orchestrator's 'perp' default
-  // with no way to reach HyperCore spot — funds landed in perp margin and
-  // nothing reported it.
-  test('forwards the HyperCore delivery venue on tokenRequests (RHI-5510)', () => {
-    const transaction = adaptTransaction(invocationContext(), {
-      chain: mainnet,
-      calls: [],
-      tokenRequests: [
-        {
-          address: '0x0000000000000000000000000000000000000020',
-          amount: 1_000_000n,
-          balance: 'spot',
-        },
-      ],
-    })
-
-    expect(transaction.tokenRequests?.[0]).toMatchObject({
-      amount: 1_000_000n,
-      balance: 'spot',
-    })
-  })
-
-  test('omits balance entirely when the caller does not set one', () => {
+  // RHI-5510: the delivery venue is the destination chain, not a field on the
+  // token request, so `adaptTransaction` carries nothing venue-specific. This
+  // pins that no stray venue field is synthesised onto a request — the previous
+  // `balance` flag was dropped by this very mapping, which is what silently
+  // routed spot deliveries into perp margin.
+  test('synthesises no venue field onto token requests', () => {
     const transaction = adaptTransaction(invocationContext(), {
       chain: mainnet,
       calls: [],
@@ -698,8 +679,7 @@ describe('account boundary adapters', () => {
       ],
     })
 
-    // Absent, not `undefined`: the orchestrator rejects `balance` on every
-    // non-HyperCore destination, so it must not appear on ordinary intents.
+    expect(transaction.tokenRequests?.[0]).toMatchObject({ amount: 1_000_000n })
     expect(transaction.tokenRequests?.[0]).not.toHaveProperty('balance')
   })
 

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -932,15 +932,6 @@ export function adaptTransaction(
           ? request.address
           : normalizeTokenAddress(request.address, destinationChainId, false),
       ...(request.amount === undefined ? {} : { amount: request.amount }),
-      // Forward the HyperCore delivery venue. This mapping rebuilds the request
-      // from named fields, so anything not listed here is dropped — which is
-      // how `balance` was lost, leaving every SDK caller on the orchestrator's
-      // 'perp' default with no way to reach spot (RHI-5510). Omitted rather
-      // than sent as `undefined` when unset, because the orchestrator rejects
-      // the field on non-HyperCore destinations. Readable directly off the
-      // union because every arm declares it — including the non-EVM one, which
-      // is the arm a `targetChain: hyperCoreMainnet` request actually uses.
-      ...(request.balance === undefined ? {} : { balance: request.balance }),
     })),
     ...(transaction.recipient
       ? {

--- a/src/chains/caip2.test.ts
+++ b/src/chains/caip2.test.ts
@@ -17,6 +17,8 @@ describe('CAIP-2', () => {
     [792703809, 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
     [728126428, 'tron:mainnet'],
     [1337, 'hypercore:mainnet'],
+    [1337001, 'hypercore:spot'],
+    [1337002, 'hypercore:perp'],
   ] as const)('formats and parses %i', (id, caip2) => {
     expect(formatCaip2(id)).toBe(caip2)
     expect(chainIdFromReference(parseCaip2(caip2))).toBe(id)
@@ -26,6 +28,27 @@ describe('CAIP-2', () => {
   test('preserves the legacy HyperCore alias', () => {
     expect(chainIdFromReference(parseCaip2('eip155:1337'))).toBe(1337)
     expect(isNonEvmChainId(1337)).toBe(false)
+  })
+
+  // The venue ids must be in this table, not just in the exported descriptors.
+  // Without an entry, `formatCaip2(1337001)` emits `eip155:1337001` and
+  // `parseCaip2('hypercore:spot')` throws — so `hyperCoreSpot` would fail to
+  // address the destination it names, which is the whole point of the split.
+  // Types cannot catch this: the table is data (RHI-5510).
+  test('routes every HyperCore venue through the wire table', () => {
+    for (const [id, caip2] of [
+      [1337001, 'hypercore:spot'],
+      [1337002, 'hypercore:perp'],
+    ] as const) {
+      expect(formatCaip2(id)).toBe(caip2)
+      expect(chainIdFromReference(parseCaip2(caip2))).toBe(id)
+      // EVM-addressed, so recipients stay hex and no non-EVM branch is taken.
+      expect(isNonEvmChainId(id)).toBe(false)
+      expect(parseCaip2(caip2).kind).toBe('evm')
+      // `hypercore:*` is EVM-addressed but not `eip155:`, the one combination
+      // `toEvmChainReference` has to let through rather than reject.
+      expect(toEvmChainReference(id).caip2).toBe(caip2)
+    }
   })
 
   test('rejects malformed and unknown values', () => {

--- a/src/chains/caip2.ts
+++ b/src/chains/caip2.ts
@@ -6,12 +6,22 @@ import type { ChainReference, EvmChainReference } from './types'
 // v2: this small table is bundled here rather than read from
 // `@rhinestone/shared-configs`. EVM is the common case and needs no table, so a
 // new EVM chain needs no SDK change; a new non-EVM chain is rare and adds one
-// entry below. HyperCore is EVM-settled (id 1337) so `isNonEvmChainId` is
-// `false` for it even though its wire id is the non-`eip155` `hypercore:mainnet`.
+// entry below. Every HyperCore id is EVM-*settled*, so `isNonEvmChainId` is
+// `false` for all of them even though their wire ids are the non-`eip155`
+// `hypercore:` namespace.
+//
+// This table is TRANSLATION, not policy: it answers "what number is this wire
+// id", and adding an entry does not make that chain a legal destination. Which
+// HyperCore ids you may TARGET is `HyperCoreCaip2ChainId` and the exported
+// descriptors — only the two venues. `hypercore:mainnet` is here because it is a
+// real chain (the Core L1, where deposits originate) that can appear in a
+// response we have to parse; it is not an addressable target (RHI-5510).
 //
 // Spec: https://chainagnostic.org/CAIPs/caip-2
 const NON_EVM_CHAINS = [
   { id: 1337, caip2: 'hypercore:mainnet', nonEvm: false },
+  { id: 1337001, caip2: 'hypercore:spot', nonEvm: false },
+  { id: 1337002, caip2: 'hypercore:perp', nonEvm: false },
   { id: 728126428, caip2: 'tron:mainnet', nonEvm: true },
   {
     id: 792703809,
@@ -23,6 +33,30 @@ const NON_EVM_CHAINS = [
   caip2: string
   nonEvm: boolean
 }>
+
+const HYPERCORE_WIRE_IDS: ReadonlySet<number> = new Set(
+  NON_EVM_CHAINS.filter((chain) => chain.caip2.startsWith('hypercore:')).map(
+    (chain) => chain.id,
+  ),
+)
+
+/**
+ * True when a chain id's wire form is in the `hypercore:` namespace.
+ *
+ * This is the one combination the `caip2.startsWith('eip155:')` test gets wrong:
+ * HyperCore is EVM-*addressed* (hex recipients, EIP-712 signing) while its wire
+ * id is not `eip155:`, so every place that decides "is this reference EVM" must
+ * ask this too. Two places did it as `chainId === 1337`, which silently became
+ * wrong the moment HyperCore gained a second id — derived from the table here so
+ * a third venue cannot reintroduce it.
+ *
+ * NOT the same as `isHyperCoreChainId` in `@rhinestone/shared-configs`, which
+ * answers "is this a delivery VENUE" and is deliberately false for the Core L1.
+ * This one is about address shape, so it is true for all three.
+ */
+export function isHyperCoreWireId(chainId: number): boolean {
+  return HYPERCORE_WIRE_IDS.has(chainId)
+}
 
 const evmPattern = /^eip155:(0|[1-9]\d*)$/
 
@@ -64,7 +98,7 @@ export function parseCaip2(value: string): ChainReference {
 
 export function toEvmChainReference(chainId: number): EvmChainReference {
   const caip2 = formatCaip2(chainId)
-  if (!caip2.startsWith('eip155:') && chainId !== 1337) {
+  if (!caip2.startsWith('eip155:') && !isHyperCoreWireId(chainId)) {
     throw new Error(`Chain ${chainId} is not EVM-compatible`)
   }
   return {
@@ -91,9 +125,9 @@ export function isEvmCaip2(value: string): value is `eip155:${number}` {
   return evmPattern.test(value)
 }
 
-// True when a numeric chain id is genuinely non-EVM (Solana / Tron). HyperCore
-// (1337) is EVM-settled, so this is `false` for it even though its wire id is
-// the non-`eip155` `hypercore:mainnet` namespace.
+// True when a numeric chain id is genuinely non-EVM (Solana / Tron). Every
+// HyperCore id is EVM-settled, so this is `false` for all of them even though
+// their wire ids are in the non-`eip155` `hypercore:` namespace.
 export function isNonEvmChainId(chainId: number): boolean {
   return NON_EVM_CHAINS.some((chain) => chain.id === chainId && chain.nonEvm)
 }

--- a/src/chains/catalog.test.ts
+++ b/src/chains/catalog.test.ts
@@ -27,6 +27,20 @@ describe('runtime chain resolution', () => {
       namespace: 'solana',
     })
   })
+
+  // Every HyperCore id must come back EVM, on its `hypercore:` caip2. This used
+  // to be spelled `chainId === 1337`, which turned every venue into a `non-evm`
+  // reference the moment a second id existed — hex recipients would then take the
+  // non-EVM branch (RHI-5510).
+  test('materializes every HyperCore id as an EVM reference', () => {
+    for (const [id, caip2] of [
+      [1337, 'hypercore:mainnet'],
+      [1337001, 'hypercore:spot'],
+      [1337002, 'hypercore:perp'],
+    ] as const) {
+      expect(getChainReference(id)).toEqual({ kind: 'evm', id, caip2 })
+    }
+  })
 })
 
 describe('normalizeTokenAddress', () => {

--- a/src/chains/catalog.ts
+++ b/src/chains/catalog.ts
@@ -1,6 +1,6 @@
 import { type Chain, defineChain } from 'viem'
 import * as viemChains from 'viem/chains'
-import { formatCaip2 } from './caip2'
+import { formatCaip2, isHyperCoreWireId } from './caip2'
 import type { ChainReference } from './types'
 
 // Chain objects (rpc / nativeCurrency / formatters, needed for signing and
@@ -29,7 +29,7 @@ export function getChainById(chainId: number): Chain {
 
 export function getChainReference(chainId: number): ChainReference {
   const caip2 = formatCaip2(chainId)
-  if (caip2.startsWith('eip155:') || chainId === 1337) {
+  if (caip2.startsWith('eip155:') || isHyperCoreWireId(chainId)) {
     return {
       kind: 'evm',
       id: chainId,

--- a/src/chains/non-evm.ts
+++ b/src/chains/non-evm.ts
@@ -15,7 +15,9 @@ import type { Chain } from 'viem'
 type EvmCaip2ChainId = `eip155:${number}`
 type SolanaCaip2ChainId = `solana:${string}`
 type TronCaip2ChainId = `tron:${string}`
-type HyperCoreCaip2ChainId = 'hypercore:mainnet'
+// One id per HyperCore delivery venue — the venue is the destination, not a
+// flag on the token request (RHI-5510).
+type HyperCoreCaip2ChainId = 'hypercore:spot' | 'hypercore:perp'
 type Caip2ChainId =
   | EvmCaip2ChainId
   | SolanaCaip2ChainId
@@ -61,12 +63,26 @@ const tronMainnet: NonEvmChain = {
   nativeCurrency: { name: 'Tron', symbol: 'TRX', decimals: 6 },
 }
 
-const hyperCoreMainnet: NonEvmChain = {
-  name: 'HyperCore',
-  caip2: 'hypercore:mainnet',
+// A HyperCore deposit credits one of two accounts that are not
+// interchangeable: the recipient's spot wallet, or the default perp dex's
+// margin account. `CoreDepositWallet.depositFor` selects between them, and the
+// wrong choice is invisible — the intent completes, the fill succeeds, and only
+// the recipient's Core state shows where the funds went. So the venue is the
+// destination you address, not an optional field that four separate
+// field-by-field rebuilds could each silently drop (RHI-5510).
+const hyperCoreSpot: NonEvmChain = {
+  name: 'HyperCore Spot',
+  caip2: 'hypercore:spot',
+  kind: 'hypercore',
+  nativeCurrency: { name: 'Hyperliquid', symbol: 'HYPE', decimals: 18 },
+}
+
+const hyperCorePerp: NonEvmChain = {
+  name: 'HyperCore Perp',
+  caip2: 'hypercore:perp',
   kind: 'hypercore',
   nativeCurrency: { name: 'Hyperliquid', symbol: 'HYPE', decimals: 18 },
 }
 
 export type { DestinationChain, NativeCurrency, NonEvmAddress, NonEvmChain }
-export { hyperCoreMainnet, solanaMainnet, tronMainnet }
+export { hyperCorePerp, hyperCoreSpot, solanaMainnet, tronMainnet }

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -199,12 +199,6 @@ interface IntentInput {
   tokenRequests: {
     tokenAddress: Address | NonEvmAddress
     amount?: bigint
-    /**
-     * HyperCore delivery venue. Present on the wire whenever the caller set it
-     * — `mapIntentRequestToWire` forwards `tokenRequests` wholesale, so this
-     * type would otherwise understate the payload (RHI-5510).
-     */
-    balance?: 'spot' | 'perp'
   }[]
   recipient?: Account
   accountAccessList?: AccountAccessList

--- a/src/clients/orchestrator/types.ts
+++ b/src/clients/orchestrator/types.ts
@@ -66,8 +66,6 @@ export interface OrchestratorIntentRequest {
   readonly tokenRequests: readonly {
     readonly tokenAddress: Address | string
     readonly amount?: bigint
-    /** HyperCore delivery venue; see `IntentTokenRequest.balance` (RHI-5510). */
-    readonly balance?: 'spot' | 'perp'
   }[]
   readonly recipient?: OrchestratorAccount
   readonly accountAccessList?: OrchestratorAccountAccessList

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -729,58 +729,28 @@ type SourceCallInput = CallInput & {
   provides?: SourceCallProvidedFunds[]
 }
 
-/**
- * Which HyperCore balance receives a token request — the recipient's spot
- * wallet, or the default perp dex's margin account.
- *
- * Required when the destination is HyperCore and rejected on every other
- * chain. There is no default: the two credit different accounts, and picking
- * wrong is silent (the intent completes and the fill succeeds; only the
- * recipient's Core state shows where the funds went). Until this field
- * existed here, the SDK dropped it while rebuilding tokenRequests, so no
- * consumer could deliver to spot even deliberately — see RHI-5510.
- */
-type HyperCoreBalance = 'spot' | 'perp'
-
 interface TokenRequestWithAmount {
   address: Address
   amount: bigint
-  balance?: HyperCoreBalance
 }
 
 interface TokenRequestWithoutAmount {
   address: Address
   amount?: undefined
-  balance?: HyperCoreBalance
 }
 
 type TokenRequest = TokenRequestWithAmount | TokenRequestWithoutAmount
 
 type TokenRequests = [TokenRequestWithoutAmount] | TokenRequestWithAmount[]
 
-// The venue lives here too, and this is in fact the arm that matters:
-// `hyperCoreMainnet` is a `NonEvmChain` (`kind: 'hypercore'`), so the supported
-// way to target HyperCore — `targetChain: hyperCoreMainnet` — resolves to
-// `CrossChainNonEvmTransaction.tokenRequests`, i.e. these types. HyperCore
-// addresses are EVM-shaped, but the SDK's EVM/non-EVM split is by CAIP-2
-// namespace (`hypercore:` is not `eip155:`), not by address shape — so
-// "HyperCore is EVM-addressed" does not put it on the EVM arm.
-//
-// Declaring it `never` here (an earlier attempt at expressing "Solana and Tron
-// have no venue") made the venue a compile error on the one descriptor that
-// needs it. Solana/Tron share this arm, so type-level exclusivity per non-EVM
-// chain isn't expressible without splitting the descriptor; the orchestrator
-// rejects `balance` on their destinations at runtime instead.
 interface NonEvmTokenRequestWithAmount {
   address: NonEvmAddress
   amount: bigint
-  balance?: HyperCoreBalance
 }
 
 interface NonEvmTokenRequestWithoutAmount {
   address: NonEvmAddress
   amount?: undefined
-  balance?: HyperCoreBalance
 }
 
 type NonEvmTokenRequest =
@@ -1002,7 +972,6 @@ export type {
   Sponsorship,
   TokenRequest,
   TokenRequests,
-  HyperCoreBalance,
   NonEvmTokenRequest,
   NonEvmTokenRequests,
   SourceAssetInput,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { RhinestoneSDK } from './api/sdk'
-import { hyperCoreMainnet, solanaMainnet, tronMainnet } from './chains/non-evm'
+import {
+  hyperCorePerp,
+  hyperCoreSpot,
+  solanaMainnet,
+  tronMainnet,
+} from './chains/non-evm'
 import { MULTI_FACTOR_VALIDATOR_ADDRESS } from './modules/validators/multi-factor'
 import { OWNABLE_VALIDATOR_ADDRESS } from './modules/validators/ownable'
 import { SMART_SESSION_EMISSARY_ADDRESS } from './modules/validators/smart-sessions/module'
@@ -8,7 +13,8 @@ import { WEBAUTHN_VALIDATOR_ADDRESS } from './modules/validators/webauthn'
 export {
   RhinestoneSDK,
   // Non-viem destination chain descriptors (Solana, Tron, HyperCore)
-  hyperCoreMainnet,
+  hyperCorePerp,
+  hyperCoreSpot,
   solanaMainnet,
   tronMainnet,
   // Validator addresses
@@ -60,7 +66,6 @@ export type {
   CrossChainSettlementLayer,
   FromLeg,
   GuardiansSignerSet,
-  HyperCoreBalance,
   MultiFactorValidatorConfig,
   NonEvmTokenRequest,
   NonEvmTokenRequests,

--- a/src/transactions/intents/domain.test.ts
+++ b/src/transactions/intents/domain.test.ts
@@ -226,47 +226,6 @@ describe('intent domain', () => {
     })
   })
 
-  // RHI-5510: two separate places rebuild a token request from named fields —
-  // `adaptTransaction` and this one, the last before the network call. Covering
-  // only the first left `balance` still dropped here, so HyperCore spot
-  // deliveries would silently keep going to the default venue. Assert at the
-  // boundary that actually reaches the orchestrator.
-  test('forwards the HyperCore delivery venue onto the orchestrator request', () => {
-    const request = buildIntentRequest({
-      transaction: {
-        destination: chain,
-        calls: [],
-        tokenRequests: [{ token: address, amount: 2n, balance: 'spot' }],
-        options: {},
-      },
-      account: { address },
-      calls: [],
-      sourceCalls: {},
-      providedFunds: {},
-    })
-    expect(request.tokenRequests).toEqual([
-      { tokenAddress: address, amount: 2n, balance: 'spot' },
-    ])
-  })
-
-  test('omits the venue when unset, so non-HyperCore intents are unaffected', () => {
-    const request = buildIntentRequest({
-      transaction: {
-        destination: chain,
-        calls: [],
-        tokenRequests: [{ token: address, amount: 2n }],
-        options: {},
-      },
-      account: { address },
-      calls: [],
-      sourceCalls: {},
-      providedFunds: {},
-    })
-    // Absent, not `undefined`: the orchestrator rejects `balance` outright on
-    // every non-HyperCore destination.
-    expect(request.tokenRequests[0]).not.toHaveProperty('balance')
-  })
-
   test('selects the best or requested quote and rejects missing quotes', () => {
     const quotes = [
       { intentId: 'a' },

--- a/src/transactions/intents/request.ts
+++ b/src/transactions/intents/request.ts
@@ -34,13 +34,6 @@ export function buildIntentRequest<CompatibilityConfig>(input: {
         nonEvm,
       ),
       ...(request.amount === undefined ? {} : { amount: request.amount }),
-      // The second of two places that rebuild a token request from named
-      // fields, and the last one before the network call — so dropping
-      // `balance` here undoes forwarding it in `adaptTransaction` and every
-      // HyperCore delivery silently reverts to the orchestrator's default
-      // venue (RHI-5510). Omitted rather than sent as `undefined` because the
-      // orchestrator rejects the field on non-HyperCore destinations.
-      ...(request.balance === undefined ? {} : { balance: request.balance }),
     })),
     ...(input.transaction.recipient
       ? { recipient: input.transaction.recipient }

--- a/src/transactions/intents/types.ts
+++ b/src/transactions/intents/types.ts
@@ -38,13 +38,6 @@ import type {
 export interface IntentTokenRequest {
   readonly token: Address | string
   readonly amount?: bigint
-  /**
-   * HyperCore delivery venue — the recipient's spot wallet or the default perp
-   * dex's margin account. Required by the orchestrator on HyperCore
-   * destinations and rejected everywhere else, so it is optional here and
-   * forwarded only when set (RHI-5510).
-   */
-  readonly balance?: 'spot' | 'perp'
 }
 
 export interface IntentSourceCall<CompatibilityConfig> {

--- a/test/types/public-boundary.ts
+++ b/test/types/public-boundary.ts
@@ -9,8 +9,8 @@ import * as sessionActions from '../../src/actions/smart-sessions'
 import type { SponsorLimitKey } from '../../src/errors/index'
 import * as errors from '../../src/errors/index'
 import {
-  type HyperCoreBalance,
-  hyperCoreMainnet,
+  hyperCorePerp,
+  hyperCoreSpot,
   type PreparedTransactionData,
   type Quote,
   type RhinestoneAccount,
@@ -96,29 +96,23 @@ const crossChainNonEvmWithDeadline = {
   customDeadline: 9_999_999_999,
 } as const satisfies Transaction
 
-// RHI-5510: the orchestrator requires a delivery venue on HyperCore, so the
-// supported descriptor must be able to express one. `hyperCoreMainnet` is a
-// `NonEvmChain`, so this resolves to `CrossChainNonEvmTransaction` — declaring
-// `balance` only on the EVM arm made the venue a *compile* error here, which no
-// runtime test can catch. This assertion is the guard.
+// RHI-5510: the delivery venue is the destination, so a caller addresses it by
+// picking a chain. There is no venue field to forget, and no way to express a
+// HyperCore delivery without stating which account it credits — both venues
+// must therefore be publicly importable descriptors.
 const hyperCoreSpotDelivery = {
   sourceChains: [mainnet],
-  targetChain: hyperCoreMainnet,
-  tokenRequests: [{ address: recipient, amount: 1_000_000n, balance: 'spot' }],
+  targetChain: hyperCoreSpot,
+  tokenRequests: [{ address: recipient, amount: 1_000_000n }],
   calls: [],
 } as const satisfies Transaction
 
 const hyperCorePerpDelivery = {
   sourceChains: [mainnet],
-  targetChain: hyperCoreMainnet,
-  tokenRequests: [{ address: recipient, amount: 1_000_000n, balance: 'perp' }],
+  targetChain: hyperCorePerp,
+  tokenRequests: [{ address: recipient, amount: 1_000_000n }],
   calls: [],
 } as const satisfies Transaction
-
-// The venue type must be importable from the package root, not just declared
-// internally — a consumer typing their own helper around it is the reason it is
-// named at all.
-const hyperCoreVenue: HyperCoreBalance = 'spot'
 // A sponsorship server types its request body with the serialized input and
 // reads it without casts; bigint fields arrive as decimal strings.
 declare const sponsorshipBody: SerializedIntentInput
@@ -184,7 +178,6 @@ void crossChainWithDeadline
 void crossChainNonEvmWithDeadline
 void hyperCoreSpotDelivery
 void hyperCorePerpDelivery
-void hyperCoreVenue
 void sponsorLimitKey
 void bridgeSponsored
 void sponsorSurchargeUsd


### PR DESCRIPTION
Part of RHI-5510.

> [!NOTE]
> **Not blocked on anything.** An earlier revision of this description claimed this could not typecheck until `@rhinestone/shared-configs` 1.11.0 shipped. That was wrong: v2 of this SDK bundles no chain data — `src/no-bundled-chain-data.test.ts` asserts that nothing in `src/` or `test/` imports the package — and the venue descriptors are defined here, in `src/chains/non-evm.ts`. The coupling to shared-configs is on the **orchestrator** side and is a runtime one; 1.11.0 is now released regardless.

## HyperCore is addressed by delivery venue

`hyperCoreMainnet` → **`hyperCoreSpot`** and **`hyperCorePerp`**. `tokenRequests[].balance` is **removed**.

The venue a deposit credits — the recipient's spot wallet, or the default perp dex's margin account — is now the destination you pass as `targetChain`:

```diff
- targetChain: hyperCoreMainnet,
- tokenRequests: [{ address: usdc, amount, balance: 'spot' }],
+ targetChain: hyperCoreSpot,
+ tokenRequests: [{ address: usdc, amount }],
```

## Why the field had to go, not just get forwarded

`balance` was optional, and optional was the defect. This SDK dropped it **twice** while rebuilding the intent — once in `adaptTransaction`, then again in `buildIntentRequest` — so callers asking for spot were silently credited to perp margin. The failure is invisible at every layer that could catch it: the intent completes, the fill succeeds, and only the recipient's Core state shows where the money went.

A `targetChain` cannot be dropped by a field-by-field rebuild, because it is what a caller must supply to address anything at all. So the whole class of bug goes with the field rather than being guarded against.

Two properties of the codebase made the original bug hard to see, both worth knowing for the next intent field:

- the intent shape is declared in **three** places, and
- conditional spreads (`...(cond ? { balance } : {})`) are **exempt from excess-property checking**, so `tsc` could not catch the drop.

## Removed as a consequence, not deprecated

The `HyperCoreBalance` type and its root export, the field on all four token-request arms — including the `balance?: never` on the non-EVM ones, which existed only to state that Solana and Tron have no venue — and the forwarding block in `adaptTransaction`.

`HyperCoreCaip2ChainId` is now `'hypercore:spot' | 'hypercore:perp'`. `'hypercore:mainnet'` is deliberately not accepted as a target: it defaulted to perp, so aliasing it to spot would silently move funds and aliasing it to perp would silently keep the bug. Upstream it survives as an **origin-only** chain (deposits arrive from the Core L1 without naming a venue), and the orchestrator refuses it as a destination by its declared registry role.

## Released as a major

`CLAUDE.md` is explicit — "adding, renaming, or removing exports is a breaking change" — and this removes `hyperCoreMainnet` and `HyperCoreBalance` from `src/index.ts`. The changeset carries migration steps: the before/after diff, which venue replaces the retired descriptor, and the `shared-configs` floor.

This first went up as a `minor`, on the argument that the removal is inert because HyperCore has never carried an external client's intent. That is true, and it is still the reason this is low-risk — but it is an argument about blast radius, not about what the version number means. A caret upgrade would compile-break a consumer either way, and the rule exists so that cannot happen quietly. Kevin's call, and the repo's.

**Downstream consequence:** consumers move `2.x → 3.0.0` explicitly rather than picking this up on a caret range. The orchestrator and deposit-processor are bumped in lockstep with this release; the processor's bump also crosses `FeeCategory.sponsored` (added in 2.1), which is unrelated to HyperCore and needs its own small fix in `amounts.test.ts`.

## Verification

tsc clean across src / tests / type-tests, biome clean, **555 unit tests pass**.

### A bug this PR introduced and Kevin caught

The venue descriptors landed in `chains/non-evm.ts`, but `chains/caip2.ts` keeps its **own** wire table — bundled deliberately rather than read from shared-configs — and the new ids were never added to it. So `formatCaip2(1337001)` emitted `eip155:1337001` and `parseCaip2('hypercore:spot')` threw: `hyperCoreSpot` could not address the destination it names, which is the exact failure this change exists to remove. Neither `tsc` nor the 550 tests caught it, because the table is data and nothing drove the new ids through it.

`chains/catalog.ts` had a second instance the review did not name: `getChainReference` decided EVM-ness with `chainId === 1337`, so both venues came back `kind: 'non-evm'` and hex recipients would have taken the Solana/Tron branch.

Both sites now ask `isHyperCoreWireId`, derived from the table itself so a third venue cannot reintroduce it. Deliberately *not* named `isHyperCoreChainId` — shared-configs exports that name meaning "is this a delivery venue", which is false for the Core L1, and two same-named predicates with different answers is its own trap.

New tests pin both instances and were verified to fail without the fix (`formats and parses 1337001` received `eip155:1337001`).

The type test in `test/types/public-boundary.ts` asserts **both** venues satisfy the public `Transaction` type. That file is the right home for it: an earlier round declared the field on the wrong arm, which was a *compile* error on the only descriptor that can target HyperCore — something no runtime test could catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgDwSpK4GJW2Jka5PeJBD
