### PR TITLE
chore(release): version the HyperCore venue change as a patch (RHI-5510)

### DIFF
--- a/.changeset/hypercore-venue-chains.md
+++ b/.changeset/hypercore-venue-chains.md
@@ -1,8 +1,8 @@
 ---
-'@rhinestone/sdk': major
+'@rhinestone/sdk': patch
 ---
 
-**Breaking:** HyperCore is addressed by delivery venue.
+HyperCore is addressed by delivery venue.
 
 A HyperCore deposit credits one of two accounts that are not interchangeable — the recipient's spot wallet, or the default perp dex's margin account. The wrong one is invisible: the intent completes, the fill succeeds, and only the recipient's Core state shows where the money went.
 
@@ -21,13 +21,11 @@ The venue is therefore part of the destination, not a flag on a token request.
   })
 ```
 
-Migration:
+Migration, if you addressed HyperCore:
 
 - `hyperCoreMainnet` → **`hyperCoreSpot`** (the recipient's spot wallet) or **`hyperCorePerp`** (the default perp dex's margin account). Pick deliberately; `hyperCoreMainnet` defaulted to perp, so callers who assumed spot were silently credited to perp margin — which needs an EOA signature to move back out of.
-- `tokenRequests[].balance` is **removed**. Delete it; the venue you passed there is now the `targetChain`.
-- The `HyperCoreBalance` type is **removed**, along with its root export.
 - `HyperCoreCaip2ChainId` is now `'hypercore:spot' | 'hypercore:perp'`. `'hypercore:mainnet'` is not accepted as a target: it named the Core L1 without naming an account, and aliasing it to either venue would silently pick one. Upstream it remains an origin-only chain — deposits arrive from the Core L1 without naming a venue — and the orchestrator refuses it as a destination by its declared registry role.
 
-Why the field was removed rather than forwarded: `balance` was optional, and optional was the defect. This SDK dropped it twice while rebuilding the intent (`adaptTransaction`, then `buildIntentRequest`), and `tsc` could not catch it because conditional spreads are exempt from excess-property checking. A `targetChain` cannot be dropped by a field-by-field rebuild — it is what a caller must supply to address anything at all — so the whole class of bug goes with the field.
+Released as a **patch**. Only one removed symbol was ever published: `hyperCoreMainnet`. `tokenRequests[].balance` and the `HyperCoreBalance` type existed solely in a `@dev` snapshot and are absent from every released version, so nothing on npm could depend on them. HyperCore has never carried an external client's intent either, so the practical blast radius of the one real removal is nil — and a caller who does reference it gets a compile error naming its replacement, not a silent behaviour change.
 
 Requires an orchestrator that accepts the venue ids (shared-configs ≥ 1.11.0 on the server side). That is a runtime coupling, not a dependency of this package: the SDK bundles no chain data and reads the supported-chain set from `GET /chains`, so pointing this version at an older orchestrator fails when the intent is submitted rather than at build time.


### PR DESCRIPTION
Follow-up to #731. Part of RHI-5510.

Versions the HyperCore venue change as a **patch** (2.2.1 → 2.2.2) instead of the major it merged as. Owner's call; this PR records why it holds up, and what it trades.

## Only one removed symbol was ever published

Verified by unpacking `@rhinestone/sdk@2.2.1` from npm:

| Removed symbol | In a published release? |
|---|---|
| `hyperCoreMainnet` | **yes** |
| `tokenRequests[].balance` | no |
| `HyperCoreBalance` | no |

`balance` and `HyperCoreBalance` landed in #729, and pushing SDK `main` publishes only a `@dev` snapshot — no release was cut between #729 and #731. So they are absent from 2.0.0, 2.1.0, 2.2.0 and 2.2.1, and nothing on the registry can depend on them. Removing them is not a breaking change to any published surface; it is deleting something that was never shipped.

That leaves `hyperCoreMainnet` as the one real removal, and HyperCore has never carried an external client's intent — every one in prod history came from two internal projects. A caller who does reference it gets a **compile error naming its replacement**, not a silent behaviour change.

## The trade, stated plainly

A consumer on `^2.2.0` picks 2.2.2 up automatically, so that one compile break arrives without an explicit migration step. That is exactly why `CLAUDE.md` says removing root exports is breaking, and it is the part being overridden here — deliberately, because the blast radius is nil and a major forces every consumer through a migration for a symbol none of them use.

## No code change

The changeset's version and prose only. The migration guidance stays, since it is still what a HyperCore caller needs; what changed is the claim about *why* the version is what it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgDwSpK4GJW2Jka5PeJBD
