### PR TITLE
fix(hypercore): never host the account runtime on a delivery venue (RHI-5510)

### DIFF
--- a/src/transactions/intents/prepare.ts
+++ b/src/transactions/intents/prepare.ts
@@ -2,7 +2,11 @@ import { hashTypedData, keccak256, stringToHex } from 'viem'
 import type { AccountRuntime } from '../../accounts/adapter'
 import { resolveCalls } from '../../calls/resolve'
 import type { Call } from '../../calls/types'
-import { chainIdFromReference, toEvmChainReference } from '../../chains/caip2'
+import {
+  chainIdFromReference,
+  isHyperCoreWireId,
+  toEvmChainReference,
+} from '../../chains/caip2'
 import type { EvmChainReference } from '../../chains/types'
 import { defineValidator } from '../../modules/validators/definition'
 import { ecdsaSignerId } from '../../modules/validators/signer-id'
@@ -84,13 +88,31 @@ export async function prepareIntent<CompatibilityConfig>(
   }
 }
 
+// The chain whose runtime hosts the account: identity, address derivation, and
+// the RPC reads that follow. The destination serves when it is a real execution
+// chain, and otherwise a source chain does.
+//
+// `kind === 'evm'` alone is not that test. HyperCore is EVM-ADDRESSED — hex
+// recipients, EIP-712 — while being virtual: it has no RPC of its own and hosts
+// no accounts, so materializing a runtime on it asks viem for a transport that
+// cannot exist. That went unnoticed while HyperCore was chain 1337, because viem
+// ships a `Localhost` chain with that exact id and quietly supplied
+// `http://127.0.0.1:8545`; the venue ids have no viem chain, so the synthesised
+// one has empty `rpcUrls` and the call fails with `UrlRequiredError` (RHI-5510).
 function selectAccountChain<CompatibilityConfig>(
   input: IntentInput<CompatibilityConfig>,
 ): EvmChainReference {
-  if (input.destination.kind === 'evm') return input.destination
+  if (
+    input.destination.kind === 'evm' &&
+    !isHyperCoreWireId(input.destination.id)
+  ) {
+    return input.destination
+  }
   const source = input.sourceChains?.at(-1)
   if (!source) {
-    throw new Error('A non-EVM intent requires at least one EVM source chain')
+    throw new Error(
+      `An intent to ${input.destination.caip2} requires at least one EVM source chain: the destination hosts no account runtime`,
+    )
   }
   return source
 }

--- a/src/transactions/intents/sessions.ts
+++ b/src/transactions/intents/sessions.ts
@@ -1,6 +1,7 @@
 import type { Hex } from 'viem'
 import type { AccountRuntime } from '../../accounts/adapter'
 import type { Call } from '../../calls/types'
+import { isHyperCoreWireId } from '../../chains/caip2'
 import type { EvmChainReference } from '../../chains/types'
 import { buildSmartSessionMockSignature } from '../../modules/validators/smart-sessions/mock-signature'
 import {
@@ -109,13 +110,25 @@ export async function prepareIntentSessions<CompatibilityConfig>(input: {
   }
 }
 
+// Chains a smart-session intent needs an enabled session on: every source, plus
+// the destination when the user's own account executes there.
+//
+// A HyperCore venue is excluded for the same reason it cannot host the account
+// runtime: it is EVM-ADDRESSED but virtual, so there is no account there to enable
+// a session on, and requiring one would demand a session on chain 1337001/1337002
+// that can never exist. Delivery is solver-mediated anyway — the orchestrator
+// builds the `depositFor` credit and the recipient never executes — so there is no
+// destination-side authorization for a session to grant (RHI-5510).
 function sessionChains<CompatibilityConfig>(
   intent: IntentInput<CompatibilityConfig>,
 ): readonly EvmChainReference[] {
   const chains = new Map(
     (intent.sourceChains ?? []).map((chain) => [chain.id, chain]),
   )
-  if (intent.destination.kind === 'evm') {
+  if (
+    intent.destination.kind === 'evm' &&
+    !isHyperCoreWireId(intent.destination.id)
+  ) {
     chains.set(intent.destination.id, intent.destination)
   }
   return [...chains.values()]

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -233,6 +233,48 @@ describe('intent workflow', () => {
     }
   })
 
+  // The session path repeats the same `kind === 'evm'` conflation, and an EOA
+  // end-to-end run does not exercise it: `sessionChains` would demand a smart
+  // session on 1337001/1337002, which can never exist — no account is deployed on
+  // a virtual chain, and HyperCore delivery is solver-mediated so there is no
+  // destination-side authorization for a session to grant (RHI-5510).
+  test('requires no session on a HyperCore venue', async () => {
+    const session = toSession({
+      chain: mainnet,
+      owners: { type: 'ecdsa', accounts: [account] },
+    })
+    const read = vi.fn(async (checkpoint: { id: string }) => [
+      { kind: 'session-enabled' as const, id: checkpoint.id, enabled: false },
+    ])
+    const workflow = context({ checkpoints: { read } })
+
+    // Only chain 1 (the source) has a session configured. Without the fix this
+    // throws `No session configured for chain 1337001`.
+    const prepared = await prepareIntent(workflow, {
+      ...input,
+      destination: toEvmChainReference(1337001),
+      calls: [],
+      signers: {
+        kind: 'smart-session',
+        byChain: {
+          1: {
+            session,
+            enableData: {
+              userSignature: signature,
+              hashesAndChainIds: [
+                { chainId: 1n, sessionDigest: `0x${'22'.repeat(32)}` },
+              ],
+              sessionToEnableIndex: 0,
+            },
+          },
+        },
+      },
+    })
+
+    expect(prepared.request.account.mockSignatures?.['1']).toMatch(/^0x/u)
+    expect(prepared.request.account.mockSignatures?.['1337001']).toBeUndefined()
+  })
+
   test('signs through the shared plan executor', async () => {
     const workflow = context()
     const prepared = await prepareIntent(workflow, input)

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -208,6 +208,31 @@ describe('intent workflow', () => {
     })
   })
 
+  // HyperCore is EVM-ADDRESSED but virtual: no RPC, no accounts. Selecting it as
+  // the account chain asks viem for a transport that cannot exist. It went
+  // unnoticed while HyperCore was chain 1337, because viem ships a `Localhost`
+  // chain with that id and quietly supplied `http://127.0.0.1:8545`; the venue
+  // ids have no viem chain, so the synthesised one has empty `rpcUrls` and the
+  // call dies with `UrlRequiredError` (RHI-5510).
+  test('hosts the account on a source chain for a HyperCore venue', async () => {
+    for (const venueId of [1337001, 1337002]) {
+      const workflow = context()
+      await prepareIntent(workflow, {
+        ...input,
+        destination: toEvmChainReference(venueId),
+        // HyperCore delivery is solver-mediated; the orchestrator builds the
+        // core-deposit ops, so a caller passes none.
+        calls: [],
+      })
+
+      // The SOURCE chain, never the venue.
+      expect(workflow.account.forChain).toHaveBeenCalledWith(chain)
+      expect(workflow.account.forChain).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: venueId }),
+      )
+    }
+  })
+
   test('signs through the shared plan executor', async () => {
     const workflow = context()
     const prepared = await prepareIntent(workflow, input)


### PR DESCRIPTION
Follow-up to #731. Part of RHI-5510.

> [!IMPORTANT]
> **#731 is not usable for HyperCore without this.** `prepareTransaction` throws viem's `UrlRequiredError` for either venue, before the request ever reaches the orchestrator. Found by running a real intent against dev — no unit test covered it, and none would have.

## An RPC client on a chain that has no RPC

`selectAccountChain` returns the destination whenever `kind === 'evm'`, and the caller then materializes an account runtime — and therefore a viem client — on it:

```ts
if (input.destination.kind === 'evm') return input.destination
```

That test is wrong for HyperCore. HyperCore is EVM-**addressed** (hex recipients, EIP-712 signing) while being **virtual**: no RPC of its own, no accounts hosted on it. `kind === 'evm'` answers "what shape are the addresses", not "is this an execution chain", and this line needs the second question.

## Why nobody hit it before

**viem ships a `Localhost` chain with id 1337.** So `forChain(1337)` resolved to `http://127.0.0.1:8545` — a URL that exists, for a node nobody was running, on a path that never dereferenced it. `hyperCoreMainnet` worked by colliding with viem's localhost.

The venue ids (1337001 / 1337002) match no viem chain, so the SDK synthesises one with empty `rpcUrls` and the same call fails loudly. **The venue split didn't introduce this bug; it removed the accident that was hiding it.**

## The fix

A HyperCore intent hosts the account on its last EVM source chain — already what happens for Solana and Tron, both of which reach the same fallback. The thrown message now names the destination, because "requires at least one EVM source chain" is confusing when the caller believes they *did* pass an EVM chain.

## Verification

End-to-end against dev, which is the only place this shows up:

| before | after |
|---|---|
| `UrlRequiredError: No URL was provided to the Transport` | `422 No balances available` |

The 422 is the intended outcome for an unfunded account: the venue was accepted, planning ran, and it failed on funding alone. That is the whole SDK→orchestrator venue path working.

The regression test asserts `forChain` is called with the source chain and **never** the venue, for both venues, and was verified to fail without the fix.

tsc clean, biome clean, **554 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LgDwSpK4GJW2Jka5PeJBD
