### PR TITLE
test(contract): allow a named surface exception under a patch (RHI-5510)

### DIFF
--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -197,15 +197,30 @@ const SURFACE_EXCEPTIONS: {
   added: ['hyperCoreSpot', 'hyperCorePerp'],
 }
 
-// Base minus the deliberate removals, current minus the deliberate additions:
-// what remains must still match exactly.
 const stripExceptions = (names: readonly string[], drop: readonly string[]) =>
   names.filter((name) => !drop.includes(name))
 
-const reconcile = (base: readonly string[], current: readonly string[]) => ({
-  base: stripExceptions(base, SURFACE_EXCEPTIONS.removed),
-  current: stripExceptions(current, SURFACE_EXCEPTIONS.added),
-})
+// The exception applies ONLY across the transition it describes — while the
+// release baseline still publishes a listed removal.
+//
+// Without that condition it would outlive its purpose and start causing the
+// failures it exists to prevent: once this ships, the baseline contains the
+// added names too, and stripping them from `current` alone would compare a base
+// that has them against a current that no longer does, failing every later clean
+// patch until someone deleted the entry. Scoped this way a stale entry is inert
+// rather than harmful, and it cannot hide real drift once the transition is past.
+const exceptionApplies = (baseNames: readonly string[]) =>
+  SURFACE_EXCEPTIONS.removed.some((name) => baseNames.includes(name))
+
+// Base minus the deliberate removals, current minus the deliberate additions:
+// what remains must still match exactly.
+const reconcile = (base: readonly string[], current: readonly string[]) =>
+  exceptionApplies(base)
+    ? {
+        base: stripExceptions(base, SURFACE_EXCEPTIONS.removed),
+        current: stripExceptions(current, SURFACE_EXCEPTIONS.added),
+      }
+    : { base, current }
 
 const declaredBump = declaredSdkBump(baseSha, process.cwd())
 const intentionalSurfaceChange =
@@ -421,6 +436,16 @@ describe('packed package contract', () => {
         ]),
       ),
     })
+
+    // Same transition scoping as `reconcile`: only while the baseline report
+    // still declares a listed removal.
+    const baseSymbols = Object.values(baseApiReport.entrypoints).flatMap(
+      (symbols) => Object.keys(symbols),
+    )
+    if (!exceptionApplies(baseSymbols)) {
+      expect(currentApiReport).toEqual(baseApiReport)
+      return
+    }
 
     expect(dropSymbols(currentApiReport, SURFACE_EXCEPTIONS.added)).toEqual(
       dropSymbols(baseApiReport, SURFACE_EXCEPTIONS.removed),

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -172,6 +172,41 @@ function privateSourceImports(packageDirectory: string): string[] {
 // - major: well-formedness only. Removals are the point of a major.
 //
 // `run.ts` gates the bidirectional assignability fixture on the same signal.
+// Deliberate surface changes shipped under a bump that would otherwise forbid
+// them. This is an override of the rule above for NAMED symbols, not an
+// exemption from it: everything not listed here is still compared exactly, and
+// an unlisted drift fails as before.
+//
+// Empty is the expected steady state. An entry earns its place by being a
+// removal whose blast radius is known to be zero — not merely believed small —
+// and it should be deleted at the next major, when the rule allows it outright.
+const SURFACE_EXCEPTIONS: {
+  reason: string
+  removed: readonly string[]
+  added: readonly string[]
+} = {
+  // RHI-5510. `hyperCoreMainnet` is replaced by `hyperCoreSpot` /
+  // `hyperCorePerp`, because a HyperCore delivery must name the venue it
+  // credits and the old descriptor silently defaulted to perp margin. Shipped
+  // as a patch deliberately: HyperCore has never carried an external client's
+  // intent (every one in prod history came from two internal projects), and a
+  // consumer that does reference the old name gets a compile error naming its
+  // replacement rather than a silent behaviour change.
+  reason: 'RHI-5510 HyperCore delivery venues',
+  removed: ['hyperCoreMainnet'],
+  added: ['hyperCoreSpot', 'hyperCorePerp'],
+}
+
+// Base minus the deliberate removals, current minus the deliberate additions:
+// what remains must still match exactly.
+const stripExceptions = (names: readonly string[], drop: readonly string[]) =>
+  names.filter((name) => !drop.includes(name))
+
+const reconcile = (base: readonly string[], current: readonly string[]) => ({
+  base: stripExceptions(base, SURFACE_EXCEPTIONS.removed),
+  current: stripExceptions(current, SURFACE_EXCEPTIONS.added),
+})
+
 const declaredBump = declaredSdkBump(baseSha, process.cwd())
 const intentionalSurfaceChange =
   declaredBump === 'minor' || declaredBump === 'major'
@@ -294,7 +329,20 @@ describe('packed package contract', () => {
       return
     }
 
-    expect(currentExports).toEqual(baseExports)
+    const reconciledExports = Object.fromEntries(
+      Object.keys({ ...baseExports, ...currentExports }).map((entrypoint) => {
+        const { base, current } = reconcile(
+          baseExports[entrypoint] ?? [],
+          currentExports[entrypoint] ?? [],
+        )
+        return [entrypoint, { base, current }]
+      }),
+    )
+    for (const [entrypoint, { base, current }] of Object.entries(
+      reconciledExports,
+    )) {
+      expect(current, `runtime exports drifted for ${entrypoint}`).toEqual(base)
+    }
   })
 
   it('keeps a declaration for every runtime value export', () => {
@@ -355,7 +403,28 @@ describe('packed package contract', () => {
       }
       return
     }
-    expect(currentApiReport).toEqual(baseApiReport)
+    // Same reconciliation, one level deeper: the report is keyed by entry point
+    // then by symbol, so drop the exception symbols from each side's symbol map.
+    const dropSymbols = (
+      report: typeof baseApiReport,
+      drop: readonly string[],
+    ) => ({
+      ...report,
+      entrypoints: Object.fromEntries(
+        Object.entries(report.entrypoints).map(([entrypoint, symbols]) => [
+          entrypoint,
+          Object.fromEntries(
+            Object.entries(symbols).filter(
+              ([symbol]) => !drop.includes(symbol),
+            ),
+          ),
+        ]),
+      ),
+    })
+
+    expect(dropSymbols(currentApiReport, SURFACE_EXCEPTIONS.added)).toEqual(
+      dropSymbols(baseApiReport, SURFACE_EXCEPTIONS.removed),
+    )
   })
 
   it('preserves compatibility-only runtime values and shapes', () => {
@@ -412,7 +481,8 @@ describe('packed package contract', () => {
     // one. The root must always import cleanly without the optional peers.
     expect(currentResult.length).toBeGreaterThan(0)
     if (!intentionalSurfaceChange) {
-      expect(currentResult).toEqual(baseResult)
+      const { base, current } = reconcile(baseResult, currentResult)
+      expect(current).toEqual(base)
     } else if (additiveOnly) {
       for (const name of baseResult) {
         expect(


### PR DESCRIPTION
Unblocks the 2.2.2 release (#730), whose required `release-package-contract` check is failing.

## What's failing and why it's right

The packed-package contract test derives strictness from the declared changeset bump:

| bump | rule |
|---|---|
| patch | exact equality of the published surface |
| minor | additive only — everything published must still be there |
| major | removals allowed; "removals are the point of a major" |

The HyperCore venue change removes `hyperCoreMainnet` and adds `hyperCoreSpot` / `hyperCorePerp`, and ships as a **patch** by owner decision. That combination fails by design, and the check caught it — it only runs on `release`, which is why #731/#734 were green.

**This is a good gate and the PR does not weaken it.**

## The exception is per-symbol, not a bypass

```ts
const SURFACE_EXCEPTIONS = {
  reason: 'RHI-5510 HyperCore delivery venues',
  removed: ['hyperCoreMainnet'],
  added: ['hyperCoreSpot', 'hyperCorePerp'],
}
```

Base minus the listed removals, current minus the listed additions — whatever remains is still compared **exactly**, in all three surface assertions (runtime export keys, declaration report, root import without optional peers). Any drift outside this list fails as before, in both directions.

## Why this removal earns an entry

The blast radius is known rather than estimated:

- `hyperCoreMainnet` is the **only** removed symbol that was ever published — `tokenRequests[].balance` and `HyperCoreBalance` existed solely in a `@dev` snapshot (verified by unpacking 2.2.1 from npm).
- HyperCore has never carried an external client's intent; every one in prod history came from two internal projects.
- A consumer that does reference it gets a **compile error naming its replacement**, not a silent behaviour change.

The list is expected to be empty in steady state, and this entry should be deleted at the next major, when the rule permits the removal outright.

## Verification

tsc clean, biome clean. The contract test runs only on `release`, so this PR's own CI will skip it — #730 is where it re-runs. Local runs die earlier, in `publint` against the base packed package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)