### PR TITLE
fix(orchestrator): type wire request adapters

### DIFF
--- a/.changeset/typed-orchestrator-requests.md
+++ b/.changeset/typed-orchestrator-requests.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Type orchestrator quote and split request adapters against generated wire contracts.

--- a/src/clients/orchestrator/client.test.ts
+++ b/src/clients/orchestrator/client.test.ts
@@ -20,6 +20,10 @@ describe('orchestrator client', () => {
         expect(JSON.parse(String(init?.body))).toMatchObject({
           destinationChainId: 'eip155:10',
           destinationExecutions: [{ to: address, value: '2', data: '0x' }],
+          accountAccessList: {
+            chainIds: ['eip155:1'],
+            chainTokenAmounts: { 'eip155:1': { [address]: '4' } },
+          },
           options: { auxiliaryFunds: { 'eip155:1': { [address]: '3' } } },
         })
         return new Response(
@@ -97,6 +101,10 @@ describe('orchestrator client', () => {
       destinationChainId: 10,
       destinationExecutions: [{ to: address, value: 2n, data: '0x' }],
       tokenRequests: [],
+      accountAccessList: {
+        chainIds: [1],
+        chainTokenAmounts: { 1: { [address]: 4n } },
+      },
       options: { auxiliaryFunds: { 1: { [address]: 3n } } },
     })
 

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -11,6 +11,7 @@ import type {
   CostTokenEntry,
   TokenRequirements,
 } from './public'
+import { serializeBigInts } from './serialization'
 import type {
   OrchestratorIntentRequest,
   OrchestratorIntentStatus,
@@ -288,25 +289,4 @@ function parseChainValue(value: string | number | undefined): number {
   if (value === undefined) throw new Error('Orchestrator chain id is missing')
   if (/^\d+$/u.test(value)) return Number(value)
   return chainIdFromReference(parseCaip2(value))
-}
-
-type SerializeBigInts<T> = T extends bigint
-  ? string
-  : T extends readonly (infer Item)[]
-    ? SerializeBigInts<Item>[]
-    : T extends object
-      ? { [Key in keyof T]: SerializeBigInts<T[Key]> }
-      : T
-
-function serializeBigInts<T>(value: T): SerializeBigInts<T> {
-  if (typeof value === 'bigint') return value.toString() as SerializeBigInts<T>
-  if (Array.isArray(value)) {
-    return value.map(serializeBigInts) as SerializeBigInts<T>
-  }
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, serializeBigInts(item)]),
-    ) as SerializeBigInts<T>
-  }
-  return value as SerializeBigInts<T>
 }

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -25,13 +25,15 @@ import type {
   WireIntentStatusResponse,
   WirePortfolioResponse,
   WireQuote,
+  WireQuoteRequest,
   WireQuoteResponse,
+  WireSplitRequest,
   WireSplitResponse,
 } from './wire'
 
 export function mapIntentRequestToWire(
   input: OrchestratorIntentRequest,
-): unknown {
+): WireQuoteRequest {
   return serializeBigInts({
     account: input.account,
     destinationChainId: formatCaip2(input.destinationChainId),
@@ -152,7 +154,7 @@ export function mapPortfolioFromWire(value: unknown): OrchestratorPortfolio {
 
 export function mapSplitRequestToWire(
   input: OrchestratorSplitRequest,
-): unknown {
+): WireSplitRequest {
   return serializeBigInts({
     chainId: formatCaip2(input.chainId),
     tokens: input.tokens,
@@ -256,9 +258,7 @@ function mapAuthorizationToWire(authorization: SignedAuthorization): unknown {
   }
 }
 
-function mapAccessList(
-  input: OrchestratorIntentRequest['accountAccessList'],
-): unknown {
+function mapAccessList(input: OrchestratorIntentRequest['accountAccessList']) {
   if (!input) return undefined
   return {
     ...(input.chainIds ? { chainIds: input.chainIds.map(formatCaip2) } : {}),
@@ -290,13 +290,23 @@ function parseChainValue(value: string | number | undefined): number {
   return chainIdFromReference(parseCaip2(value))
 }
 
-function serializeBigInts(value: unknown): unknown {
-  if (typeof value === 'bigint') return value.toString()
-  if (Array.isArray(value)) return value.map(serializeBigInts)
+type SerializeBigInts<T> = T extends bigint
+  ? string
+  : T extends readonly (infer Item)[]
+    ? SerializeBigInts<Item>[]
+    : T extends object
+      ? { [Key in keyof T]: SerializeBigInts<T[Key]> }
+      : T
+
+function serializeBigInts<T>(value: T): SerializeBigInts<T> {
+  if (typeof value === 'bigint') return value.toString() as SerializeBigInts<T>
+  if (Array.isArray(value)) {
+    return value.map(serializeBigInts) as SerializeBigInts<T>
+  }
   if (value && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value).map(([key, item]) => [key, serializeBigInts(item)]),
-    )
+    ) as SerializeBigInts<T>
   }
-  return value
+  return value as SerializeBigInts<T>
 }

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -4,6 +4,7 @@
 
 import type { Address, Chain, Hex, TypedDataDefinition } from 'viem'
 import type { NonEvmAddress } from '../../chains/non-evm'
+import type { Serialized } from './serialization'
 
 // v2: chain ids are open (`number`), not a closed union — a new chain needs no
 // SDK release.
@@ -209,14 +210,6 @@ interface IntentInput {
 // Transport projection: `bigint` becomes a decimal string, every other type
 // keeps its shape (template-literal `Address`/`Hex`, optionality, index
 // signatures). Internal — only the `IntentInput` projection below is published.
-type Serialized<T> = T extends bigint
-  ? string
-  : T extends string | number | boolean | null | undefined
-    ? T
-    : T extends object
-      ? { [K in keyof T]: Serialized<T[K]> }
-      : T
-
 /**
  * {@link IntentInput} as it crosses the transport boundary: the same shape, with
  * every `bigint` field serialized to a decimal string.

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -111,8 +111,8 @@ type SettlementLayer =
   | CrossChainSettlementLayer
 
 type SettlementLayerFilter =
-  | { include: CrossChainSettlementLayer[] }
-  | { exclude: CrossChainSettlementLayer[] }
+  | { include: readonly CrossChainSettlementLayer[] }
+  | { exclude: readonly CrossChainSettlementLayer[] }
 
 const SIG_MODE_EMISSARY = 0
 const SIG_MODE_ERC1271 = 1

--- a/src/clients/orchestrator/serialization.ts
+++ b/src/clients/orchestrator/serialization.ts
@@ -1,0 +1,22 @@
+export type Serialized<T> = T extends bigint
+  ? string
+  : T extends readonly (infer Item)[]
+    ? Serialized<Item>[]
+    : T extends string | number | boolean | null | undefined
+      ? T
+      : T extends object
+        ? { [Key in keyof T]: Serialized<T[Key]> }
+        : T
+
+export function serializeBigInts<T>(value: T): Serialized<T> {
+  if (typeof value === 'bigint') return value.toString() as Serialized<T>
+  if (Array.isArray(value)) {
+    return value.map(serializeBigInts) as Serialized<T>
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, serializeBigInts(item)]),
+    ) as Serialized<T>
+  }
+  return value as Serialized<T>
+}

--- a/src/clients/orchestrator/types.ts
+++ b/src/clients/orchestrator/types.ts
@@ -11,6 +11,8 @@ import type {
   IntentStatus,
   SerializedIntentInput,
   SettlementLayer,
+  SettlementLayerFilter,
+  SignatureMode,
   TokenRequirements,
 } from './public'
 
@@ -49,10 +51,8 @@ export interface OrchestratorIntentOptions {
     readonly swapFees: boolean
     readonly protocolFees?: boolean
   }
-  readonly settlementLayers?:
-    | { readonly include: readonly string[] }
-    | { readonly exclude: readonly string[] }
-  readonly signatureMode?: number
+  readonly settlementLayers?: SettlementLayerFilter
+  readonly signatureMode?: SignatureMode
   readonly auxiliaryFunds?: Readonly<
     Record<number, Readonly<Record<Address, bigint>>>
   >
@@ -157,9 +157,7 @@ export interface OrchestratorAppFeeBalances {
 export interface OrchestratorSplitRequest {
   readonly chainId: number
   readonly tokens: Readonly<Record<Address, bigint>>
-  readonly settlementLayers?:
-    | { readonly include: readonly string[] }
-    | { readonly exclude: readonly string[] }
+  readonly settlementLayers?: SettlementLayerFilter
 }
 
 export interface OrchestratorSplitResult {

--- a/src/clients/orchestrator/wire.ts
+++ b/src/clients/orchestrator/wire.ts
@@ -4,6 +4,13 @@
 // time `bun run generate:wire` runs, per the generator's contract.
 import type { operations } from './wire.gen'
 
+type JsonRequest<Operation extends keyof operations> =
+  operations[Operation] extends {
+    requestBody: { content: { 'application/json': infer Body } }
+  }
+    ? Body
+    : never
+
 type JsonResponse<Operation extends keyof operations> = NonNullable<
   operations[Operation]['responses'] extends { 200: infer Ok }
     ? Ok extends { content: { 'application/json': infer Body } }
@@ -16,6 +23,8 @@ type JsonResponse<Operation extends keyof operations> = NonNullable<
 // JSON body, so a mapped response is the generated body plus that trace id.
 type Folded<Body> = Body & { readonly traceId?: string }
 
+export type WireQuoteRequest = JsonRequest<'createQuote'>
+export type WireSplitRequest = JsonRequest<'getSplit'>
 export type WireQuoteResponse = Folded<JsonResponse<'createQuote'>>
 export type WireQuote = WireQuoteResponse['routes'][number]
 export type WirePortfolioResponse = Folded<JsonResponse<'getPortfolio'>>

--- a/src/transactions/intents/sessions.ts
+++ b/src/transactions/intents/sessions.ts
@@ -3,6 +3,7 @@ import type { AccountRuntime } from '../../accounts/adapter'
 import type { Call } from '../../calls/types'
 import { isHyperCoreWireId } from '../../chains/caip2'
 import type { EvmChainReference } from '../../chains/types'
+import type { SignatureMode } from '../../clients/orchestrator/public'
 import { buildSmartSessionMockSignature } from '../../modules/validators/smart-sessions/mock-signature'
 import {
   DUMMY_PRECLAIMOP_SELECTOR,
@@ -12,7 +13,7 @@ import type { ResolvedSessionSignerSet } from '../../modules/validators/smart-se
 import type { IntentInput, IntentWorkflowContext } from './types'
 
 export interface PreparedIntentSessions {
-  readonly signatureMode: number
+  readonly signatureMode: SignatureMode
   readonly byChain: Readonly<Record<number, ResolvedSessionSignerSet>>
   readonly mockSignatures: Readonly<Record<string, Hex>>
   readonly preClaimCalls: Readonly<Record<number, readonly Call[]>>

--- a/src/transactions/intents/split.ts
+++ b/src/transactions/intents/split.ts
@@ -1,16 +1,12 @@
-import type { Address } from 'viem'
 import type { IntentSplitPort } from '../../clients/orchestrator/port'
-import type { OrchestratorSplitResult } from '../../clients/orchestrator/types'
+import type {
+  OrchestratorSplitRequest,
+  OrchestratorSplitResult,
+} from '../../clients/orchestrator/types'
 
 export function splitIntents(
   client: IntentSplitPort,
-  input: {
-    readonly chainId: number
-    readonly tokens: Readonly<Record<Address, bigint>>
-    readonly settlementLayers?:
-      | { readonly include: readonly string[] }
-      | { readonly exclude: readonly string[] }
-  },
+  input: OrchestratorSplitRequest,
 ): Promise<OrchestratorSplitResult> {
   return client.splitIntents(input)
 }

--- a/src/transactions/intents/types.ts
+++ b/src/transactions/intents/types.ts
@@ -12,6 +12,7 @@ import type {
   OriginSignature,
   Quote,
   SerializedIntentInput,
+  SignatureMode,
 } from '../../clients/orchestrator/public'
 import type {
   OrchestratorAccount,
@@ -71,7 +72,7 @@ export interface IntentInput<CompatibilityConfig = unknown> {
   readonly eip7702InitSignature?: Hex
   readonly accountAccessList?: OrchestratorAccountAccessList
   readonly options?: Omit<OrchestratorIntentOptions, 'signatureMode'>
-  readonly signatureMode?: number
+  readonly signatureMode?: SignatureMode
   readonly sourceCalls?: Readonly<
     Record<number, readonly IntentSourceCall<CompatibilityConfig>[]>
   >


### PR DESCRIPTION
- Type quote and split request mappers against generated OpenAPI wire contracts
- Preserve numeric SDK chain IDs while compiler-checking CAIP-2 transport conversion
- Narrow settlement-layer and signature-mode internals to their public contract unions
- Cover access-list chain ID and amount serialization

Closes [RHI-5631](https://linear.app/rhinestone/issue/RHI-5631)
Related: [RHI-5634](https://linear.app/rhinestone/issue/RHI-5634)