### PR TITLE
fix: use Nexus 1.2.0 default validator

### DIFF
--- a/.changeset/fix-nexus-120-default-validator.md
+++ b/.changeset/fix-nexus-120-default-validator.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Use the installed default validator when signing with Rhinestone Nexus 1.2.0 accounts.

--- a/src/accounts/nexus.test.ts
+++ b/src/accounts/nexus.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, test } from 'vitest'
 import { accountA, accountB, passkeyAccount } from '../../test/consts'
 import { assertNotNull } from '../../test/utils/utils'
 import { MODULE_TYPE_ID_VALIDATOR } from '../modules/common'
+import { OWNABLE_VALIDATOR_ADDRESS } from '../modules/validators/core'
 import {
   getAddress,
+  getDefaultValidatorAddress,
   getDeployArgs,
   getInstallData,
   packSignature,
@@ -230,7 +232,40 @@ describe('Accounts: Nexus', () => {
     })
   })
 
+  describe('Get Default Validator Address', () => {
+    test.each([undefined, '1.2.0', '1.2.1', 'rhinestone-1.0.0'] as const)(
+      'uses the deployment default for %s',
+      (version) => {
+        expect(getDefaultValidatorAddress(version)).toEqual(
+          OWNABLE_VALIDATOR_ADDRESS,
+        )
+      },
+    )
+
+    test('preserves adopted account defaults', () => {
+      expect(getDefaultValidatorAddress('1.0.2')).toEqual(
+        '0x0000002d6db27c52e3c11c1cf24072004ac75cba',
+      )
+      expect(getDefaultValidatorAddress('rhinestone-1.0.0-beta')).toEqual(
+        '0x0000000000e9e6e96bcaa3c113187cdb7e38aed9',
+      )
+    })
+  })
+
   describe('Get Packed Signature', () => {
+    test('elides the 1.2.0 default validator', async () => {
+      const signature = await packSignature(
+        '0x1234',
+        { address: OWNABLE_VALIDATOR_ADDRESS, isRoot: true },
+        undefined,
+        getDefaultValidatorAddress('1.2.0'),
+      )
+
+      expect(signature).toEqual(
+        '0x00000000000000000000000000000000000000001234',
+      )
+    })
+
     test('Mock signature', async () => {
       const mockSignature = '0x1234'
       const validator = {

--- a/src/accounts/nexus.ts
+++ b/src/accounts/nexus.ts
@@ -347,7 +347,8 @@ function getDefaultValidatorAddress(version: NexusAccount['version']): Address {
     case '1.0.2':
       return '0x0000002d6db27c52e3c11c1cf24072004ac75cba'
     case '1.2.0':
-      return '0x00000000d12897ddadc2044614a9677b191a2d95'
+      // Rhinestone's 1.2.0 deployment hardwires OwnableValidator, unlike upstream Nexus.
+      return NEXUS_DEFAULT_VALIDATOR_ADDRESS
     case '1.2.1':
       return NEXUS_DEFAULT_VALIDATOR_ADDRESS
     case 'rhinestone-1.0.0-beta':


### PR DESCRIPTION
- Map Nexus 1.2.0 signing to the OwnableValidator installed by Rhinestone deployments.
- Add regression coverage for deployable and adopted account versions.
- v2 is unaffected, and the deposit service needs no companion change.

Closes [RHI-5026](https://linear.app/rhinestone/issue/RHI-5026)