### PR TITLE
fix(orchestrator): preserve public request types

### DIFF
--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -44,6 +44,10 @@ export function mapIntentRequestToWire(
     accountAccessList: mapAccessList(input.accountAccessList),
     options: {
       ...input.options,
+      settlementLayers: mapSettlementLayers(input.options.settlementLayers),
+      signatureMode: input.options.signatureMode as
+        | NonNullable<WireQuoteRequest['options']>['signatureMode']
+        | undefined,
       ...(input.options.auxiliaryFunds
         ? {
             auxiliaryFunds: mapChainRecord(input.options.auxiliaryFunds),
@@ -159,7 +163,7 @@ export function mapSplitRequestToWire(
   return serializeBigInts({
     chainId: formatCaip2(input.chainId),
     tokens: input.tokens,
-    settlementLayers: input.settlementLayers,
+    settlementLayers: mapSettlementLayers(input.settlementLayers),
   })
 }
 
@@ -271,6 +275,15 @@ function mapAccessList(input: OrchestratorIntentRequest['accountAccessList']) {
       ? { chainTokenAmounts: mapChainRecord(input.chainTokenAmounts) }
       : {}),
   }
+}
+
+function mapSettlementLayers(
+  input:
+    | OrchestratorIntentRequest['options']['settlementLayers']
+    | OrchestratorSplitRequest['settlementLayers'],
+): NonNullable<WireQuoteRequest['options']>['settlementLayers'] {
+  // Keep the legacy public string arrays while checking the rest of the wire shape.
+  return input as NonNullable<WireQuoteRequest['options']>['settlementLayers']
 }
 
 function mapChainRecord<T>(

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -4,7 +4,6 @@
 
 import type { Address, Chain, Hex, TypedDataDefinition } from 'viem'
 import type { NonEvmAddress } from '../../chains/non-evm'
-import type { Serialized } from './serialization'
 
 // v2: chain ids are open (`number`), not a closed union — a new chain needs no
 // SDK release.
@@ -112,8 +111,8 @@ type SettlementLayer =
   | CrossChainSettlementLayer
 
 type SettlementLayerFilter =
-  | { include: readonly CrossChainSettlementLayer[] }
-  | { exclude: readonly CrossChainSettlementLayer[] }
+  | { include: CrossChainSettlementLayer[] }
+  | { exclude: CrossChainSettlementLayer[] }
 
 const SIG_MODE_EMISSARY = 0
 const SIG_MODE_ERC1271 = 1
@@ -210,6 +209,14 @@ interface IntentInput {
 // Transport projection: `bigint` becomes a decimal string, every other type
 // keeps its shape (template-literal `Address`/`Hex`, optionality, index
 // signatures). Internal — only the `IntentInput` projection below is published.
+type Serialized<T> = T extends bigint
+  ? string
+  : T extends string | number | boolean | null | undefined
+    ? T
+    : T extends object
+      ? { [K in keyof T]: Serialized<T[K]> }
+      : T
+
 /**
  * {@link IntentInput} as it crosses the transport boundary: the same shape, with
  * every `bigint` field serialized to a decimal string.

--- a/src/clients/orchestrator/types.ts
+++ b/src/clients/orchestrator/types.ts
@@ -11,8 +11,6 @@ import type {
   IntentStatus,
   SerializedIntentInput,
   SettlementLayer,
-  SettlementLayerFilter,
-  SignatureMode,
   TokenRequirements,
 } from './public'
 
@@ -51,8 +49,10 @@ export interface OrchestratorIntentOptions {
     readonly swapFees: boolean
     readonly protocolFees?: boolean
   }
-  readonly settlementLayers?: SettlementLayerFilter
-  readonly signatureMode?: SignatureMode
+  readonly settlementLayers?:
+    | { readonly include: readonly string[] }
+    | { readonly exclude: readonly string[] }
+  readonly signatureMode?: number
   readonly auxiliaryFunds?: Readonly<
     Record<number, Readonly<Record<Address, bigint>>>
   >
@@ -157,7 +157,9 @@ export interface OrchestratorAppFeeBalances {
 export interface OrchestratorSplitRequest {
   readonly chainId: number
   readonly tokens: Readonly<Record<Address, bigint>>
-  readonly settlementLayers?: SettlementLayerFilter
+  readonly settlementLayers?:
+    | { readonly include: readonly string[] }
+    | { readonly exclude: readonly string[] }
 }
 
 export interface OrchestratorSplitResult {

--- a/src/transactions/intents/sessions.ts
+++ b/src/transactions/intents/sessions.ts
@@ -3,7 +3,6 @@ import type { AccountRuntime } from '../../accounts/adapter'
 import type { Call } from '../../calls/types'
 import { isHyperCoreWireId } from '../../chains/caip2'
 import type { EvmChainReference } from '../../chains/types'
-import type { SignatureMode } from '../../clients/orchestrator/public'
 import { buildSmartSessionMockSignature } from '../../modules/validators/smart-sessions/mock-signature'
 import {
   DUMMY_PRECLAIMOP_SELECTOR,
@@ -13,7 +12,7 @@ import type { ResolvedSessionSignerSet } from '../../modules/validators/smart-se
 import type { IntentInput, IntentWorkflowContext } from './types'
 
 export interface PreparedIntentSessions {
-  readonly signatureMode: SignatureMode
+  readonly signatureMode: number
   readonly byChain: Readonly<Record<number, ResolvedSessionSignerSet>>
   readonly mockSignatures: Readonly<Record<string, Hex>>
   readonly preClaimCalls: Readonly<Record<number, readonly Call[]>>

--- a/src/transactions/intents/split.ts
+++ b/src/transactions/intents/split.ts
@@ -1,12 +1,16 @@
+import type { Address } from 'viem'
 import type { IntentSplitPort } from '../../clients/orchestrator/port'
-import type {
-  OrchestratorSplitRequest,
-  OrchestratorSplitResult,
-} from '../../clients/orchestrator/types'
+import type { OrchestratorSplitResult } from '../../clients/orchestrator/types'
 
 export function splitIntents(
   client: IntentSplitPort,
-  input: OrchestratorSplitRequest,
+  input: {
+    readonly chainId: number
+    readonly tokens: Readonly<Record<Address, bigint>>
+    readonly settlementLayers?:
+      | { readonly include: readonly string[] }
+      | { readonly exclude: readonly string[] }
+  },
 ): Promise<OrchestratorSplitResult> {
   return client.splitIntents(input)
 }

--- a/src/transactions/intents/types.ts
+++ b/src/transactions/intents/types.ts
@@ -12,7 +12,6 @@ import type {
   OriginSignature,
   Quote,
   SerializedIntentInput,
-  SignatureMode,
 } from '../../clients/orchestrator/public'
 import type {
   OrchestratorAccount,
@@ -72,7 +71,7 @@ export interface IntentInput<CompatibilityConfig = unknown> {
   readonly eip7702InitSignature?: Hex
   readonly accountAccessList?: OrchestratorAccountAccessList
   readonly options?: Omit<OrchestratorIntentOptions, 'signatureMode'>
-  readonly signatureMode?: SignatureMode
+  readonly signatureMode?: number
   readonly sourceCalls?: Readonly<
     Record<number, readonly IntentSourceCall<CompatibilityConfig>[]>
   >


### PR DESCRIPTION
- Restore the previously published request type shapes while retaining generated OpenAPI checks at the wire boundary
- Keep bigint serialization and CAIP-2 request mapping changes from #744
- Unblock the `main` → `release` package contract check

Relates to [RHI-5646](https://linear.app/rhinestone/issue/RHI-5646)