### PR TITLE
fix(contract): classify patch API compatibility

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,8 +38,11 @@ offline. The command validates:
 
 - every published subpath resolves, its declaration file exists, and its runtime
   export keys match the packed release package;
-- semantic declaration reports and bidirectional assignability match the packed
-  release declarations;
+- patch releases keep the exact declared export inventory and require changed
+  public types to be mutually assignable with the packed release. Text-equal
+  symbols take a fast path; generic types use representative `never`, `any`, and
+  default instantiations, while classes with private or protected members keep
+  their own declaration text strict;
 - representative consumer projects type-check configurations, selected root
   APIs, and every published subpath against both packages
   (`test/contract/fixtures/consumer.ts`). Type-only root exports must be imported
@@ -53,8 +56,11 @@ offline. The command validates:
 - the per-entry `size-limit` gate for every published subpath.
 
 The suite runs through `scripts/contract/run.ts`, which owns the build, pack,
-consumer staging, and size run; `vitest.config.contract.ts` only discovers the
-`*.ctest.ts` assertions and requires the staged environment.
+consumer staging, compatibility report, and size run. A patch failure reports
+only the affected entry point and symbol with its base and current declarations.
+Minor and major changes keep their existing additive and well-formedness rules.
+`vitest.config.contract.ts` only discovers the `*.ctest.ts` assertions and
+requires the staged environment.
 
 ## Integration tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,8 +41,9 @@ offline. The command validates:
 - patch releases keep the exact declared export inventory and require changed
   public types to be mutually assignable with the packed release. Text-equal
   symbols take a fast path; generic types use representative `never`, `any`, and
-  default instantiations, while classes with private or protected members keep
-  their own declaration text strict;
+  default instantiations. Namespaces and classes with private or protected
+  members (including inherited members) keep their declarations and referenced
+  declarations text-strict;
 - representative consumer projects type-check configurations, selected root
   APIs, and every published subpath against both packages
   (`test/contract/fixtures/consumer.ts`). Type-only root exports must be imported

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,10 +41,10 @@ offline. The command validates:
 - patch releases keep the exact declared export inventory and require changed
   public types to be mutually assignable with the packed release. Text-equal
   symbols take a fast path; generic types use representative `never`, `any`, and
-  default instantiations. Namespaces, types containing method syntax (whose
-  parameters TypeScript checks bivariantly), and classes with private or
-  protected members (including inherited members) keep their declarations and
-  referenced declarations text-strict;
+  default instantiations. Namespaces, variance-sensitive declarations (method
+  or constructor syntax and readonly object properties), and classes with
+  private or protected members (including inherited members) keep their
+  declarations and referenced declarations text-strict;
 - representative consumer projects type-check configurations, selected root
   APIs, and every published subpath against both packages
   (`test/contract/fixtures/consumer.ts`). Type-only root exports must be imported

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,9 +41,10 @@ offline. The command validates:
 - patch releases keep the exact declared export inventory and require changed
   public types to be mutually assignable with the packed release. Text-equal
   symbols take a fast path; generic types use representative `never`, `any`, and
-  default instantiations. Namespaces and classes with private or protected
-  members (including inherited members) keep their declarations and referenced
-  declarations text-strict;
+  default instantiations. Namespaces, types containing method syntax (whose
+  parameters TypeScript checks bivariantly), and classes with private or
+  protected members (including inherited members) keep their declarations and
+  referenced declarations text-strict;
 - representative consumer projects type-check configurations, selected root
   APIs, and every published subpath against both packages
   (`test/contract/fixtures/consumer.ts`). Type-only root exports must be imported

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,10 +41,10 @@ offline. The command validates:
 - patch releases keep the exact declared export inventory and require changed
   public types to be mutually assignable with the packed release. Text-equal
   symbols take a fast path; generic types use representative `never`, `any`, and
-  default instantiations. Namespaces, variance-sensitive declarations (method
-  or constructor syntax and readonly object properties), and classes with
-  private or protected members (including inherited members) keep their
-  declarations and referenced declarations text-strict;
+  default instantiations. Namespaces, checker-sensitive declarations (explicit
+  `any`, method or constructor syntax, and readonly object properties), and
+  classes with private or protected members (including inherited members) keep
+  their declarations and referenced declarations text-strict;
 - representative consumer projects type-check configurations, selected root
   APIs, and every published subpath against both packages
   (`test/contract/fixtures/consumer.ts`). Type-only root exports must be imported

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,8 +40,9 @@ offline. The command validates:
   export keys match the packed release package;
 - patch releases keep the exact declared export inventory and require changed
   public types to be mutually assignable with the packed release. Text-equal
-  symbols take a fast path; generic types use representative `never`, `any`, and
-  default instantiations. Namespaces, checker-sensitive declarations (explicit
+  symbols take a fast path; generic types use representative `never`, `any`,
+  default, and SDK smart-session ABI instantiations. Namespaces,
+  checker-sensitive declarations (explicit
   `any`, method or constructor syntax, and readonly object properties), and
   classes with private or protected members (including inherited members) keep
   their declarations and referenced declarations text-strict;

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -239,6 +239,22 @@ describe('API compatibility report', () => {
     )
   })
 
+  test('rejects method parameter narrowing through a referenced alias', () => {
+    const report = compare(
+      'type Options = string | number; export interface Handler { on(value: Options): void }',
+      'type Options = string; export interface Handler { on(value: Options): void }',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Handler',
+          reasons: ['declaration text changed for a checker-sensitive type'],
+        }),
+      ]),
+    )
+  })
+
   test('rejects constructor parameter narrowing', () => {
     const report = compare(
       'export declare class Handler { constructor(value: string | number) }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -349,6 +349,28 @@ describe('API compatibility report', () => {
     },
   )
 
+  test.each([
+    [
+      'writable field to getter',
+      'export declare class Config { value: string }',
+      'export declare class Config { get value(): string }',
+    ],
+    [
+      'setter removal',
+      'export declare class Config { get value(): string; set value(value: string) }',
+      'export declare class Config { get value(): string }',
+    ],
+  ])('rejects %s', (_, base, current) => {
+    const report = compare(base, current)
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Config',
+        reasons: ['declaration text changed for a checker-sensitive type'],
+      },
+    ])
+  })
+
   test('rejects mutable to readonly property changes', () => {
     const report = compare(
       'export interface Config { value: string }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -39,6 +39,19 @@ function compare(baseDeclaration: string, currentDeclaration: string) {
   temporaryDirectories.push(root)
   const base = createPackage(root, '@rhinestone/sdk-base', baseDeclaration)
   const current = createPackage(root, '@rhinestone/sdk', currentDeclaration)
+  const external = join(root, 'node_modules/external')
+  writeJson(join(external, 'package.json'), {
+    name: 'external',
+    version: '1.0.0',
+    type: 'module',
+    types: './index.d.ts',
+    exports: { '.': { types: './index.d.ts', import: './index.js' } },
+  })
+  writeFileSync(
+    join(external, 'index.d.ts'),
+    'export interface ExternalOptions { external?: string }',
+  )
+  writeFileSync(join(external, 'index.js'), '')
   const consumer = join(root, 'consumer')
   mkdirSync(join(consumer, 'node_modules/@rhinestone'), { recursive: true })
   cpSync(base, join(consumer, 'node_modules/@rhinestone/sdk-base'), {
@@ -47,6 +60,7 @@ function compare(baseDeclaration: string, currentDeclaration: string) {
   cpSync(current, join(consumer, 'node_modules/@rhinestone/sdk'), {
     recursive: true,
   })
+  cpSync(external, join(consumer, 'node_modules/external'), { recursive: true })
   writeJson(join(consumer, 'package.json'), { private: true, type: 'module' })
 
   return generateApiCompatibilityReport({
@@ -300,6 +314,11 @@ describe('API compatibility report', () => {
       "export type Config = { kind: 'a'; value?: string } | { kind: 'b' }",
       "export type Config = { kind: 'a' } | { kind: 'b' }",
     ],
+    [
+      'inherited external removal',
+      "import type { ExternalOptions } from 'external'; export interface Config extends ExternalOptions {}",
+      'export interface Config {}',
+    ],
   ])('rejects optional public member %s', (_, base, current) => {
     const report = compare(base, current)
 
@@ -378,7 +397,9 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toMatchObject([
       {
         symbol: '.:Config',
-        reasons: ['type: current is not assignable to base'],
+        reasons: expect.arrayContaining([
+          'type: current is not assignable to base',
+        ]),
       },
     ])
   })

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -161,6 +161,50 @@ describe('API compatibility report', () => {
     ])
   })
 
+  test('rejects method parameter narrowing', () => {
+    const report = compare(
+      'export interface Handler { on(value: string | number): void }',
+      'export interface Handler { on(value: string): void }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Handler',
+        reasons: ['declaration text changed for a type containing methods'],
+      },
+    ])
+  })
+
+  test('rejects nested method parameter narrowing', () => {
+    const report = compare(
+      'interface Handler { on(value: string | number): void } export interface Config { handler: Handler }',
+      'interface Handler { on(value: string): void } export interface Config { handler: Handler }',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Config',
+          reasons: ['declaration text changed for a type containing methods'],
+        }),
+      ]),
+    )
+  })
+
+  test('still compares function properties semantically', () => {
+    const report = compare(
+      'export interface Handler { on: (value: string | number) => void }',
+      'export interface Handler { on: (value: string) => void }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Handler',
+        reasons: ['type: current is not assignable to base'],
+      },
+    ])
+  })
+
   test('rejects mutable to readonly property changes', () => {
     const report = compare(
       'export interface Config { items: string[] }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -83,6 +83,16 @@ describe('API compatibility report', () => {
     },
   )
 
+  test('accepts renamed enclosing and method type parameters', () => {
+    const report = compare(
+      'export interface Box<T> { map<U>(value: T): U }',
+      'export interface Box<Value> { map<Item>(value: Value): Item }',
+    )
+
+    expect(report.compatible).toEqual(['.:Box'])
+    expect(report.incompatible).toEqual([])
+  })
+
   test('accepts renamed type parameters in constraints', () => {
     const report = compare(
       'export type Value<T, K extends keyof T> = T[K]',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -107,6 +107,43 @@ describe('API compatibility report', () => {
     )
   })
 
+  test('accepts type parameter renames in constraint dependencies', () => {
+    const report = compare(
+      'type Options<K> = { value: K }; export type Box<T extends Options<string>> = T',
+      'type Options<Key> = { value: Key }; export type Box<T extends Options<string>> = T',
+    )
+
+    expect(report.incompatible).toEqual([])
+  })
+
+  test('rejects changed generic defaults', () => {
+    const report = compare(
+      'export type Box<T = string> = { value: T }',
+      'export type Box<T = number> = { value: T }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Box',
+        reasons: ['type parameter modifiers or defaults changed'],
+      },
+    ])
+  })
+
+  test('rejects removed const type parameter modifiers', () => {
+    const report = compare(
+      'export declare function define<const T>(value: T): T',
+      'export declare function define<T>(value: T): T',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:define',
+        reasons: ['type parameter modifiers or defaults changed'],
+      },
+    ])
+  })
+
   test('rejects incompatible relationships between generic parameters', () => {
     const report = compare(
       'export type Pair<A, B> = { first: A; second: B }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -177,6 +177,19 @@ describe('API compatibility report', () => {
     ])
   })
 
+  test('probes concrete ABI branches in public config generics', () => {
+    const report = compare(
+      "export type PermissionFunctionConfig<T extends { name: string }> = T['name'] extends 'transfer' ? { spendingLimit?: bigint } : { spendingLimit?: never }",
+      "export type PermissionFunctionConfig<T extends { name: string }> = T['name'] extends 'approve' ? { spendingLimit?: bigint } : { spendingLimit?: never }",
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ symbol: '.:PermissionFunctionConfig' }),
+      ]),
+    )
+  })
+
   test('rejects method parameter narrowing', () => {
     const report = compare(
       'export interface Handler { on(value: string | number): void }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -67,6 +67,30 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toEqual([])
   })
 
+  test('accepts renamed type parameters in constraints', () => {
+    const report = compare(
+      'export type Value<T, K extends keyof T> = T[K]',
+      'export type Value<Item, Key extends keyof Item> = Item[Key]',
+    )
+
+    expect(report.compatible).toEqual(['.:Value'])
+    expect(report.incompatible).toEqual([])
+  })
+
+  test('rejects changed generic constraints', () => {
+    const report = compare(
+      'export type Box<T extends string> = { value: T }',
+      'export type Box<T extends number> = { value: T }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Box',
+        reasons: ['type parameter constraints changed'],
+      },
+    ])
+  })
+
   test('rejects incompatible relationships between generic parameters', () => {
     const report = compare(
       'export type Pair<A, B> = { first: A; second: B }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -67,6 +67,23 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toEqual([])
   })
 
+  test('rejects incompatible relationships between generic parameters', () => {
+    const report = compare(
+      'export type Pair<A, B> = { first: A; second: B }',
+      'export type Pair<A, B> = { first: B; second: A }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Pair',
+        reasons: expect.arrayContaining([
+          'type<never, any>: base is not assignable to current',
+          'type<never, any>: current is not assignable to base',
+        ]),
+      },
+    ])
+  })
+
   test('rejects mutable to readonly property changes', () => {
     const report = compare(
       'export interface Config { items: string[] }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -177,18 +177,21 @@ describe('API compatibility report', () => {
     ])
   })
 
-  test('probes concrete ABI branches in public config generics', () => {
-    const report = compare(
-      "export type PermissionFunctionConfig<T extends { name: string }> = T['name'] extends 'transfer' ? { spendingLimit?: bigint } : { spendingLimit?: never }",
-      "export type PermissionFunctionConfig<T extends { name: string }> = T['name'] extends 'approve' ? { spendingLimit?: bigint } : { spendingLimit?: never }",
-    )
+  test.each(['approve', 'increaseAllowance', 'transfer', 'transferFrom'])(
+    'probes the %s ABI branch in public config generics',
+    (functionName) => {
+      const report = compare(
+        `export type PermissionFunctionConfig<T extends { name: string }> = T['name'] extends '${functionName}' ? { spendingLimit?: bigint } : { spendingLimit?: never }`,
+        'export type PermissionFunctionConfig<T extends { name: string }> = { spendingLimit?: never }',
+      )
 
-    expect(report.incompatible).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ symbol: '.:PermissionFunctionConfig' }),
-      ]),
-    )
-  })
+      expect(report.incompatible).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ symbol: '.:PermissionFunctionConfig' }),
+        ]),
+      )
+    },
+  )
 
   test('rejects method parameter narrowing', () => {
     const report = compare(

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -313,6 +313,20 @@ describe('API compatibility report', () => {
     ])
   })
 
+  test('rejects mutable to Readonly-wrapped object property changes', () => {
+    const report = compare(
+      'export interface Config { value: { name: string } }',
+      'export interface Config { value: Readonly<{ name: string }> }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Config',
+        reasons: ['declaration text changed for a checker-sensitive type'],
+      },
+    ])
+  })
+
   test('rejects mutable to readonly array property changes', () => {
     const report = compare(
       'export interface Config { items: string[] }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -95,24 +95,93 @@ describe('API compatibility report', () => {
     ])
   })
 
-  test('ignores referenced text drift when a nominal class declaration is unchanged', () => {
+  test('keeps namespace type members text-strict', () => {
     const report = compare(
-      'type Box<K> = { value: K }; export declare class Secret { private token; read(): Box<string> }',
-      'type Box<Key> = { value: Key }; export declare class Secret { private token; read(): Box<string> }',
+      "export declare namespace Values { const value: 'a'; type Item = 'a' }",
+      "export declare namespace Values { const value: 'a'; type Item = 'b' }",
     )
 
-    expect(report.compatible).toEqual(['.:Box', '.:Secret'])
-    expect(report.incompatible).toEqual([])
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Values',
+        reasons: ['declaration text changed for a namespace'],
+      },
+    ])
   })
 
-  test('checks changed referenced types through a nominal class public surface', () => {
+  test('keeps type-only namespaces text-strict', () => {
     const report = compare(
-      'type Box = { items: string[] }; export declare class Secret { private token; read(): Box }',
-      'type Box = { items: readonly string[] }; export declare class Secret { private token; read(): Box }',
+      "export declare namespace Types { type Item = 'a' }",
+      "export declare namespace Types { type Item = 'b' }",
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Types',
+        reasons: ['declaration text changed for a namespace'],
+      },
+    ])
+  })
+
+  test('keeps protected surfaces and their references text-strict', () => {
+    const report = compare(
+      'type Options = { value?: string }; export declare class Secret { protected run(options: Options): void }',
+      'type Options = { value: string }; export declare class Secret { protected run(options: Options): void }',
     )
 
     expect(report.incompatible).toEqual(
-      expect.arrayContaining([expect.objectContaining({ symbol: '.:Secret' })]),
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Secret',
+          reasons: ['declaration text changed for a nominal class'],
+        }),
+      ]),
+    )
+  })
+
+  test('detects inherited private members as nominal', () => {
+    const report = compare(
+      'declare class Base { private token; } export declare class Child extends Base { constructor(value: string) }',
+      'declare class Base { private token; } export declare class Child extends Base { constructor(input: string) }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Child',
+        reasons: ['declaration text changed for a nominal class'],
+      },
+    ])
+  })
+
+  test('does not generate probes for generic nominal classes', () => {
+    const report = compare(
+      'type Box<K> = { value: K }; export declare class Secret<T> { private token; read(): Box<T> }',
+      'type Box<Key> = { value: Key }; export declare class Secret<T> { private token; read(): Box<T> }',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Secret',
+          reasons: ['declaration text changed for a nominal class'],
+        }),
+      ]),
+    )
+  })
+
+  test('does not generate constructor probes for private constructors', () => {
+    const report = compare(
+      'type Box<K> = { value: K }; export declare class Secret { private constructor(); private token; read(): Box<string> }',
+      'type Box<Key> = { value: Key }; export declare class Secret { private constructor(); private token; read(): Box<string> }',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Secret',
+          reasons: ['declaration text changed for a nominal class'],
+        }),
+      ]),
     )
   })
 

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -186,7 +186,7 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toMatchObject([
       {
         symbol: '.:Handler',
-        reasons: ['declaration text changed for a variance-sensitive type'],
+        reasons: ['declaration text changed for a checker-sensitive type'],
       },
     ])
   })
@@ -201,7 +201,7 @@ describe('API compatibility report', () => {
       expect.arrayContaining([
         expect.objectContaining({
           symbol: '.:Config',
-          reasons: ['declaration text changed for a variance-sensitive type'],
+          reasons: ['declaration text changed for a checker-sensitive type'],
         }),
       ]),
     )
@@ -216,7 +216,7 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toMatchObject([
       {
         symbol: '.:Handler',
-        reasons: ['declaration text changed for a variance-sensitive type'],
+        reasons: ['declaration text changed for a checker-sensitive type'],
       },
     ])
   })
@@ -230,9 +230,25 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toMatchObject([
       {
         symbol: '.:Config',
-        reasons: ['declaration text changed for a variance-sensitive type'],
+        reasons: ['declaration text changed for a checker-sensitive type'],
       },
     ])
+  })
+
+  test('rejects any narrowing', () => {
+    const report = compare(
+      'type Value = any; export interface Config { value: Value }',
+      'type Value = string; export interface Config { value: Value }',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Config',
+          reasons: ['declaration text changed for a checker-sensitive type'],
+        }),
+      ]),
+    )
   })
 
   test('still compares function properties semantically', () => {

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -67,6 +67,22 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toEqual([])
   })
 
+  test.each([
+    ['readonly property', 'readonly value: T'],
+    ['method', 'set(value: T): void'],
+  ])(
+    'accepts a generic type parameter rename in a %s',
+    (_, memberDeclaration) => {
+      const report = compare(
+        `export interface Box<T> { ${memberDeclaration} }`,
+        `export interface Box<Value> { ${memberDeclaration.replaceAll('T', 'Value')} }`,
+      )
+
+      expect(report.compatible).toEqual(['.:Box'])
+      expect(report.incompatible).toEqual([])
+    },
+  )
+
   test('accepts renamed type parameters in constraints', () => {
     const report = compare(
       'export type Value<T, K extends keyof T> = T[K]',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -1,0 +1,132 @@
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import { generateApiCompatibilityReport } from './api-compat'
+import { generateApiReport } from './api-report'
+import { writeJson } from './shared'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+function createPackage(
+  root: string,
+  name: string,
+  declaration: string,
+): string {
+  const directory = join(root, name.endsWith('base') ? 'base' : 'current')
+  writeJson(join(directory, 'package.json'), {
+    name,
+    version: '1.0.0',
+    type: 'module',
+    types: './index.d.ts',
+    exports: {
+      '.': { types: './index.d.ts', import: './index.js' },
+    },
+  })
+  writeFileSync(join(directory, 'index.d.ts'), declaration)
+  writeFileSync(join(directory, 'index.js'), '')
+  return directory
+}
+
+function compare(baseDeclaration: string, currentDeclaration: string) {
+  const root = mkdtempSync(join(tmpdir(), 'api-compat-test-'))
+  temporaryDirectories.push(root)
+  const base = createPackage(root, '@rhinestone/sdk-base', baseDeclaration)
+  const current = createPackage(root, '@rhinestone/sdk', currentDeclaration)
+  const consumer = join(root, 'consumer')
+  mkdirSync(join(consumer, 'node_modules/@rhinestone'), { recursive: true })
+  cpSync(base, join(consumer, 'node_modules/@rhinestone/sdk-base'), {
+    recursive: true,
+  })
+  cpSync(current, join(consumer, 'node_modules/@rhinestone/sdk'), {
+    recursive: true,
+  })
+  writeJson(join(consumer, 'package.json'), { private: true, type: 'module' })
+
+  return generateApiCompatibilityReport({
+    consumerDirectory: consumer,
+    baseReport: generateApiReport(base),
+    currentReport: generateApiReport(current),
+  })
+}
+
+describe('API compatibility report', () => {
+  test('accepts a generic type parameter rename through probe instantiations', () => {
+    const report = compare(
+      'export type Box<K> = { value: K }',
+      'export type Box<Key> = { value: Key }',
+    )
+
+    expect(report.compatible).toEqual(['.:Box'])
+    expect(report.incompatible).toEqual([])
+  })
+
+  test('rejects mutable to readonly property changes', () => {
+    const report = compare(
+      'export interface Config { items: string[] }',
+      'export interface Config { items: readonly string[] }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Config',
+        reasons: ['type: current is not assignable to base'],
+      },
+    ])
+  })
+
+  test('rejects union member additions', () => {
+    const report = compare(
+      "export type State = 'ready'",
+      "export type State = 'ready' | 'pending'",
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:State',
+        reasons: ['type: current is not assignable to base'],
+      },
+    ])
+  })
+
+  test('ignores referenced text drift when a nominal class declaration is unchanged', () => {
+    const report = compare(
+      'type Box<K> = { value: K }; export declare class Secret { private token; read(): Box<string> }',
+      'type Box<Key> = { value: Key }; export declare class Secret { private token; read(): Box<string> }',
+    )
+
+    expect(report.compatible).toEqual(['.:Box', '.:Secret'])
+    expect(report.incompatible).toEqual([])
+  })
+
+  test('checks changed referenced types through a nominal class public surface', () => {
+    const report = compare(
+      'type Box = { items: string[] }; export declare class Secret { private token; read(): Box }',
+      'type Box = { items: readonly string[] }; export declare class Secret { private token; read(): Box }',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([expect.objectContaining({ symbol: '.:Secret' })]),
+    )
+  })
+
+  test('keeps changed nominal classes text-strict', () => {
+    const report = compare(
+      'export declare class Secret { private token; constructor(value: string) }',
+      'export declare class Secret { private token; constructor(input: string) }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Secret',
+        reasons: ['declaration text changed for a nominal class'],
+      },
+    ])
+  })
+})

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -170,7 +170,7 @@ describe('API compatibility report', () => {
     expect(report.incompatible).toMatchObject([
       {
         symbol: '.:Handler',
-        reasons: ['declaration text changed for a type containing methods'],
+        reasons: ['declaration text changed for a variance-sensitive type'],
       },
     ])
   })
@@ -185,10 +185,38 @@ describe('API compatibility report', () => {
       expect.arrayContaining([
         expect.objectContaining({
           symbol: '.:Config',
-          reasons: ['declaration text changed for a type containing methods'],
+          reasons: ['declaration text changed for a variance-sensitive type'],
         }),
       ]),
     )
+  })
+
+  test('rejects constructor parameter narrowing', () => {
+    const report = compare(
+      'export declare class Handler { constructor(value: string | number) }',
+      'export declare class Handler { constructor(value: string) }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Handler',
+        reasons: ['declaration text changed for a variance-sensitive type'],
+      },
+    ])
+  })
+
+  test('rejects mutable to readonly property changes', () => {
+    const report = compare(
+      'export interface Config { value: string }',
+      'export interface Config { readonly value: string }',
+    )
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Config',
+        reasons: ['declaration text changed for a variance-sensitive type'],
+      },
+    ])
   })
 
   test('still compares function properties semantically', () => {
@@ -205,7 +233,7 @@ describe('API compatibility report', () => {
     ])
   })
 
-  test('rejects mutable to readonly property changes', () => {
+  test('rejects mutable to readonly array property changes', () => {
     const report = compare(
       'export interface Config { items: string[] }',
       'export interface Config { items: readonly string[] }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -109,11 +109,27 @@ describe('API compatibility report', () => {
 
   test('accepts type parameter renames in constraint dependencies', () => {
     const report = compare(
-      'type Options<K> = { value: K }; export type Box<T extends Options<string>> = T',
-      'type Options<Key> = { value: Key }; export type Box<T extends Options<string>> = T',
+      'type Options<K> = { K: K }; export type Box<T extends Options<string>> = T',
+      'type Options<Key> = { K: Key }; export type Box<T extends Options<string>> = T',
     )
 
     expect(report.incompatible).toEqual([])
+  })
+
+  test('does not normalize matching property names as type parameters', () => {
+    const report = compare(
+      'type Options<K> = { K: string }; export type Box<T extends Options<string>> = T',
+      'type Options<Key> = { Key: string }; export type Box<T extends Options<string>> = T',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Box',
+          reasons: ['type parameter constraints changed'],
+        }),
+      ]),
+    )
   })
 
   test('rejects changed generic defaults', () => {

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -91,6 +91,22 @@ describe('API compatibility report', () => {
     ])
   })
 
+  test('rejects changes to declarations referenced by generic constraints', () => {
+    const report = compare(
+      'type Options = { value?: string }; export type Box<T extends Options> = T',
+      'type Options = { value: string }; export type Box<T extends Options> = T',
+    )
+
+    expect(report.incompatible).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: '.:Box',
+          reasons: ['type parameter constraints changed'],
+        }),
+      ]),
+    )
+  })
+
   test('rejects incompatible relationships between generic parameters', () => {
     const report = compare(
       'export type Pair<A, B> = { first: A; second: B }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -279,6 +279,38 @@ describe('API compatibility report', () => {
     ])
   })
 
+  test.each([
+    [
+      'removal',
+      'export interface Config { value?: string }',
+      'export interface Config {}',
+    ],
+    [
+      'rename',
+      'export interface Config { value?: string }',
+      'export interface Config { renamed?: string }',
+    ],
+    [
+      'nested removal',
+      'export interface Config { options: { value?: string } }',
+      'export interface Config { options: {} }',
+    ],
+    [
+      'union branch removal',
+      "export type Config = { kind: 'a'; value?: string } | { kind: 'b' }",
+      "export type Config = { kind: 'a' } | { kind: 'b' }",
+    ],
+  ])('rejects optional public member %s', (_, base, current) => {
+    const report = compare(base, current)
+
+    expect(report.incompatible).toMatchObject([
+      {
+        symbol: '.:Config',
+        reasons: expect.arrayContaining(['type: public member shape changed']),
+      },
+    ])
+  })
+
   test('rejects mutable to readonly property changes', () => {
     const report = compare(
       'export interface Config { value: string }',

--- a/scripts/contract/api-compat.test.ts
+++ b/scripts/contract/api-compat.test.ts
@@ -330,6 +330,25 @@ describe('API compatibility report', () => {
     ])
   })
 
+  test.each(['string', 'number'])(
+    'rejects removed %s index signatures',
+    (keyType) => {
+      const report = compare(
+        `export interface Config { [key: ${keyType}]: string }`,
+        'export interface Config {}',
+      )
+
+      expect(report.incompatible).toMatchObject([
+        {
+          symbol: '.:Config',
+          reasons: expect.arrayContaining([
+            'type: public member shape changed',
+          ]),
+        },
+      ])
+    },
+  )
+
   test('rejects mutable to readonly property changes', () => {
     const report = compare(
       'export interface Config { value: string }',

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -177,8 +177,8 @@ export function generateApiCompatibilityReport(options: {
       continue
     }
     if (
-      comparison.base.hasCheckerSensitiveDeclarations ||
-      comparison.current.hasCheckerSensitiveDeclarations
+      JSON.stringify(comparison.base.checkerSensitiveDeclarations) !==
+      JSON.stringify(comparison.current.checkerSensitiveDeclarations)
     ) {
       incompatible.push(
         failure(comparison, [

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -151,12 +151,12 @@ export function generateApiCompatibilityReport(options: {
       continue
     }
     if (
-      comparison.base.hasBivariantMethods ||
-      comparison.current.hasBivariantMethods
+      comparison.base.hasVarianceSensitiveDeclarations ||
+      comparison.current.hasVarianceSensitiveDeclarations
     ) {
       incompatible.push(
         failure(comparison, [
-          'declaration text changed for a type containing methods',
+          'declaration text changed for a variance-sensitive type',
         ]),
       )
       continue

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -151,12 +151,12 @@ export function generateApiCompatibilityReport(options: {
       continue
     }
     if (
-      comparison.base.hasVarianceSensitiveDeclarations ||
-      comparison.current.hasVarianceSensitiveDeclarations
+      comparison.base.hasCheckerSensitiveDeclarations ||
+      comparison.current.hasCheckerSensitiveDeclarations
     ) {
       incompatible.push(
         failure(comparison, [
-          'declaration text changed for a variance-sensitive type',
+          'declaration text changed for a checker-sensitive type',
         ]),
       )
       continue

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -72,21 +72,27 @@ function typeArgumentProbes(count: number, symbol: string): string[] {
     }
   }
 
-  const transferFunction =
-    "{ readonly type: 'function'; readonly name: 'transfer'; readonly stateMutability: 'nonpayable'; readonly inputs: readonly [{ readonly name: 'to'; readonly type: 'address' }, { readonly name: 'amount'; readonly type: 'uint256' }]; readonly outputs: readonly [] }"
+  const erc20Function = (name: string, inputs: string) =>
+    `{ readonly type: 'function'; readonly name: '${name}'; readonly stateMutability: 'nonpayable'; readonly inputs: readonly [${inputs}]; readonly outputs: readonly [] }`
+  const addressInput = "{ readonly name: 'account'; readonly type: 'address' }"
+  const amountInput = "{ readonly name: 'amount'; readonly type: 'uint256' }"
+  const erc20Functions = [
+    erc20Function('approve', `${addressInput}, ${amountInput}`),
+    erc20Function('increaseAllowance', `${addressInput}, ${amountInput}`),
+    erc20Function('transfer', `${addressInput}, ${amountInput}`),
+    erc20Function(
+      'transferFrom',
+      `${addressInput}, ${addressInput}, ${amountInput}`,
+    ),
+  ]
   const payableFunction =
     "{ readonly type: 'function'; readonly name: 'deposit'; readonly stateMutability: 'payable'; readonly inputs: readonly [{ readonly name: 'amount'; readonly type: 'uint256' }]; readonly outputs: readonly [] }"
+  const abiFunctions = [...erc20Functions, payableFunction]
   const concreteProbes: Record<string, string[]> = {
     ParamConstraint: ['string', '{ readonly value: string }'],
-    PermissionFunctionConfig: [transferFunction, payableFunction],
-    Permission: [
-      `readonly [${transferFunction}]`,
-      `readonly [${payableFunction}]`,
-    ],
-    SessionDefinition: [
-      `readonly [readonly [${transferFunction}]]`,
-      `readonly [readonly [${payableFunction}]]`,
-    ],
+    PermissionFunctionConfig: abiFunctions,
+    Permission: abiFunctions.map((fn) => `readonly [${fn}]`),
+    SessionDefinition: abiFunctions.map((fn) => `readonly [readonly [${fn}]]`),
   }
   for (const argument of concreteProbes[symbol] ?? []) {
     probes.add(`<${argument}>`)

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -1,0 +1,385 @@
+import { writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import ts from 'typescript'
+import type { ApiExportReport, ApiReport } from './api-report.ts'
+import { writeJson } from './shared.ts'
+
+export interface ApiCompatibilityFailure {
+  symbol: string
+  reasons: string[]
+  baseDeclarations: string[]
+  currentDeclarations: string[]
+}
+
+export interface ApiCompatibilityReport {
+  formatVersion: 1
+  added: string[]
+  removed: string[]
+  natureChanged: string[]
+  compatible: string[]
+  incompatible: ApiCompatibilityFailure[]
+}
+
+interface Comparison {
+  symbol: string
+  base: ApiExportReport
+  current: ApiExportReport
+}
+
+interface TypeProbe {
+  comparison: Comparison
+  facet: string
+  baseAlias: string
+  currentAlias: string
+}
+
+function changedReportText(
+  report: ApiExportReport,
+  counterpart: ApiExportReport,
+): string[] {
+  if (
+    JSON.stringify(report.declarations) !==
+    JSON.stringify(counterpart.declarations)
+  ) {
+    return report.declarations
+  }
+  const counterpartReferences = new Set(counterpart.referencedDeclarations)
+  const changedReferences = report.referencedDeclarations.filter(
+    (declaration) => !counterpartReferences.has(declaration),
+  )
+  return changedReferences.length > 0 ? changedReferences : report.declarations
+}
+
+function sameReport(base: ApiExportReport, current: ApiExportReport): boolean {
+  return JSON.stringify(base) === JSON.stringify(current)
+}
+
+function sameNominalDeclaration(
+  base: ApiExportReport,
+  current: ApiExportReport,
+): boolean {
+  const { referencedDeclarations: _baseReferences, ...baseDeclaration } = base
+  const { referencedDeclarations: _currentReferences, ...currentDeclaration } =
+    current
+  return JSON.stringify(baseDeclaration) === JSON.stringify(currentDeclaration)
+}
+
+function packageSpecifier(packageName: string, entrypoint: string): string {
+  return entrypoint === '.'
+    ? packageName
+    : `${packageName}/${entrypoint.replace(/^\.\//, '')}`
+}
+
+function typeArguments(count: number, value: 'any' | 'never'): string {
+  return `<${Array.from({ length: count }, () => value).join(', ')}>`
+}
+
+function failure(
+  comparison: Comparison,
+  reasons: string[],
+): ApiCompatibilityFailure {
+  return {
+    symbol: comparison.symbol,
+    reasons,
+    baseDeclarations: changedReportText(comparison.base, comparison.current),
+    currentDeclarations: changedReportText(comparison.current, comparison.base),
+  }
+}
+
+export function generateApiCompatibilityReport(options: {
+  consumerDirectory: string
+  baseReport: ApiReport
+  currentReport: ApiReport
+}): ApiCompatibilityReport {
+  const added: string[] = []
+  const removed: string[] = []
+  const natureChanged: string[] = []
+  const comparisons: Comparison[] = []
+  const entrypoints = new Set([
+    ...Object.keys(options.baseReport.entrypoints),
+    ...Object.keys(options.currentReport.entrypoints),
+  ])
+
+  for (const entrypoint of [...entrypoints].sort()) {
+    const baseSymbols = options.baseReport.entrypoints[entrypoint] ?? {}
+    const currentSymbols = options.currentReport.entrypoints[entrypoint] ?? {}
+    const symbols = new Set([
+      ...Object.keys(baseSymbols),
+      ...Object.keys(currentSymbols),
+    ])
+    for (const symbol of [...symbols].sort()) {
+      const qualified = `${entrypoint}:${symbol}`
+      const base = baseSymbols[symbol]
+      const current = currentSymbols[symbol]
+      if (!base) {
+        added.push(qualified)
+        continue
+      }
+      if (!current) {
+        removed.push(qualified)
+        continue
+      }
+      if (
+        base.hasType !== current.hasType ||
+        base.hasValue !== current.hasValue
+      ) {
+        natureChanged.push(qualified)
+        continue
+      }
+      if (!sameReport(base, current)) {
+        comparisons.push({ symbol: qualified, base, current })
+      }
+    }
+  }
+
+  const incompatible: ApiCompatibilityFailure[] = []
+  const nominalComparisons = new Set<Comparison>()
+  const candidates: Comparison[] = []
+  for (const comparison of comparisons) {
+    if (
+      comparison.base.hasPrivateOrProtectedMembers ||
+      comparison.current.hasPrivateOrProtectedMembers
+    ) {
+      if (sameNominalDeclaration(comparison.base, comparison.current)) {
+        nominalComparisons.add(comparison)
+        candidates.push(comparison)
+      } else {
+        incompatible.push(
+          failure(comparison, ['declaration text changed for a nominal class']),
+        )
+      }
+      continue
+    }
+    if (
+      comparison.base.typeParameters.length !==
+      comparison.current.typeParameters.length
+    ) {
+      incompatible.push(failure(comparison, ['type parameter arity changed']))
+      continue
+    }
+    if (
+      comparison.base.typeParameters.some(
+        (parameter, index) =>
+          parameter.hasDefault !==
+          comparison.current.typeParameters[index]?.hasDefault,
+      )
+    ) {
+      incompatible.push(
+        failure(comparison, ['type parameter defaults changed']),
+      )
+      continue
+    }
+    candidates.push(comparison)
+  }
+
+  const source: string[] =
+    nominalComparisons.size > 0
+      ? [
+          'type PublicInstance<T> = { [K in keyof T]: T[K] }',
+          "type PublicStatic<T> = { [K in Exclude<keyof T, 'prototype'>]: T[K] }",
+        ]
+      : []
+  const probes: TypeProbe[] = []
+  const entrypointAliases = new Map<string, { base: string; current: string }>()
+  for (const comparison of candidates) {
+    const separator = comparison.symbol.indexOf(':')
+    const entrypoint = comparison.symbol.slice(0, separator)
+    const symbol = comparison.symbol.slice(separator + 1)
+    if (!/^[A-Za-z_$][\w$]*$/.test(symbol)) {
+      incompatible.push(
+        failure(comparison, ['export name is not an identifier']),
+      )
+      continue
+    }
+
+    let aliases = entrypointAliases.get(entrypoint)
+    if (!aliases) {
+      const index = entrypointAliases.size
+      aliases = { base: `Base${index}`, current: `Current${index}` }
+      entrypointAliases.set(entrypoint, aliases)
+      source.push(
+        `import * as ${aliases.base} from '${packageSpecifier('@rhinestone/sdk-base', entrypoint)}'`,
+        `import * as ${aliases.current} from '${packageSpecifier('@rhinestone/sdk', entrypoint)}'`,
+      )
+    }
+
+    const addProbe = (facet: string, baseType: string, currentType: string) => {
+      const index = probes.length
+      const baseAlias = `BaseType${index}`
+      const currentAlias = `CurrentType${index}`
+      source.push(
+        `type ${baseAlias} = ${baseType}`,
+        `type ${currentAlias} = ${currentType}`,
+      )
+      probes.push({
+        comparison,
+        facet,
+        baseAlias,
+        currentAlias,
+      })
+    }
+
+    if (nominalComparisons.has(comparison)) {
+      if (comparison.base.hasValue) {
+        addProbe(
+          'static',
+          `PublicStatic<typeof ${aliases.base}.${symbol}>`,
+          `PublicStatic<typeof ${aliases.current}.${symbol}>`,
+        )
+        addProbe(
+          'constructor parameters',
+          `ConstructorParameters<typeof ${aliases.base}.${symbol}>`,
+          `ConstructorParameters<typeof ${aliases.current}.${symbol}>`,
+        )
+      }
+      if (comparison.base.hasType) {
+        addProbe(
+          'public instance',
+          `PublicInstance<${aliases.base}.${symbol}>`,
+          `PublicInstance<${aliases.current}.${symbol}>`,
+        )
+      }
+      continue
+    }
+
+    if (comparison.base.hasValue) {
+      addProbe(
+        'value',
+        `typeof ${aliases.base}.${symbol}`,
+        `typeof ${aliases.current}.${symbol}`,
+      )
+    }
+    if (comparison.base.hasType) {
+      const count = comparison.base.typeParameters.length
+      if (count === 0) {
+        addProbe(
+          'type',
+          `${aliases.base}.${symbol}`,
+          `${aliases.current}.${symbol}`,
+        )
+      } else {
+        for (const value of ['never', 'any'] as const) {
+          const argumentsText = typeArguments(count, value)
+          addProbe(
+            `type<${value}>`,
+            `${aliases.base}.${symbol}${argumentsText}`,
+            `${aliases.current}.${symbol}${argumentsText}`,
+          )
+        }
+        if (
+          comparison.base.typeParameters.every(
+            (parameter) => parameter.hasDefault,
+          )
+        ) {
+          addProbe(
+            'type<defaults>',
+            `${aliases.base}.${symbol}`,
+            `${aliases.current}.${symbol}`,
+          )
+        }
+      }
+    }
+  }
+
+  const fixturePath = join(options.consumerDirectory, 'api-compat.generated.ts')
+  writeFileSync(fixturePath, `${source.join('\n')}\n`)
+  const program = ts.createProgram([fixturePath], {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+  })
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+  if (diagnostics.length > 0) {
+    throw new Error(
+      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCanonicalFileName: (fileName) => fileName,
+        getCurrentDirectory: () => process.cwd(),
+        getNewLine: () => '\n',
+      }),
+    )
+  }
+
+  const fixture = program.getSourceFile(resolve(fixturePath))
+  if (!fixture)
+    throw new Error('Generated API compatibility fixture was not loaded')
+  const checker = program.getTypeChecker()
+  const aliases = new Map<string, ts.TypeAliasDeclaration>()
+  for (const statement of fixture.statements) {
+    if (ts.isTypeAliasDeclaration(statement)) {
+      aliases.set(statement.name.text, statement)
+    }
+  }
+
+  const reasons = new Map<Comparison, string[]>()
+  for (const probe of probes) {
+    const baseAlias = aliases.get(probe.baseAlias)
+    const currentAlias = aliases.get(probe.currentAlias)
+    if (!baseAlias || !currentAlias) {
+      throw new Error(
+        `Generated aliases missing for ${probe.comparison.symbol}`,
+      )
+    }
+    const baseType = checker.getTypeAtLocation(baseAlias.type)
+    const currentType = checker.getTypeAtLocation(currentAlias.type)
+    if (!checker.isTypeAssignableTo(baseType, currentType)) {
+      const entries = reasons.get(probe.comparison) ?? []
+      entries.push(`${probe.facet}: base is not assignable to current`)
+      reasons.set(probe.comparison, entries)
+    }
+    if (!checker.isTypeAssignableTo(currentType, baseType)) {
+      const entries = reasons.get(probe.comparison) ?? []
+      entries.push(`${probe.facet}: current is not assignable to base`)
+      reasons.set(probe.comparison, entries)
+    }
+  }
+
+  const compatible: string[] = []
+  for (const comparison of candidates) {
+    const comparisonReasons = reasons.get(comparison)
+    if (comparisonReasons) {
+      incompatible.push(failure(comparison, comparisonReasons))
+    } else if (probes.some((probe) => probe.comparison === comparison)) {
+      compatible.push(comparison.symbol)
+    }
+  }
+
+  return {
+    formatVersion: 1,
+    added,
+    removed,
+    natureChanged,
+    compatible: compatible.sort(),
+    incompatible: incompatible.sort((left, right) =>
+      left.symbol.localeCompare(right.symbol),
+    ),
+  }
+}
+
+if (import.meta.main) {
+  const consumerDirectory = process.argv[2]
+  const baseReportPath = process.argv[3]
+  const currentReportPath = process.argv[4]
+  const outputPath = process.argv[5]
+  if (
+    !consumerDirectory ||
+    !baseReportPath ||
+    !currentReportPath ||
+    !outputPath
+  ) {
+    throw new Error(
+      'Usage: api-compat.ts <consumer-directory> <base-report> <current-report> <output-path>',
+    )
+  }
+  const { readJson } = await import('./shared.ts')
+  writeJson(
+    outputPath,
+    generateApiCompatibilityReport({
+      consumerDirectory: resolve(consumerDirectory),
+      baseReport: readJson<ApiReport>(baseReportPath),
+      currentReport: readJson<ApiReport>(currentReportPath),
+    }),
+  )
+}

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -100,6 +100,52 @@ function typeArgumentProbes(count: number, symbol: string): string[] {
   return [...probes]
 }
 
+function packageMemberShape(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  packageRoots: readonly string[],
+): string[] {
+  const members = new Set<string>()
+
+  const visit = (candidate: ts.Type, path: string, ancestors: Set<ts.Type>) => {
+    if (ancestors.has(candidate)) return
+    const nextAncestors = new Set(ancestors).add(candidate)
+
+    if (candidate.isUnionOrIntersection()) {
+      for (const constituent of candidate.types) {
+        visit(constituent, path, nextAncestors)
+      }
+    }
+
+    for (const property of checker.getPropertiesOfType(candidate)) {
+      const declarations = property.getDeclarations() ?? []
+      if (
+        declarations.length === 0 ||
+        !declarations.some((declaration) => {
+          const fileName = resolve(declaration.getSourceFile().fileName)
+          return packageRoots.some((root) => fileName.startsWith(`${root}/`))
+        })
+      ) {
+        continue
+      }
+
+      const memberPath = `${path}/${JSON.stringify(property.getName())}`
+      members.add(memberPath)
+      const declaration = property.valueDeclaration ?? declarations[0]
+      if (declaration) {
+        visit(
+          checker.getTypeOfSymbolAtLocation(property, declaration),
+          memberPath,
+          nextAncestors,
+        )
+      }
+    }
+  }
+
+  visit(type, '', new Set())
+  return [...members].sort()
+}
+
 function failure(
   comparison: Comparison,
   reasons: string[],
@@ -332,6 +378,10 @@ export function generateApiCompatibilityReport(options: {
   if (!fixture)
     throw new Error('Generated API compatibility fixture was not loaded')
   const checker = program.getTypeChecker()
+  const packageRoots = [
+    resolve(options.consumerDirectory, 'node_modules/@rhinestone/sdk-base'),
+    resolve(options.consumerDirectory, 'node_modules/@rhinestone/sdk'),
+  ]
   const aliases = new Map<string, ts.TypeAliasDeclaration>()
   for (const statement of fixture.statements) {
     if (ts.isTypeAliasDeclaration(statement)) {
@@ -350,6 +400,14 @@ export function generateApiCompatibilityReport(options: {
     }
     const baseType = checker.getTypeAtLocation(baseAlias.type)
     const currentType = checker.getTypeAtLocation(currentAlias.type)
+    if (
+      JSON.stringify(packageMemberShape(baseType, checker, packageRoots)) !==
+      JSON.stringify(packageMemberShape(currentType, checker, packageRoots))
+    ) {
+      const entries = reasons.get(probe.comparison) ?? []
+      entries.push(`${probe.facet}: public member shape changed`)
+      reasons.set(probe.comparison, entries)
+    }
     if (!checker.isTypeAssignableTo(baseType, currentType)) {
       const entries = reasons.get(probe.comparison) ?? []
       entries.push(`${probe.facet}: base is not assignable to current`)

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -173,14 +173,18 @@ export function generateApiCompatibilityReport(options: {
       continue
     }
     if (
-      comparison.base.typeParameters.some(
-        (parameter, index) =>
-          parameter.hasDefault !==
-          comparison.current.typeParameters[index]?.hasDefault,
-      )
+      comparison.base.typeParameters.some((parameter, index) => {
+        const currentParameter = comparison.current.typeParameters[index]
+        return (
+          parameter.isConst !== currentParameter?.isConst ||
+          parameter.default !== currentParameter?.default ||
+          JSON.stringify(parameter.defaultReferences) !==
+            JSON.stringify(currentParameter?.defaultReferences)
+        )
+      })
     ) {
       incompatible.push(
-        failure(comparison, ['type parameter defaults changed']),
+        failure(comparison, ['type parameter modifiers or defaults changed']),
       )
       continue
     }
@@ -253,7 +257,7 @@ export function generateApiCompatibilityReport(options: {
         }
         if (
           comparison.base.typeParameters.every(
-            (parameter) => parameter.hasDefault,
+            (parameter) => parameter.default !== undefined,
           )
         ) {
           addProbe(

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -100,10 +100,10 @@ function typeArgumentProbes(count: number, symbol: string): string[] {
   return [...probes]
 }
 
-function packageMemberShape(
+function publicMemberShape(
   type: ts.Type,
   checker: ts.TypeChecker,
-  packageRoots: readonly string[],
+  program: ts.Program,
 ): string[] {
   const members = new Set<string>()
 
@@ -118,21 +118,14 @@ function packageMemberShape(
     }
 
     for (const property of checker.getPropertiesOfType(candidate)) {
-      const declarations = property.getDeclarations() ?? []
-      if (
-        declarations.length === 0 ||
-        !declarations.some((declaration) => {
-          const fileName = resolve(declaration.getSourceFile().fileName)
-          return packageRoots.some((root) => fileName.startsWith(`${root}/`))
-        })
-      ) {
-        continue
-      }
-
       const memberPath = `${path}/${JSON.stringify(property.getName())}`
       members.add(memberPath)
+      const declarations = property.getDeclarations() ?? []
       const declaration = property.valueDeclaration ?? declarations[0]
-      if (declaration) {
+      if (
+        declaration &&
+        !program.isSourceFileDefaultLibrary(declaration.getSourceFile())
+      ) {
         visit(
           checker.getTypeOfSymbolAtLocation(property, declaration),
           memberPath,
@@ -378,10 +371,6 @@ export function generateApiCompatibilityReport(options: {
   if (!fixture)
     throw new Error('Generated API compatibility fixture was not loaded')
   const checker = program.getTypeChecker()
-  const packageRoots = [
-    resolve(options.consumerDirectory, 'node_modules/@rhinestone/sdk-base'),
-    resolve(options.consumerDirectory, 'node_modules/@rhinestone/sdk'),
-  ]
   const aliases = new Map<string, ts.TypeAliasDeclaration>()
   for (const statement of fixture.statements) {
     if (ts.isTypeAliasDeclaration(statement)) {
@@ -401,8 +390,8 @@ export function generateApiCompatibilityReport(options: {
     const baseType = checker.getTypeAtLocation(baseAlias.type)
     const currentType = checker.getTypeAtLocation(currentAlias.type)
     if (
-      JSON.stringify(packageMemberShape(baseType, checker, packageRoots)) !==
-      JSON.stringify(packageMemberShape(currentType, checker, packageRoots))
+      JSON.stringify(publicMemberShape(baseType, checker, program)) !==
+      JSON.stringify(publicMemberShape(currentType, checker, program))
     ) {
       const entries = reasons.get(probe.comparison) ?? []
       entries.push(`${probe.facet}: public member shape changed`)

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -160,6 +160,18 @@ export function generateApiCompatibilityReport(options: {
     if (
       comparison.base.typeParameters.some(
         (parameter, index) =>
+          parameter.constraint !==
+          comparison.current.typeParameters[index]?.constraint,
+      )
+    ) {
+      incompatible.push(
+        failure(comparison, ['type parameter constraints changed']),
+      )
+      continue
+    }
+    if (
+      comparison.base.typeParameters.some(
+        (parameter, index) =>
           parameter.hasDefault !==
           comparison.current.typeParameters[index]?.hasDefault,
       )

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -54,16 +54,6 @@ function sameReport(base: ApiExportReport, current: ApiExportReport): boolean {
   return JSON.stringify(base) === JSON.stringify(current)
 }
 
-function sameNominalDeclaration(
-  base: ApiExportReport,
-  current: ApiExportReport,
-): boolean {
-  const { referencedDeclarations: _baseReferences, ...baseDeclaration } = base
-  const { referencedDeclarations: _currentReferences, ...currentDeclaration } =
-    current
-  return JSON.stringify(baseDeclaration) === JSON.stringify(currentDeclaration)
-}
-
 function packageSpecifier(packageName: string, entrypoint: string): string {
   return entrypoint === '.'
     ? packageName
@@ -133,21 +123,21 @@ export function generateApiCompatibilityReport(options: {
   }
 
   const incompatible: ApiCompatibilityFailure[] = []
-  const nominalComparisons = new Set<Comparison>()
   const candidates: Comparison[] = []
   for (const comparison of comparisons) {
+    if (comparison.base.isNamespace || comparison.current.isNamespace) {
+      incompatible.push(
+        failure(comparison, ['declaration text changed for a namespace']),
+      )
+      continue
+    }
     if (
       comparison.base.hasPrivateOrProtectedMembers ||
       comparison.current.hasPrivateOrProtectedMembers
     ) {
-      if (sameNominalDeclaration(comparison.base, comparison.current)) {
-        nominalComparisons.add(comparison)
-        candidates.push(comparison)
-      } else {
-        incompatible.push(
-          failure(comparison, ['declaration text changed for a nominal class']),
-        )
-      }
+      incompatible.push(
+        failure(comparison, ['declaration text changed for a nominal class']),
+      )
       continue
     }
     if (
@@ -172,13 +162,7 @@ export function generateApiCompatibilityReport(options: {
     candidates.push(comparison)
   }
 
-  const source: string[] =
-    nominalComparisons.size > 0
-      ? [
-          'type PublicInstance<T> = { [K in keyof T]: T[K] }',
-          "type PublicStatic<T> = { [K in Exclude<keyof T, 'prototype'>]: T[K] }",
-        ]
-      : []
+  const source: string[] = []
   const probes: TypeProbe[] = []
   const entrypointAliases = new Map<string, { base: string; current: string }>()
   for (const comparison of candidates) {
@@ -217,29 +201,6 @@ export function generateApiCompatibilityReport(options: {
         baseAlias,
         currentAlias,
       })
-    }
-
-    if (nominalComparisons.has(comparison)) {
-      if (comparison.base.hasValue) {
-        addProbe(
-          'static',
-          `PublicStatic<typeof ${aliases.base}.${symbol}>`,
-          `PublicStatic<typeof ${aliases.current}.${symbol}>`,
-        )
-        addProbe(
-          'constructor parameters',
-          `ConstructorParameters<typeof ${aliases.base}.${symbol}>`,
-          `ConstructorParameters<typeof ${aliases.current}.${symbol}>`,
-        )
-      }
-      if (comparison.base.hasType) {
-        addProbe(
-          'public instance',
-          `PublicInstance<${aliases.base}.${symbol}>`,
-          `PublicInstance<${aliases.current}.${symbol}>`,
-        )
-      }
-      continue
     }
 
     if (comparison.base.hasValue) {

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -60,7 +60,7 @@ function packageSpecifier(packageName: string, entrypoint: string): string {
     : `${packageName}/${entrypoint.replace(/^\.\//, '')}`
 }
 
-function typeArgumentProbes(count: number): string[] {
+function typeArgumentProbes(count: number, symbol: string): string[] {
   const probes = new Set<string>()
   for (const primary of ['never', 'any'] as const) {
     const secondary = primary === 'never' ? 'any' : 'never'
@@ -70,6 +70,26 @@ function typeArgumentProbes(count: number): string[] {
       )
       probes.add(`<${values.join(', ')}>`)
     }
+  }
+
+  const transferFunction =
+    "{ readonly type: 'function'; readonly name: 'transfer'; readonly stateMutability: 'nonpayable'; readonly inputs: readonly [{ readonly name: 'to'; readonly type: 'address' }, { readonly name: 'amount'; readonly type: 'uint256' }]; readonly outputs: readonly [] }"
+  const payableFunction =
+    "{ readonly type: 'function'; readonly name: 'deposit'; readonly stateMutability: 'payable'; readonly inputs: readonly [{ readonly name: 'amount'; readonly type: 'uint256' }]; readonly outputs: readonly [] }"
+  const concreteProbes: Record<string, string[]> = {
+    ParamConstraint: ['string', '{ readonly value: string }'],
+    PermissionFunctionConfig: [transferFunction, payableFunction],
+    Permission: [
+      `readonly [${transferFunction}]`,
+      `readonly [${payableFunction}]`,
+    ],
+    SessionDefinition: [
+      `readonly [readonly [${transferFunction}]]`,
+      `readonly [readonly [${payableFunction}]]`,
+    ],
+  }
+  for (const argument of concreteProbes[symbol] ?? []) {
+    probes.add(`<${argument}>`)
   }
   return [...probes]
 }
@@ -259,7 +279,7 @@ export function generateApiCompatibilityReport(options: {
           `${aliases.current}.${symbol}`,
         )
       } else {
-        for (const argumentsText of typeArgumentProbes(count)) {
+        for (const argumentsText of typeArgumentProbes(count, symbol)) {
           addProbe(
             `type${argumentsText}`,
             `${aliases.base}.${symbol}${argumentsText}`,

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -158,11 +158,14 @@ export function generateApiCompatibilityReport(options: {
       continue
     }
     if (
-      comparison.base.typeParameters.some(
-        (parameter, index) =>
-          parameter.constraint !==
-          comparison.current.typeParameters[index]?.constraint,
-      )
+      comparison.base.typeParameters.some((parameter, index) => {
+        const currentParameter = comparison.current.typeParameters[index]
+        return (
+          parameter.constraint !== currentParameter?.constraint ||
+          JSON.stringify(parameter.constraintReferences) !==
+            JSON.stringify(currentParameter?.constraintReferences)
+        )
+      })
     ) {
       incompatible.push(
         failure(comparison, ['type parameter constraints changed']),

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -60,8 +60,18 @@ function packageSpecifier(packageName: string, entrypoint: string): string {
     : `${packageName}/${entrypoint.replace(/^\.\//, '')}`
 }
 
-function typeArguments(count: number, value: 'any' | 'never'): string {
-  return `<${Array.from({ length: count }, () => value).join(', ')}>`
+function typeArgumentProbes(count: number): string[] {
+  const probes = new Set<string>()
+  for (const primary of ['never', 'any'] as const) {
+    const secondary = primary === 'never' ? 'any' : 'never'
+    for (let index = 0; index < count; index++) {
+      const values = Array.from({ length: count }, (_, position) =>
+        position === index ? primary : secondary,
+      )
+      probes.add(`<${values.join(', ')}>`)
+    }
+  }
+  return [...probes]
 }
 
 function failure(
@@ -219,10 +229,9 @@ export function generateApiCompatibilityReport(options: {
           `${aliases.current}.${symbol}`,
         )
       } else {
-        for (const value of ['never', 'any'] as const) {
-          const argumentsText = typeArguments(count, value)
+        for (const argumentsText of typeArgumentProbes(count)) {
           addProbe(
-            `type<${value}>`,
+            `type${argumentsText}`,
             `${aliases.base}.${symbol}${argumentsText}`,
             `${aliases.current}.${symbol}${argumentsText}`,
           )

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -151,6 +151,17 @@ export function generateApiCompatibilityReport(options: {
       continue
     }
     if (
+      comparison.base.hasBivariantMethods ||
+      comparison.current.hasBivariantMethods
+    ) {
+      incompatible.push(
+        failure(comparison, [
+          'declaration text changed for a type containing methods',
+        ]),
+      )
+      continue
+    }
+    if (
       comparison.base.typeParameters.length !==
       comparison.current.typeParameters.length
     ) {

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -117,6 +117,12 @@ function publicMemberShape(
       }
     }
 
+    for (const index of checker.getIndexInfosOfType(candidate)) {
+      const indexPath = `${path}/[${checker.typeToString(index.keyType)}]${index.isReadonly ? ':readonly' : ''}`
+      members.add(indexPath)
+      visit(index.type, indexPath, nextAncestors)
+    }
+
     for (const property of checker.getPropertiesOfType(candidate)) {
       const memberPath = `${path}/${JSON.stringify(property.getName())}`
       members.add(memberPath)

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -157,13 +157,11 @@ function referencedDeclarationsForNode(
 
     for (const declaration of declarations) {
       const declarationTypeParameters = typeParametersInScope(declaration)
-      const text = normalizeTypeParameterText(
-        printer.printNode(
-          ts.EmitHint.Unspecified,
-          declaration,
-          declaration.getSourceFile(),
-        ),
+      const text = printWithNormalizedTypeParameters(
+        declaration,
         declarationTypeParameters,
+        checker,
+        printer,
         packageDirectory,
       )
       referenced.set(`${target.getName()}:${text}`, text)
@@ -200,34 +198,54 @@ function typeParametersInScope(
   return []
 }
 
-function normalizeTypeParameterText(
-  value: string,
+function printWithNormalizedTypeParameters(
+  node: ts.Node,
   typeParameters: readonly ts.TypeParameterDeclaration[],
+  checker: ts.TypeChecker,
+  printer: ts.Printer,
   packageDirectory: string,
 ): string {
-  let text = value
+  const namesBySymbol = new Map<ts.Symbol, string>()
   for (const [index, parameter] of typeParameters.entries()) {
-    const escapedName = parameter.name.text.replace(
-      /[.*+?^${}()|[\]\\]/g,
-      '\\$&',
-    )
-    text = text.replace(
-      new RegExp(`(?<![\\w$])${escapedName}(?![\\w$])`, 'g'),
-      `T${index}`,
-    )
+    const symbol = checker.getSymbolAtLocation(parameter.name)
+    if (symbol) namesBySymbol.set(symbol, `T${index}`)
   }
+  const result = ts.transform(node, [
+    (context) => (root) => {
+      const visit = (candidate: ts.Node): ts.VisitResult<ts.Node> => {
+        if (ts.isIdentifier(candidate)) {
+          const symbol = checker.getSymbolAtLocation(candidate)
+          const name = symbol ? namesBySymbol.get(symbol) : undefined
+          if (name) return ts.factory.createIdentifier(name)
+        }
+        return ts.visitEachChild(candidate, visit, context)
+      }
+      return ts.visitNode(root, visit)
+    },
+  ])
+  const transformed = result.transformed[0]
+  if (!transformed) throw new Error('Type parameter normalization failed')
+  const text = printer.printNode(
+    ts.EmitHint.Unspecified,
+    transformed,
+    node.getSourceFile(),
+  )
+  result.dispose()
   return normalizeText(text, packageDirectory)
 }
 
 function normalizeTypeParameterExpression(
   node: ts.TypeNode,
   typeParameters: readonly ts.TypeParameterDeclaration[],
+  checker: ts.TypeChecker,
   printer: ts.Printer,
   packageDirectory: string,
 ): string {
-  return normalizeTypeParameterText(
-    printer.printNode(ts.EmitHint.Unspecified, node, node.getSourceFile()),
+  return printWithNormalizedTypeParameters(
+    node,
     typeParameters,
+    checker,
+    printer,
     packageDirectory,
   )
 }
@@ -421,6 +439,7 @@ function reportExport(
             constraint: normalizeTypeParameterExpression(
               parameter.constraint,
               genericTypeParameters,
+              checker,
               printer,
               packageDirectory,
             ),
@@ -431,6 +450,7 @@ function reportExport(
             default: normalizeTypeParameterExpression(
               parameter.default,
               genericTypeParameters,
+              checker,
               printer,
               packageDirectory,
             ),

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -186,16 +186,17 @@ function referencedDeclarationsForNode(
 function typeParametersInScope(
   node: ts.Node,
 ): readonly ts.TypeParameterDeclaration[] {
+  const parameters: ts.TypeParameterDeclaration[] = []
   let current: ts.Node | undefined = node
   while (current) {
     if ('typeParameters' in current && current.typeParameters) {
-      return [
+      parameters.push(
         ...(current.typeParameters as ts.NodeArray<ts.TypeParameterDeclaration>),
-      ]
+      )
     }
     current = current.parent
   }
-  return []
+  return parameters
 }
 
 function printWithNormalizedTypeParameters(

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -18,12 +18,12 @@ export interface ApiExportReport {
     defaultReferences: string[]
   }[]
   hasPrivateOrProtectedMembers: boolean
-  hasCheckerSensitiveDeclarations: boolean
+  checkerSensitiveDeclarations: string[]
   isNamespace: boolean
 }
 
 export interface ApiReport {
-  formatVersion: 5
+  formatVersion: 6
   entrypoints: Record<string, Record<string, ApiExportReport>>
 }
 
@@ -279,33 +279,35 @@ function classHasPrivateOrProtectedMembers(
   })
 }
 
-function symbolHasCheckerSensitiveDeclarations(
+function checkerSensitiveDeclarationsForSymbol(
   candidate: ts.Symbol,
   checker: ts.TypeChecker,
+  printer: ts.Printer,
   packageDirectory: string,
   seen = new Set<ts.Symbol>(),
-): boolean {
+  declarations = new Set<string>(),
+): string[] {
   const symbol =
     candidate.flags & ts.SymbolFlags.Alias
       ? checker.getAliasedSymbol(candidate)
       : candidate
-  if (seen.has(symbol)) return false
+  if (seen.has(symbol)) return [...declarations].sort()
   seen.add(symbol)
 
-  const declarations = symbol.getDeclarations() ?? []
+  const symbolDeclarations = symbol.getDeclarations() ?? []
   if (
-    declarations.length === 0 ||
-    declarations.some(
+    symbolDeclarations.length === 0 ||
+    symbolDeclarations.some(
       (declaration) =>
         !resolve(declaration.getSourceFile().fileName).startsWith(
           `${resolve(packageDirectory)}/`,
         ),
     )
   ) {
-    return false
+    return [...declarations].sort()
   }
 
-  const visitNode = (node: ts.Node): boolean => {
+  const visitNode = (node: ts.Node): void => {
     if (
       node.kind === ts.SyntaxKind.AnyKeyword ||
       ts.isMethodSignature(node) ||
@@ -319,26 +321,35 @@ function symbolHasCheckerSensitiveDeclarations(
         ts.isIndexSignatureDeclaration(node)) &&
         ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Readonly)
     ) {
-      return true
+      declarations.add(
+        printWithNormalizedTypeParameters(
+          node,
+          typeParametersInScope(node),
+          checker,
+          printer,
+          packageDirectory,
+        ),
+      )
+      return
     }
     if (ts.isIdentifier(node)) {
       const referencedSymbol = checker.getSymbolAtLocation(node)
-      if (
-        referencedSymbol &&
-        symbolHasCheckerSensitiveDeclarations(
+      if (referencedSymbol) {
+        checkerSensitiveDeclarationsForSymbol(
           referencedSymbol,
           checker,
+          printer,
           packageDirectory,
           seen,
+          declarations,
         )
-      ) {
-        return true
       }
     }
-    return node.getChildren().some(visitNode)
+    ts.forEachChild(node, visitNode)
   }
 
-  return declarations.some(visitNode)
+  for (const declaration of symbolDeclarations) visitNode(declaration)
+  return [...declarations].sort()
 }
 
 function reportExport(
@@ -459,9 +470,10 @@ function reportExport(
         : {}),
     })),
     hasPrivateOrProtectedMembers,
-    hasCheckerSensitiveDeclarations: symbolHasCheckerSensitiveDeclarations(
+    checkerSensitiveDeclarations: checkerSensitiveDeclarationsForSymbol(
       symbol,
       checker,
+      printer,
       packageDirectory,
     ),
     isNamespace,
@@ -523,7 +535,7 @@ export function generateApiReport(packageDirectory: string): ApiReport {
     )
   }
 
-  return { formatVersion: 5, entrypoints }
+  return { formatVersion: 6, entrypoints }
 }
 
 if (import.meta.main) {

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -321,16 +321,30 @@ function checkerSensitiveDeclarationsForSymbol(
         ts.isIndexSignatureDeclaration(node)) &&
         ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Readonly)
     ) {
+      const typeParameters = typeParametersInScope(node)
       declarations.add(
         printWithNormalizedTypeParameters(
           node,
-          typeParametersInScope(node),
+          typeParameters,
           checker,
           printer,
           packageDirectory,
         ),
       )
-      return
+      const ignoredSymbols = new Set<ts.Symbol>([symbol])
+      for (const parameter of typeParameters) {
+        const parameterSymbol = checker.getSymbolAtLocation(parameter.name)
+        if (parameterSymbol) ignoredSymbols.add(parameterSymbol)
+      }
+      for (const referenced of referencedDeclarationsForNode(
+        node,
+        checker,
+        printer,
+        packageDirectory,
+        ignoredSymbols,
+      )) {
+        declarations.add(referenced)
+      }
     }
     if (ts.isIdentifier(node)) {
       const referencedSymbol = checker.getSymbolAtLocation(node)

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -11,9 +11,11 @@ export interface ApiExportReport {
   callSignatures: string[]
   constructSignatures: string[]
   typeParameters: {
-    hasDefault: boolean
+    isConst: boolean
     constraint?: string
     constraintReferences: string[]
+    default?: string
+    defaultReferences: string[]
   }[]
   hasPrivateOrProtectedMembers: boolean
   isNamespace: boolean
@@ -153,12 +155,14 @@ function referencedDeclarationsForNode(
     }
 
     for (const declaration of declarations) {
-      const text = normalizeText(
+      const declarationTypeParameters = typeParametersInScope(declaration)
+      const text = normalizeTypeParameterText(
         printer.printNode(
           ts.EmitHint.Unspecified,
           declaration,
           declaration.getSourceFile(),
         ),
+        declarationTypeParameters,
         packageDirectory,
       )
       referenced.set(`${target.getName()}:${text}`, text)
@@ -180,17 +184,27 @@ function referencedDeclarationsForNode(
     .map(([, text]) => text)
 }
 
-function normalizeTypeParameterExpression(
-  node: ts.TypeNode,
+function typeParametersInScope(
+  node: ts.Node,
+): readonly ts.TypeParameterDeclaration[] {
+  let current: ts.Node | undefined = node
+  while (current) {
+    if ('typeParameters' in current && current.typeParameters) {
+      return [
+        ...(current.typeParameters as ts.NodeArray<ts.TypeParameterDeclaration>),
+      ]
+    }
+    current = current.parent
+  }
+  return []
+}
+
+function normalizeTypeParameterText(
+  value: string,
   typeParameters: readonly ts.TypeParameterDeclaration[],
-  printer: ts.Printer,
   packageDirectory: string,
 ): string {
-  let text = printer.printNode(
-    ts.EmitHint.Unspecified,
-    node,
-    node.getSourceFile(),
-  )
+  let text = value
   for (const [index, parameter] of typeParameters.entries()) {
     const escapedName = parameter.name.text.replace(
       /[.*+?^${}()|[\]\\]/g,
@@ -202,6 +216,19 @@ function normalizeTypeParameterExpression(
     )
   }
   return normalizeText(text, packageDirectory)
+}
+
+function normalizeTypeParameterExpression(
+  node: ts.TypeNode,
+  typeParameters: readonly ts.TypeParameterDeclaration[],
+  printer: ts.Printer,
+  packageDirectory: string,
+): string {
+  return normalizeTypeParameterText(
+    printer.printNode(ts.EmitHint.Unspecified, node, node.getSourceFile()),
+    typeParameters,
+    packageDirectory,
+  )
 }
 
 function classHasPrivateOrProtectedMembers(
@@ -304,10 +331,23 @@ function reportExport(
         ),
     ),
     typeParameters: genericTypeParameters.map((parameter) => ({
-      hasDefault: Boolean(parameter.default),
+      isConst: Boolean(
+        parameter.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ConstKeyword,
+        ),
+      ),
       constraintReferences: parameter.constraint
         ? referencedDeclarationsForNode(
             parameter.constraint,
+            checker,
+            printer,
+            packageDirectory,
+            genericTypeParameterSymbols,
+          )
+        : [],
+      defaultReferences: parameter.default
+        ? referencedDeclarationsForNode(
+            parameter.default,
             checker,
             printer,
             packageDirectory,
@@ -318,6 +358,16 @@ function reportExport(
         ? {
             constraint: normalizeTypeParameterExpression(
               parameter.constraint,
+              genericTypeParameters,
+              printer,
+              packageDirectory,
+            ),
+          }
+        : {}),
+      ...(parameter.default
+        ? {
+            default: normalizeTypeParameterExpression(
+              parameter.default,
               genericTypeParameters,
               printer,
               packageDirectory,

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -313,6 +313,8 @@ function checkerSensitiveDeclarationsForSymbol(
       node.kind === ts.SyntaxKind.AnyKeyword ||
       ts.isMethodSignature(node) ||
       ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node) ||
       ts.isConstructorDeclaration(node) ||
       ts.isConstructSignatureDeclaration(node) ||
       ts.isConstructorTypeNode(node) ||

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -18,7 +18,7 @@ export interface ApiExportReport {
     defaultReferences: string[]
   }[]
   hasPrivateOrProtectedMembers: boolean
-  hasVarianceSensitiveDeclarations: boolean
+  hasCheckerSensitiveDeclarations: boolean
   isNamespace: boolean
 }
 
@@ -279,7 +279,7 @@ function classHasPrivateOrProtectedMembers(
   })
 }
 
-function symbolHasVarianceSensitiveDeclarations(
+function symbolHasCheckerSensitiveDeclarations(
   candidate: ts.Symbol,
   checker: ts.TypeChecker,
   packageDirectory: string,
@@ -307,6 +307,7 @@ function symbolHasVarianceSensitiveDeclarations(
 
   const visitNode = (node: ts.Node): boolean => {
     if (
+      node.kind === ts.SyntaxKind.AnyKeyword ||
       ts.isMethodSignature(node) ||
       ts.isMethodDeclaration(node) ||
       ts.isConstructorDeclaration(node) ||
@@ -324,7 +325,7 @@ function symbolHasVarianceSensitiveDeclarations(
       const referencedSymbol = checker.getSymbolAtLocation(node)
       if (
         referencedSymbol &&
-        symbolHasVarianceSensitiveDeclarations(
+        symbolHasCheckerSensitiveDeclarations(
           referencedSymbol,
           checker,
           packageDirectory,
@@ -458,7 +459,7 @@ function reportExport(
         : {}),
     })),
     hasPrivateOrProtectedMembers,
-    hasVarianceSensitiveDeclarations: symbolHasVarianceSensitiveDeclarations(
+    hasCheckerSensitiveDeclarations: symbolHasCheckerSensitiveDeclarations(
       symbol,
       checker,
       packageDirectory,

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -315,6 +315,9 @@ function checkerSensitiveDeclarationsForSymbol(
       ts.isConstructorDeclaration(node) ||
       ts.isConstructSignatureDeclaration(node) ||
       ts.isConstructorTypeNode(node) ||
+      (ts.isTypeReferenceNode(node) &&
+        ts.isIdentifier(node.typeName) &&
+        node.typeName.text === 'Readonly') ||
       (ts.isMappedTypeNode(node) && node.readonlyToken !== undefined) ||
       ((ts.isPropertySignature(node) ||
         ts.isPropertyDeclaration(node) ||

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 import ts from 'typescript'
 import { type PackageManifest, readJson, writeJson } from './shared.ts'
 
-interface ApiExportReport {
+export interface ApiExportReport {
   hasType: boolean
   hasValue: boolean
   declarations: string[]
@@ -10,10 +10,12 @@ interface ApiExportReport {
   valueType?: string
   callSignatures: string[]
   constructSignatures: string[]
+  typeParameters: { hasDefault: boolean }[]
+  hasPrivateOrProtectedMembers: boolean
 }
 
 export interface ApiReport {
-  formatVersion: 1
+  formatVersion: 2
   entrypoints: Record<string, Record<string, ApiExportReport>>
 }
 
@@ -133,6 +135,23 @@ function reportExport(
   const declaration = symbol.valueDeclaration ?? symbol.getDeclarations()?.[0]
   const hasValue = Boolean(symbol.flags & ts.SymbolFlags.Value)
   const hasType = Boolean(symbol.flags & ts.SymbolFlags.Type)
+  const symbolDeclarations = symbol.getDeclarations() ?? []
+  const genericDeclaration = symbolDeclarations.find(
+    (
+      candidate,
+    ): candidate is ts.Declaration & {
+      typeParameters: ts.NodeArray<ts.TypeParameterDeclaration>
+    } => 'typeParameters' in candidate && Boolean(candidate.typeParameters),
+  )
+  const classDeclaration = symbolDeclarations.find(ts.isClassDeclaration)
+  const hasPrivateOrProtectedMembers = Boolean(
+    classDeclaration?.members.some(
+      (member) =>
+        (member.name && ts.isPrivateIdentifier(member.name)) ||
+        ts.getCombinedModifierFlags(member) &
+          (ts.ModifierFlags.Private | ts.ModifierFlags.Protected),
+    ),
+  )
   const valueType =
     hasValue && declaration
       ? checker.getTypeOfSymbolAtLocation(symbol, declaration)
@@ -163,6 +182,10 @@ function reportExport(
           packageDirectory,
         ),
     ),
+    typeParameters: [...(genericDeclaration?.typeParameters ?? [])].map(
+      (parameter) => ({ hasDefault: Boolean(parameter.default) }),
+    ),
+    hasPrivateOrProtectedMembers,
   }
 }
 
@@ -221,7 +244,7 @@ export function generateApiReport(packageDirectory: string): ApiReport {
     )
   }
 
-  return { formatVersion: 1, entrypoints }
+  return { formatVersion: 2, entrypoints }
 }
 
 if (import.meta.main) {

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -12,6 +12,7 @@ export interface ApiExportReport {
   constructSignatures: string[]
   typeParameters: { hasDefault: boolean }[]
   hasPrivateOrProtectedMembers: boolean
+  isNamespace: boolean
 }
 
 export interface ApiReport {
@@ -116,6 +117,35 @@ function declarationsForSymbol(
   }
 }
 
+function classHasPrivateOrProtectedMembers(
+  declaration: ts.ClassDeclaration,
+  checker: ts.TypeChecker,
+  seen = new Set<ts.Symbol>(),
+): boolean {
+  if (
+    declaration.members.some(
+      (member) =>
+        (member.name && ts.isPrivateIdentifier(member.name)) ||
+        ts.getCombinedModifierFlags(member) &
+          (ts.ModifierFlags.Private | ts.ModifierFlags.Protected),
+    )
+  ) {
+    return true
+  }
+
+  const classType = checker.getTypeAtLocation(declaration) as ts.InterfaceType
+  return (checker.getBaseTypes(classType) ?? []).some((baseType) => {
+    const baseSymbol = baseType.getSymbol()
+    if (!baseSymbol || seen.has(baseSymbol)) return false
+    seen.add(baseSymbol)
+    return (baseSymbol.getDeclarations() ?? [])
+      .filter(ts.isClassDeclaration)
+      .some((baseDeclaration) =>
+        classHasPrivateOrProtectedMembers(baseDeclaration, checker, seen),
+      )
+  })
+}
+
 function reportExport(
   exportedSymbol: ts.Symbol,
   checker: ts.TypeChecker,
@@ -145,13 +175,10 @@ function reportExport(
   )
   const classDeclaration = symbolDeclarations.find(ts.isClassDeclaration)
   const hasPrivateOrProtectedMembers = Boolean(
-    classDeclaration?.members.some(
-      (member) =>
-        (member.name && ts.isPrivateIdentifier(member.name)) ||
-        ts.getCombinedModifierFlags(member) &
-          (ts.ModifierFlags.Private | ts.ModifierFlags.Protected),
-    ),
+    classDeclaration &&
+      classHasPrivateOrProtectedMembers(classDeclaration, checker),
   )
+  const isNamespace = Boolean(symbol.flags & ts.SymbolFlags.Namespace)
   const valueType =
     hasValue && declaration
       ? checker.getTypeOfSymbolAtLocation(symbol, declaration)
@@ -186,6 +213,7 @@ function reportExport(
       (parameter) => ({ hasDefault: Boolean(parameter.default) }),
     ),
     hasPrivateOrProtectedMembers,
+    isNamespace,
   }
 }
 

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -10,13 +10,13 @@ export interface ApiExportReport {
   valueType?: string
   callSignatures: string[]
   constructSignatures: string[]
-  typeParameters: { hasDefault: boolean }[]
+  typeParameters: { hasDefault: boolean; constraint?: string }[]
   hasPrivateOrProtectedMembers: boolean
   isNamespace: boolean
 }
 
 export interface ApiReport {
-  formatVersion: 2
+  formatVersion: 3
   entrypoints: Record<string, Record<string, ApiExportReport>>
 }
 
@@ -117,6 +117,30 @@ function declarationsForSymbol(
   }
 }
 
+function normalizeTypeParameterExpression(
+  node: ts.TypeNode,
+  typeParameters: readonly ts.TypeParameterDeclaration[],
+  printer: ts.Printer,
+  packageDirectory: string,
+): string {
+  let text = printer.printNode(
+    ts.EmitHint.Unspecified,
+    node,
+    node.getSourceFile(),
+  )
+  for (const [index, parameter] of typeParameters.entries()) {
+    const escapedName = parameter.name.text.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&',
+    )
+    text = text.replace(
+      new RegExp(`(?<![\\w$])${escapedName}(?![\\w$])`, 'g'),
+      `T${index}`,
+    )
+  }
+  return normalizeText(text, packageDirectory)
+}
+
 function classHasPrivateOrProtectedMembers(
   declaration: ts.ClassDeclaration,
   checker: ts.TypeChecker,
@@ -210,7 +234,19 @@ function reportExport(
         ),
     ),
     typeParameters: [...(genericDeclaration?.typeParameters ?? [])].map(
-      (parameter) => ({ hasDefault: Boolean(parameter.default) }),
+      (parameter) => ({
+        hasDefault: Boolean(parameter.default),
+        ...(parameter.constraint
+          ? {
+              constraint: normalizeTypeParameterExpression(
+                parameter.constraint,
+                genericDeclaration?.typeParameters ?? [],
+                printer,
+                packageDirectory,
+              ),
+            }
+          : {}),
+      }),
     ),
     hasPrivateOrProtectedMembers,
     isNamespace,
@@ -272,7 +308,7 @@ export function generateApiReport(packageDirectory: string): ApiReport {
     )
   }
 
-  return { formatVersion: 2, entrypoints }
+  return { formatVersion: 3, entrypoints }
 }
 
 if (import.meta.main) {

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -18,11 +18,12 @@ export interface ApiExportReport {
     defaultReferences: string[]
   }[]
   hasPrivateOrProtectedMembers: boolean
+  hasBivariantMethods: boolean
   isNamespace: boolean
 }
 
 export interface ApiReport {
-  formatVersion: 4
+  formatVersion: 5
   entrypoints: Record<string, Record<string, ApiExportReport>>
 }
 
@@ -260,6 +261,54 @@ function classHasPrivateOrProtectedMembers(
   })
 }
 
+function symbolHasBivariantMethods(
+  candidate: ts.Symbol,
+  checker: ts.TypeChecker,
+  packageDirectory: string,
+  seen = new Set<ts.Symbol>(),
+): boolean {
+  const symbol =
+    candidate.flags & ts.SymbolFlags.Alias
+      ? checker.getAliasedSymbol(candidate)
+      : candidate
+  if (seen.has(symbol)) return false
+  seen.add(symbol)
+
+  const declarations = symbol.getDeclarations() ?? []
+  if (
+    declarations.length === 0 ||
+    declarations.some(
+      (declaration) =>
+        !resolve(declaration.getSourceFile().fileName).startsWith(
+          `${resolve(packageDirectory)}/`,
+        ),
+    )
+  ) {
+    return false
+  }
+
+  const visitNode = (node: ts.Node): boolean => {
+    if (ts.isMethodSignature(node) || ts.isMethodDeclaration(node)) return true
+    if (ts.isIdentifier(node)) {
+      const referencedSymbol = checker.getSymbolAtLocation(node)
+      if (
+        referencedSymbol &&
+        symbolHasBivariantMethods(
+          referencedSymbol,
+          checker,
+          packageDirectory,
+          seen,
+        )
+      ) {
+        return true
+      }
+    }
+    return node.getChildren().some(visitNode)
+  }
+
+  return declarations.some(visitNode)
+}
+
 function reportExport(
   exportedSymbol: ts.Symbol,
   checker: ts.TypeChecker,
@@ -376,6 +425,11 @@ function reportExport(
         : {}),
     })),
     hasPrivateOrProtectedMembers,
+    hasBivariantMethods: symbolHasBivariantMethods(
+      symbol,
+      checker,
+      packageDirectory,
+    ),
     isNamespace,
   }
 }
@@ -435,7 +489,7 @@ export function generateApiReport(packageDirectory: string): ApiReport {
     )
   }
 
-  return { formatVersion: 4, entrypoints }
+  return { formatVersion: 5, entrypoints }
 }
 
 if (import.meta.main) {

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -18,7 +18,7 @@ export interface ApiExportReport {
     defaultReferences: string[]
   }[]
   hasPrivateOrProtectedMembers: boolean
-  hasBivariantMethods: boolean
+  hasVarianceSensitiveDeclarations: boolean
   isNamespace: boolean
 }
 
@@ -261,7 +261,7 @@ function classHasPrivateOrProtectedMembers(
   })
 }
 
-function symbolHasBivariantMethods(
+function symbolHasVarianceSensitiveDeclarations(
   candidate: ts.Symbol,
   checker: ts.TypeChecker,
   packageDirectory: string,
@@ -288,12 +288,25 @@ function symbolHasBivariantMethods(
   }
 
   const visitNode = (node: ts.Node): boolean => {
-    if (ts.isMethodSignature(node) || ts.isMethodDeclaration(node)) return true
+    if (
+      ts.isMethodSignature(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isConstructorDeclaration(node) ||
+      ts.isConstructSignatureDeclaration(node) ||
+      ts.isConstructorTypeNode(node) ||
+      (ts.isMappedTypeNode(node) && node.readonlyToken !== undefined) ||
+      ((ts.isPropertySignature(node) ||
+        ts.isPropertyDeclaration(node) ||
+        ts.isIndexSignatureDeclaration(node)) &&
+        ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Readonly)
+    ) {
+      return true
+    }
     if (ts.isIdentifier(node)) {
       const referencedSymbol = checker.getSymbolAtLocation(node)
       if (
         referencedSymbol &&
-        symbolHasBivariantMethods(
+        symbolHasVarianceSensitiveDeclarations(
           referencedSymbol,
           checker,
           packageDirectory,
@@ -425,7 +438,7 @@ function reportExport(
         : {}),
     })),
     hasPrivateOrProtectedMembers,
-    hasBivariantMethods: symbolHasBivariantMethods(
+    hasVarianceSensitiveDeclarations: symbolHasVarianceSensitiveDeclarations(
       symbol,
       checker,
       packageDirectory,

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -10,13 +10,17 @@ export interface ApiExportReport {
   valueType?: string
   callSignatures: string[]
   constructSignatures: string[]
-  typeParameters: { hasDefault: boolean; constraint?: string }[]
+  typeParameters: {
+    hasDefault: boolean
+    constraint?: string
+    constraintReferences: string[]
+  }[]
   hasPrivateOrProtectedMembers: boolean
   isNamespace: boolean
 }
 
 export interface ApiReport {
-  formatVersion: 3
+  formatVersion: 4
   entrypoints: Record<string, Record<string, ApiExportReport>>
 }
 
@@ -117,6 +121,65 @@ function declarationsForSymbol(
   }
 }
 
+function referencedDeclarationsForNode(
+  node: ts.Node,
+  checker: ts.TypeChecker,
+  printer: ts.Printer,
+  packageDirectory: string,
+  ignoredSymbols: ReadonlySet<ts.Symbol>,
+): string[] {
+  const seen = new Set(ignoredSymbols)
+  const referenced = new Map<string, string>()
+
+  const visitSymbol = (candidate: ts.Symbol): void => {
+    const target =
+      candidate.flags & ts.SymbolFlags.Alias
+        ? checker.getAliasedSymbol(candidate)
+        : candidate
+    if (seen.has(target)) return
+    seen.add(target)
+
+    const declarations = target.getDeclarations() ?? []
+    if (
+      declarations.length === 0 ||
+      declarations.some(
+        (declaration) =>
+          !resolve(declaration.getSourceFile().fileName).startsWith(
+            `${resolve(packageDirectory)}/`,
+          ),
+      )
+    ) {
+      return
+    }
+
+    for (const declaration of declarations) {
+      const text = normalizeText(
+        printer.printNode(
+          ts.EmitHint.Unspecified,
+          declaration,
+          declaration.getSourceFile(),
+        ),
+        packageDirectory,
+      )
+      referenced.set(`${target.getName()}:${text}`, text)
+      ts.forEachChild(declaration, visitNode)
+    }
+  }
+
+  const visitNode = (candidate: ts.Node): void => {
+    if (ts.isIdentifier(candidate)) {
+      const symbol = checker.getSymbolAtLocation(candidate)
+      if (symbol) visitSymbol(symbol)
+    }
+    ts.forEachChild(candidate, visitNode)
+  }
+
+  visitNode(node)
+  return [...referenced.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, text]) => text)
+}
+
 function normalizeTypeParameterExpression(
   node: ts.TypeNode,
   typeParameters: readonly ts.TypeParameterDeclaration[],
@@ -197,6 +260,13 @@ function reportExport(
       typeParameters: ts.NodeArray<ts.TypeParameterDeclaration>
     } => 'typeParameters' in candidate && Boolean(candidate.typeParameters),
   )
+  const genericTypeParameters = [...(genericDeclaration?.typeParameters ?? [])]
+  const genericTypeParameterSymbols = new Set(
+    genericTypeParameters.flatMap((parameter) => {
+      const parameterSymbol = checker.getSymbolAtLocation(parameter.name)
+      return parameterSymbol ? [parameterSymbol] : []
+    }),
+  )
   const classDeclaration = symbolDeclarations.find(ts.isClassDeclaration)
   const hasPrivateOrProtectedMembers = Boolean(
     classDeclaration &&
@@ -233,21 +303,28 @@ function reportExport(
           packageDirectory,
         ),
     ),
-    typeParameters: [...(genericDeclaration?.typeParameters ?? [])].map(
-      (parameter) => ({
-        hasDefault: Boolean(parameter.default),
-        ...(parameter.constraint
-          ? {
-              constraint: normalizeTypeParameterExpression(
-                parameter.constraint,
-                genericDeclaration?.typeParameters ?? [],
-                printer,
-                packageDirectory,
-              ),
-            }
-          : {}),
-      }),
-    ),
+    typeParameters: genericTypeParameters.map((parameter) => ({
+      hasDefault: Boolean(parameter.default),
+      constraintReferences: parameter.constraint
+        ? referencedDeclarationsForNode(
+            parameter.constraint,
+            checker,
+            printer,
+            packageDirectory,
+            genericTypeParameterSymbols,
+          )
+        : [],
+      ...(parameter.constraint
+        ? {
+            constraint: normalizeTypeParameterExpression(
+              parameter.constraint,
+              genericTypeParameters,
+              printer,
+              packageDirectory,
+            ),
+          }
+        : {}),
+    })),
     hasPrivateOrProtectedMembers,
     isNamespace,
   }
@@ -308,7 +385,7 @@ export function generateApiReport(packageDirectory: string): ApiReport {
     )
   }
 
-  return { formatVersion: 3, entrypoints }
+  return { formatVersion: 4, entrypoints }
 }
 
 if (import.meta.main) {

--- a/scripts/contract/run.ts
+++ b/scripts/contract/run.ts
@@ -295,10 +295,13 @@ async function main(): Promise<void> {
       { recursive: true },
     )
 
-    // The hand-written fixture remains a supplementary patch check. Intentional
-    // minor and major changes may break it, while the generated comparator below
-    // still records a verdict for the contract assertions.
-    if (declaresSurfaceChange(baseSha, repositoryRoot)) {
+    // The hand-written fixture and generated semantic comparison are patch
+    // checks. Minor and major changes retain their existing report assertions.
+    const hasDeclaredSurfaceChange = declaresSurfaceChange(
+      baseSha,
+      repositoryRoot,
+    )
+    if (hasDeclaredSurfaceChange) {
       process.stdout.write(
         'Skipping bidirectional assignability check: PR declares an intentional public-surface change\n',
       )
@@ -325,11 +328,20 @@ async function main(): Promise<void> {
     )
     writeJson(
       apiCompatibilityReportPath,
-      generateApiCompatibilityReport({
-        consumerDirectory: compatibilityConsumer,
-        baseReport: baseApiReport,
-        currentReport: currentApiReport,
-      }),
+      hasDeclaredSurfaceChange
+        ? {
+            formatVersion: 1,
+            added: [],
+            removed: [],
+            natureChanged: [],
+            compatible: [],
+            incompatible: [],
+          }
+        : generateApiCompatibilityReport({
+            consumerDirectory: compatibilityConsumer,
+            baseReport: baseApiReport,
+            currentReport: currentApiReport,
+          }),
     )
 
     runCommand(

--- a/scripts/contract/run.ts
+++ b/scripts/contract/run.ts
@@ -1,6 +1,7 @@
 import { cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
+import { generateApiCompatibilityReport } from './api-compat.ts'
 import { generateApiReport } from './api-report.ts'
 import {
   createConsumerLayout,
@@ -277,32 +278,32 @@ async function main(): Promise<void> {
     compileConsumer(baseConsumers.full)
     compileConsumer(currentConsumers.full)
 
-    // The bidirectional assignability fixture asserts the public types stay
-    // compatible with the base release. A PR that declares an intentional
-    // surface change (minor/major changeset) is allowed to break that, so skip
-    // it there — matching the changeset-aware relaxation in the Vitest suite.
+    const compatibilityConsumer = join(
+      temporaryDirectory,
+      'compatibility-consumer',
+    )
+    createConsumerLayout({
+      packageDirectory: current.packageDirectory,
+      consumerDirectory: compatibilityConsumer,
+      dependencyRoot: current.dependencyRoot,
+      runtimeProbePath,
+      includeOptionalPeers: true,
+    })
+    cpSync(
+      baseBuild.subject.packageDirectory,
+      join(compatibilityConsumer, 'node_modules/@rhinestone/sdk-base'),
+      { recursive: true },
+    )
+
+    // The hand-written fixture remains a supplementary patch check. Intentional
+    // minor and major changes may break it, while the generated comparator below
+    // still records a verdict for the contract assertions.
     if (declaresSurfaceChange(baseSha, repositoryRoot)) {
       process.stdout.write(
         'Skipping bidirectional assignability check: PR declares an intentional public-surface change\n',
       )
     } else {
-      const assignabilityConsumer = join(
-        temporaryDirectory,
-        'assignability-consumer',
-      )
-      createConsumerLayout({
-        packageDirectory: current.packageDirectory,
-        consumerDirectory: assignabilityConsumer,
-        dependencyRoot: current.dependencyRoot,
-        runtimeProbePath,
-        includeOptionalPeers: true,
-      })
-      cpSync(
-        baseBuild.subject.packageDirectory,
-        join(assignabilityConsumer, 'node_modules/@rhinestone/sdk-base'),
-        { recursive: true },
-      )
-      compileConsumer(assignabilityConsumer, assignabilityFixturePath)
+      compileConsumer(compatibilityConsumer, assignabilityFixturePath)
     }
     validateMetadata(baseBuild.subject.packageDirectory)
     validateMetadata(current.packageDirectory)
@@ -312,13 +313,23 @@ async function main(): Promise<void> {
       temporaryDirectory,
       'current-api-report.json',
     )
-    writeJson(
-      baseApiReportPath,
-      generateApiReport(baseConsumers.packageDirectory),
+    const baseApiReport = generateApiReport(baseConsumers.packageDirectory)
+    const currentApiReport = generateApiReport(
+      currentConsumers.packageDirectory,
+    )
+    writeJson(baseApiReportPath, baseApiReport)
+    writeJson(currentApiReportPath, currentApiReport)
+    const apiCompatibilityReportPath = join(
+      temporaryDirectory,
+      'api-compatibility-report.json',
     )
     writeJson(
-      currentApiReportPath,
-      generateApiReport(currentConsumers.packageDirectory),
+      apiCompatibilityReportPath,
+      generateApiCompatibilityReport({
+        consumerDirectory: compatibilityConsumer,
+        baseReport: baseApiReport,
+        currentReport: currentApiReport,
+      }),
     )
 
     runCommand(
@@ -339,6 +350,7 @@ async function main(): Promise<void> {
           SDK_CONTRACT_CURRENT_NO_EXPRESS_DIR: currentConsumers.withoutExpress,
           SDK_CONTRACT_BASE_API_REPORT: baseApiReportPath,
           SDK_CONTRACT_CURRENT_API_REPORT: currentApiReportPath,
+          SDK_CONTRACT_API_COMPATIBILITY_REPORT: apiCompatibilityReportPath,
         },
       },
     )

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -169,8 +169,8 @@ function privateSourceImports(packageDirectory: string): string[] {
 //
 // - patch (or no new changeset, or an unreadable base): exact symbol inventory
 //   and mutually assignable types. Text-equal symbols take a fast path; generic
-//   types use representative instantiations, while nominal classes keep their
-//   own declaration text strict.
+//   types use representative instantiations, while namespaces and nominal
+//   classes keep their declarations and referenced declarations text-strict.
 // - minor: additive only. New entry points, exports, and symbols are allowed,
 //   but everything the base published must still be there. Shapes may widen —
 //   adding a union member changes a symbol's report while staying compatible —

--- a/test/contract/package.ctest.ts
+++ b/test/contract/package.ctest.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import sizeLimits from '../../.size-limit.ts'
+import type { ApiCompatibilityReport } from '../../scripts/contract/api-compat.ts'
 import type { ApiReport } from '../../scripts/contract/api-report.ts'
 import {
   declaredSdkBump,
@@ -74,6 +75,9 @@ const baseApiReport = readJson<ApiReport>(
 )
 const currentApiReport = readJson<ApiReport>(
   requiredEnvironment('SDK_CONTRACT_CURRENT_API_REPORT'),
+)
+const apiCompatibilityReport = readJson<ApiCompatibilityReport>(
+  requiredEnvironment('SDK_CONTRACT_API_COMPATIBILITY_REPORT'),
 )
 
 function normalizeExportTargets(
@@ -163,8 +167,10 @@ function privateSourceImports(packageDirectory: string): string[] {
 
 // Strictness follows the declared bump:
 //
-// - patch (or no new changeset, or an unreadable base): exact equality, so
-//   accidental undocumented drift fails.
+// - patch (or no new changeset, or an unreadable base): exact symbol inventory
+//   and mutually assignable types. Text-equal symbols take a fast path; generic
+//   types use representative instantiations, while nominal classes keep their
+//   own declaration text strict.
 // - minor: additive only. New entry points, exports, and symbols are allowed,
 //   but everything the base published must still be there. Shapes may widen —
 //   adding a union member changes a symbol's report while staying compatible —
@@ -355,7 +361,32 @@ describe('packed package contract', () => {
       }
       return
     }
-    expect(currentApiReport).toEqual(baseApiReport)
+    expect(
+      apiCompatibilityReport.added,
+      `patch added declared exports: ${apiCompatibilityReport.added.join(', ')}`,
+    ).toEqual([])
+    expect(
+      apiCompatibilityReport.removed,
+      `patch removed declared exports: ${apiCompatibilityReport.removed.join(', ')}`,
+    ).toEqual([])
+    expect(
+      apiCompatibilityReport.natureChanged,
+      `patch changed type/value export nature: ${apiCompatibilityReport.natureChanged.join(', ')}`,
+    ).toEqual([])
+
+    const incompatibilities = apiCompatibilityReport.incompatible
+      .map(({ symbol, reasons, baseDeclarations, currentDeclarations }) =>
+        [
+          `${symbol}: ${reasons.join('; ')}`,
+          `  base: ${baseDeclarations.join(' ')}`,
+          `  current: ${currentDeclarations.join(' ')}`,
+        ].join('\n'),
+      )
+      .join('\n')
+    expect(
+      apiCompatibilityReport.incompatible,
+      `patch has incompatible declarations:\n${incompatibilities}`,
+    ).toEqual([])
   })
 
   it('preserves compatibility-only runtime values and shapes', () => {

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: [
       'src/**/*.test.ts',
       'scripts/architecture/**/*.test.ts',
+      'scripts/contract/**/*.test.ts',
       'test/integration/config/**/*.test.ts',
       'test/integration/framework/**/*.test.ts',
       'test/vectors/**/*.test.ts',


### PR DESCRIPTION
- Compare changed public symbols with mutual TypeScript assignability while keeping nominal and namespace declarations text-strict.
- Report concise per-symbol incompatibilities and cover semantic compatibility edge cases.

Closes [RHI-5646](https://linear.app/rhinestone/issue/RHI-5646)