### PR TITLE
fix(orchestrator): align authorization chain IDs with wire types

### DIFF
--- a/.changeset/fix-intent-authorization-chain-ids.md
+++ b/.changeset/fix-intent-authorization-chain-ids.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Submit EIP-7702 any-chain authorizations with the numeric zero sentinel while encoding concrete chain IDs as eip155 identifiers.

--- a/src/clients/orchestrator/client.test.ts
+++ b/src/clients/orchestrator/client.test.ts
@@ -157,6 +157,12 @@ describe('orchestrator client', () => {
           Authorization: 'Bearer access',
           'X-Intent-Extension': 'Bearer extension',
         })
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          authorizations: {
+            sponsor: [{ chainId: 'eip155:8453' }],
+            recipient: [{ chainId: 0 }],
+          },
+        })
         return Response.json({ intentId: 'intent-1' })
       },
     )
@@ -174,6 +180,28 @@ describe('orchestrator client', () => {
       {
         intentId: 'intent-1',
         signatures: { origin: [], destination: '0x' },
+        authorizations: {
+          sponsor: [
+            {
+              chainId: 8453,
+              address,
+              nonce: 1,
+              yParity: 0,
+              r: '0x01',
+              s: '0x02',
+            },
+          ],
+          recipient: [
+            {
+              chainId: 0,
+              address,
+              nonce: 2,
+              yParity: 1,
+              r: '0x03',
+              s: '0x04',
+            },
+          ],
+        },
       },
       { intentInput: serializedIntentInput, sponsored: true },
     )

--- a/src/clients/orchestrator/mappers.test.ts
+++ b/src/clients/orchestrator/mappers.test.ts
@@ -99,13 +99,16 @@ describe('mapSignedIntentToWire', () => {
     ['negative', -1],
     ['fractional', 1.5],
     ['unsafe', Number.MAX_SAFE_INTEGER + 1],
+    ['HyperCore L1', 1337],
+    ['HyperCore spot', 1337001],
+    ['HyperCore perp', 1337002],
+    ['Tron', 728126428],
+    ['Solana', 792703809],
   ])('rejects %s authorization chain IDs', (_name, chainId) => {
     expect(() =>
       mapSignedIntentToWire(
         signedIntent({ sponsor: [authorization(chainId)] }),
       ),
-    ).toThrow(
-      new RangeError(`Invalid EIP-7702 authorization chain ID: ${chainId}`),
-    )
+    ).toThrow(new Error(`Invalid EIP-7702 authorization chain ID: ${chainId}`))
   })
 })

--- a/src/clients/orchestrator/mappers.test.ts
+++ b/src/clients/orchestrator/mappers.test.ts
@@ -1,0 +1,111 @@
+import type { SignedAuthorization } from 'viem'
+import { describe, expect, test } from 'vitest'
+import { mapSignedIntentToWire } from './mappers'
+import type { OrchestratorSignedIntent } from './types'
+
+const address = '0x0000000000000000000000000000000000000001' as const
+
+function authorization(chainId: number): SignedAuthorization {
+  return {
+    chainId,
+    address,
+    nonce: 7,
+    yParity: 1,
+    r: '0x01',
+    s: '0x02',
+  }
+}
+
+function signedIntent(
+  authorizations?: OrchestratorSignedIntent['authorizations'],
+): OrchestratorSignedIntent {
+  return {
+    intentId: 'intent-1',
+    signatures: {
+      origin: ['0x03', { preClaimSig: '0x04', notarizedClaimSig: '0x05' }],
+      destination: '0x06',
+      targetExecution: '0x07',
+    },
+    ...(authorizations ? { authorizations } : {}),
+    dryRun: true,
+  }
+}
+
+describe('mapSignedIntentToWire', () => {
+  test('maps concrete and any-chain sponsor and recipient authorizations', () => {
+    const result = mapSignedIntentToWire(
+      signedIntent({
+        sponsor: [authorization(8453), authorization(0)],
+        recipient: [authorization(10), authorization(0)],
+      }),
+    )
+
+    expect(result).toEqual({
+      intentId: 'intent-1',
+      signatures: {
+        origin: ['0x03', { preClaimSig: '0x04', notarizedClaimSig: '0x05' }],
+        destination: '0x06',
+        targetExecution: '0x07',
+      },
+      authorizations: {
+        sponsor: [
+          {
+            chainId: 'eip155:8453',
+            address,
+            nonce: 7,
+            yParity: 1,
+            r: '0x01',
+            s: '0x02',
+          },
+          {
+            chainId: 0,
+            address,
+            nonce: 7,
+            yParity: 1,
+            r: '0x01',
+            s: '0x02',
+          },
+        ],
+        recipient: [
+          {
+            chainId: 'eip155:10',
+            address,
+            nonce: 7,
+            yParity: 1,
+            r: '0x01',
+            s: '0x02',
+          },
+          {
+            chainId: 0,
+            address,
+            nonce: 7,
+            yParity: 1,
+            r: '0x01',
+            s: '0x02',
+          },
+        ],
+      },
+      options: { dryRun: true },
+    })
+  })
+
+  test('keeps omitted authorizations omitted', () => {
+    expect(mapSignedIntentToWire(signedIntent())).not.toHaveProperty(
+      'authorizations',
+    )
+  })
+
+  test.each([
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['unsafe', Number.MAX_SAFE_INTEGER + 1],
+  ])('rejects %s authorization chain IDs', (_name, chainId) => {
+    expect(() =>
+      mapSignedIntentToWire(
+        signedIntent({ sponsor: [authorization(chainId)] }),
+      ),
+    ).toThrow(
+      new RangeError(`Invalid EIP-7702 authorization chain ID: ${chainId}`),
+    )
+  })
+})

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -23,6 +23,7 @@ import type {
   OrchestratorSplitResult,
 } from './types'
 import type {
+  WireIntentRequest,
   WireIntentStatusResponse,
   WirePortfolioResponse,
   WireQuote,
@@ -75,7 +76,7 @@ export function mapQuoteResponseFromWire(
 
 export function mapSignedIntentToWire(
   input: OrchestratorSignedIntent,
-): unknown {
+): WireIntentRequest {
   return serializeBigInts({
     intentId: input.intentId,
     signatures: input.signatures,
@@ -252,15 +253,29 @@ function mapBridgeFillFromWire(
   return bridgeFill as BridgeFill
 }
 
-function mapAuthorizationToWire(authorization: SignedAuthorization): unknown {
+type WireAuthorization = NonNullable<
+  NonNullable<WireIntentRequest['authorizations']>['sponsor']
+>[number]
+
+function mapAuthorizationToWire(
+  authorization: SignedAuthorization,
+): WireAuthorization {
   return {
-    chainId: formatCaip2(authorization.chainId),
+    chainId: mapAuthorizationChainIdToWire(authorization.chainId),
     address: authorization.address,
     nonce: authorization.nonce,
     yParity: authorization.yParity ?? 0,
     r: authorization.r,
     s: authorization.s,
   }
+}
+
+function mapAuthorizationChainIdToWire(chainId: number): 0 | string {
+  if (chainId === 0) return 0
+  if (!Number.isSafeInteger(chainId) || chainId < 0) {
+    throw new RangeError(`Invalid EIP-7702 authorization chain ID: ${chainId}`)
+  }
+  return `eip155:${chainId}`
 }
 
 function mapAccessList(input: OrchestratorIntentRequest['accountAccessList']) {

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -2,6 +2,8 @@ import type { Address, SignedAuthorization } from 'viem'
 import {
   chainIdFromReference,
   formatCaip2,
+  isHyperCoreWireId,
+  isNonEvmChainId,
   parseCaip2,
 } from '../../chains/caip2'
 import type {
@@ -24,6 +26,7 @@ import type {
 } from './types'
 import type {
   WireIntentRequest,
+  WireIntentRequestInternal,
   WireIntentStatusResponse,
   WirePortfolioResponse,
   WireQuote,
@@ -76,7 +79,7 @@ export function mapQuoteResponseFromWire(
 
 export function mapSignedIntentToWire(
   input: OrchestratorSignedIntent,
-): WireIntentRequest {
+): WireIntentRequestInternal {
   return serializeBigInts({
     intentId: input.intentId,
     signatures: input.signatures,
@@ -270,10 +273,17 @@ function mapAuthorizationToWire(
   }
 }
 
-function mapAuthorizationChainIdToWire(chainId: number): 0 | string {
+function mapAuthorizationChainIdToWire(
+  chainId: number,
+): 0 | `eip155:${number}` {
   if (chainId === 0) return 0
-  if (!Number.isSafeInteger(chainId) || chainId < 0) {
-    throw new RangeError(`Invalid EIP-7702 authorization chain ID: ${chainId}`)
+  if (
+    !Number.isSafeInteger(chainId) ||
+    chainId < 0 ||
+    isHyperCoreWireId(chainId) ||
+    isNonEvmChainId(chainId)
+  ) {
+    throw new Error(`Invalid EIP-7702 authorization chain ID: ${chainId}`)
   }
   return `eip155:${chainId}`
 }

--- a/src/clients/orchestrator/wire.ts
+++ b/src/clients/orchestrator/wire.ts
@@ -24,6 +24,7 @@ type JsonResponse<Operation extends keyof operations> = NonNullable<
 type Folded<Body> = Body & { readonly traceId?: string }
 
 export type WireQuoteRequest = JsonRequest<'createQuote'>
+export type WireIntentRequest = JsonRequest<'createIntent'>
 export type WireSplitRequest = JsonRequest<'getSplit'>
 export type WireQuoteResponse = Folded<JsonResponse<'createQuote'>>
 export type WireQuote = WireQuoteResponse['routes'][number]

--- a/src/clients/orchestrator/wire.ts
+++ b/src/clients/orchestrator/wire.ts
@@ -25,6 +25,10 @@ type Folded<Body> = Body & { readonly traceId?: string }
 
 export type WireQuoteRequest = JsonRequest<'createQuote'>
 export type WireIntentRequest = JsonRequest<'createIntent'>
+// The orchestrator consumes this internal simulation flag outside the public schema.
+export type WireIntentRequestInternal = WireIntentRequest & {
+  readonly options?: { readonly dryRun?: boolean }
+}
 export type WireSplitRequest = JsonRequest<'getSplit'>
 export type WireQuoteResponse = Folded<JsonResponse<'createQuote'>>
 export type WireQuote = WireQuoteResponse['routes'][number]


### PR DESCRIPTION
- Type intent submissions against the generated orchestrator request contract.
- Preserve the EIP-7702 any-chain sentinel as `0`, map concrete IDs to `eip155`, and reject invalid IDs locally.
- Add mapper and serialized-request regressions plus a patch changeset.

Closes [RHI-5708](https://linear.app/rhinestone/issue/RHI-5708)