### PR TITLE
perf(contract): share program construction across api checks

### DIFF
--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path'
 import ts from 'typescript'
 import type { ApiExportReport, ApiReport } from './api-report.ts'
 import { writeJson } from './shared.ts'
+import { createContractProgram } from './ts-program.ts'
 
 export interface ApiCompatibilityFailure {
   symbol: string
@@ -354,24 +355,7 @@ export function generateApiCompatibilityReport(options: {
 
   const fixturePath = join(options.consumerDirectory, 'api-compat.generated.ts')
   writeFileSync(fixturePath, `${source.join('\n')}\n`)
-  const program = ts.createProgram([fixturePath], {
-    target: ts.ScriptTarget.ES2022,
-    module: ts.ModuleKind.NodeNext,
-    moduleResolution: ts.ModuleResolutionKind.NodeNext,
-    strict: true,
-    skipLibCheck: true,
-    noEmit: true,
-  })
-  const diagnostics = ts.getPreEmitDiagnostics(program)
-  if (diagnostics.length > 0) {
-    throw new Error(
-      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
-        getCanonicalFileName: (fileName) => fileName,
-        getCurrentDirectory: () => process.cwd(),
-        getNewLine: () => '\n',
-      }),
-    )
-  }
+  const program = createContractProgram([fixturePath])
 
   const fixture = program.getSourceFile(resolve(fixturePath))
   if (!fixture)

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
 import ts from 'typescript'
 import { type PackageManifest, readJson, writeJson } from './shared.ts'
+import { createContractProgram } from './ts-program.ts'
 
 export interface ApiExportReport {
   hasType: boolean
@@ -507,24 +508,7 @@ export function generateApiReport(packageDirectory: string): ApiReport {
   const entryFiles = Object.values(manifest.exports).map((target) =>
     resolve(packageDirectory, target.types),
   )
-  const program = ts.createProgram(entryFiles, {
-    target: ts.ScriptTarget.ES2022,
-    module: ts.ModuleKind.NodeNext,
-    moduleResolution: ts.ModuleResolutionKind.NodeNext,
-    strict: true,
-    skipLibCheck: true,
-    noEmit: true,
-  })
-  const diagnostics = ts.getPreEmitDiagnostics(program)
-  if (diagnostics.length > 0) {
-    throw new Error(
-      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
-        getCanonicalFileName: (fileName) => fileName,
-        getCurrentDirectory: () => process.cwd(),
-        getNewLine: () => '\n',
-      }),
-    )
-  }
+  const program = createContractProgram(entryFiles)
 
   const checker = program.getTypeChecker()
   const printer = ts.createPrinter({ removeComments: true })

--- a/scripts/contract/ts-program.ts
+++ b/scripts/contract/ts-program.ts
@@ -1,0 +1,57 @@
+import ts from 'typescript'
+
+// `types: []` opts out of ambient `@types/*` auto-inclusion: without it every
+// program picks up every type package reachable from the working directory
+// (~120 extra declaration files), so reports would also depend on what the host
+// repository happens to have installed.
+const compilerOptions: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  strict: true,
+  skipLibCheck: true,
+  noEmit: true,
+  types: [],
+}
+
+// Standard library files carry no module imports and every program here uses
+// the options above, so their parsed form is shared for the process lifetime.
+// Keyed by file name only — valid while `compilerOptions` is the sole option set.
+const standardLibrary = new Map<string, ts.SourceFile | undefined>()
+
+export function createContractProgram(rootNames: string[]): ts.Program {
+  const host = ts.createCompilerHost(compilerOptions)
+  const defaultLibraryDirectory = host.getDefaultLibLocation?.()
+  const readSourceFile = host.getSourceFile.bind(host)
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+    const cacheable =
+      defaultLibraryDirectory !== undefined &&
+      fileName.startsWith(defaultLibraryDirectory)
+    if (cacheable && standardLibrary.has(fileName)) {
+      return standardLibrary.get(fileName)
+    }
+    const sourceFile = readSourceFile(
+      fileName,
+      languageVersion,
+      onError,
+      shouldCreate,
+    )
+    if (cacheable) {
+      standardLibrary.set(fileName, sourceFile)
+    }
+    return sourceFile
+  }
+
+  const program = ts.createProgram(rootNames, compilerOptions, host)
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+  if (diagnostics.length > 0) {
+    throw new Error(
+      ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCanonicalFileName: (fileName) => fileName,
+        getCurrentDirectory: () => process.cwd(),
+        getNewLine: () => '\n',
+      }),
+    )
+  }
+  return program
+}


### PR DESCRIPTION
Both `api-report.ts` and `api-compat.ts` built their `ts.Program` inline with duplicated compiler options and diagnostics guards. Each program cost ~380ms of fixed overhead that had nothing to do with the code under comparison, and the compatibility fixture builds three of them per case.

- New `scripts/contract/ts-program.ts` owns program construction: shared compiler options, a process-level cache of parsed standard-library source files, and the throw-on-diagnostics guard.
- `generateApiReport` and `generateApiCompatibilityReport` route through it; both inline option blocks and duplicated guards are gone.
- `types: []` opts out of `@types/*` auto-inclusion, which was pulling ~120 unrelated declaration files into every program (183 source files vs 64). It also makes reports independent of what the host repo has installed.
- Caching parsed lib files is safe here: only files under the TypeScript installation's own lib directory are cached, every program uses the same frozen options object, and lib files carry no module imports.

Measured locally: **~380ms → ~11ms per program**; compatibility cases 55.2s → 5.0s of test time; full unit suite 607/607 unchanged at 16.1s wall. No test, fixture, or config changes.

The release-gating path is unaffected — an API report over the real built package is byte-identical with `types: []` (962,285 bytes both ways), and `test:contract` in CI exercises it against packed packages.

No changeset: `scripts/` sits outside the published package.

Closes [RHI-5899](https://linear.app/rhinestone/issue/RHI-5899)
