### PR TITLE
fix: order hex lists and EIP-712 dependencies independently of host locale

### DIFF
--- a/.changeset/fix-locale-independent-ordering.md
+++ b/.changeset/fix-locale-independent-ordering.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Order ENS owners, WebAuthn credential IDs, and EIP-712 type dependencies by value instead of host collation, so the same account config derives the same address and multi-passkey signatures stay valid on locales such as `da`, `nb`, and `cy`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Docs: https://docs.rhinestone.dev/smart-wallet
 - `bun run test:integration:smoke` - Run the live SDK smoke suite against testnets.
 - `bun run test:integration` - Run all live SDK integration tests.
 - `bun run check` - Lint and format (biome)
-- `bun run check:architecture` - Enforce dependency direction and import boundaries.
+- `bun run check:architecture` - Enforce dependency direction, import boundaries, and host-independent ordering.
 - `bun run typecheck` - Type check without emit
 
 ## Stack
@@ -71,6 +71,7 @@ After a changeset reaches `main`, a successful `@dev` publish opens one `main` �
 ## Patterns
 
 - Use viem types for addresses, chains, and hex values
+- Ordering and case conversion must never depend on the host locale — sort hex values with `compareHexValues` and use the default `.sort()` comparator or `toLowerCase`/`toUpperCase` elsewhere; `check:architecture` rejects `localeCompare`, `toLocale*Case`, and `Intl.Collator` in `src/`
 - Placement of a new public method — `RhinestoneSDK` vs `RhinestoneAccount`: put it on **`RhinestoneSDK`** when its data is scoped to the API key's project/integrator and needs no account (auth-only orchestrator reads, e.g. `getIntentStatus`, `splitIntents`, `getAppFeeBalances`); put it on **`RhinestoneAccount`** only when it is genuinely account-scoped (needs the account address / owners / on-chain state, e.g. `getPortfolio`, signing). Exposing project-scoped data as an account method misleads callers into reading it as account-scoped.
 - Account implementations live in `/src/accounts/adapters/*.ts`
 - Public API is the union of the explicit exports from `src/index.ts` and the subpath exports in `src/package.json` (`/actions`, `/errors`, `/jwt-server`, `/smart-sessions`, etc.) — adding, renaming, or removing exports is a breaking change. Determine root exports from export declarations or the packed package; a symbol imported into `src/index.ts` only for use in a public signature is not itself a named export.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@ integration setup.
 | ------------------ | ------------------------------------- | ---------------------------------- | ---------------------------- |
 | Unit and vectors   | `src/**/*.test.ts`, `test/vectors/**` | Local code and deterministic fakes | `bun run test`               |
 | Pure-core coverage | Rewritten core and pure adapters      | V8 coverage with scoped thresholds | `bun run test:coverage:pure` |
-| Architecture       | Production imports                    | Dependency and cycle rules         | `bun run check:architecture` |
+| Architecture       | Production imports                    | Dependency, cycle, and host-independence rules | `bun run check:architecture` |
 | Typecheck           | Source, unit tests, and test harnesses | TypeScript                         | `bun run typecheck`          |
 | Public types        | `test/types/**`                       | Consumer-facing compile fixtures   | `bun run test:types`         |
 | Package contract   | `test/contract/**/*.ctest.ts`         | Packed release and current packages | `bun run test:contract`      |

--- a/scripts/architecture/check.test.ts
+++ b/scripts/architecture/check.test.ts
@@ -76,6 +76,37 @@ describe('architecture rules', () => {
     })
   })
 
+  test('rejects locale-sensitive ordering and case conversion', () => {
+    const file = 'src/modules/validators/ens.ts'
+    for (const source of [
+      'owners.sort((a, b) => a.localeCompare(b))',
+      'address.toLocaleLowerCase()',
+      'name.toLocaleUpperCase()',
+      'new Intl.Collator()',
+    ]) {
+      expect(
+        analyzeArchitecture({
+          files: [file],
+          edges: [],
+          sourceText: { [file]: source },
+        }),
+      ).toContainEqual({
+        rule: 'no-locale-sensitive-ordering',
+        path: [file],
+        message:
+          'ordering and case conversion must not depend on the host locale',
+      })
+    }
+
+    expect(
+      analyzeArchitecture({
+        files: [file],
+        edges: [],
+        sourceText: { [file]: 'owners.sort(compareHexValues)' },
+      }),
+    ).toEqual([])
+  })
+
   test('reports a shortest cycle path', () => {
     const violations = analyzeArchitecture(
       graph([

--- a/scripts/architecture/check.ts
+++ b/scripts/architecture/check.ts
@@ -133,9 +133,12 @@ function collectEdges(path: string, source: ts.SourceFile): DependencyEdge[] {
 }
 
 export function readArchitectureGraph(): ArchitectureGraph {
-  const absoluteFiles = listSourceFiles(sourceRoot).sort((left, right) =>
-    sourcePath(left).localeCompare(sourcePath(right)),
-  )
+  const absoluteFiles = listSourceFiles(sourceRoot).sort((left, right) => {
+    const leftPath = sourcePath(left)
+    const rightPath = sourcePath(right)
+    if (leftPath === rightPath) return 0
+    return leftPath < rightPath ? -1 : 1
+  })
   const files = absoluteFiles.map(sourcePath)
   const sourceText: Record<string, string> = {}
   const edges: DependencyEdge[] = []
@@ -410,6 +413,18 @@ export function analyzeArchitecture(
         rule: 'no-global-buckets',
         path: [file],
         message: 'behaviorful global common/types/utils buckets are forbidden',
+      })
+    }
+    if (
+      /\.localeCompare\(|toLocaleLowerCase|toLocaleUpperCase|Intl\.Collator/.test(
+        graph.sourceText[file] ?? '',
+      )
+    ) {
+      violations.push({
+        rule: 'no-locale-sensitive-ordering',
+        path: [file],
+        message:
+          'ordering and case conversion must not depend on the host locale',
       })
     }
     if (

--- a/scripts/contract/api-compat.ts
+++ b/scripts/contract/api-compat.ts
@@ -415,9 +415,10 @@ export function generateApiCompatibilityReport(options: {
     removed,
     natureChanged,
     compatible: compatible.sort(),
-    incompatible: incompatible.sort((left, right) =>
-      left.symbol.localeCompare(right.symbol),
-    ),
+    incompatible: incompatible.sort((left, right) => {
+      if (left.symbol === right.symbol) return 0
+      return left.symbol < right.symbol ? -1 : 1
+    }),
   }
 }
 

--- a/scripts/contract/api-report.ts
+++ b/scripts/contract/api-report.ts
@@ -120,7 +120,7 @@ function declarationsForSymbol(
   return {
     declarations: rootDeclarations,
     referencedDeclarations: [...referenced.entries()]
-      .sort(([left], [right]) => left.localeCompare(right))
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
       .map(([, text]) => text),
   }
 }
@@ -180,7 +180,7 @@ function referencedDeclarationsForNode(
 
   visitNode(node)
   return [...referenced.entries()]
-    .sort(([left], [right]) => left.localeCompare(right))
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
     .map(([, text]) => text)
 }
 
@@ -531,7 +531,12 @@ export function generateApiReport(packageDirectory: string): ApiReport {
     entrypoints[entrypoint] = Object.fromEntries(
       checker
         .getExportsOfModule(moduleSymbol)
-        .sort((left, right) => left.getName().localeCompare(right.getName()))
+        .sort((left, right) => {
+          const leftName = left.getName()
+          const rightName = right.getName()
+          if (leftName === rightName) return 0
+          return leftName < rightName ? -1 : 1
+        })
         .map((symbol) => [
           symbol.getName(),
           reportExport(symbol, checker, printer, packageDirectory),

--- a/src/accounts/adapters/contract.test.ts
+++ b/src/accounts/adapters/contract.test.ts
@@ -6,7 +6,13 @@ import {
   zeroHash,
 } from 'viem'
 import { describe, expect, test } from 'vitest'
-import { accountA, accountB } from '../../../test/consts'
+import {
+  accountA,
+  accountB,
+  collationAccountHigh,
+  collationAccountLow,
+} from '../../../test/consts'
+import { withoutHostCollation } from '../../../test/utils/locale'
 import type { AccountConstructionInput } from '../../config/input'
 import { resolveStandaloneAccountConfig } from '../../config/resolve'
 import type { ResolvedModule } from '../../modules/types'
@@ -421,6 +427,33 @@ describe('account adapter contract', () => {
       verifyingContract: accountA.address,
       salt: zeroHash,
     })
+  })
+
+  test('HCA derives the same address for multiple ENS owners on any host', () => {
+    // The CREATE3 salt is the first sorted owner, so a collation-dependent sort
+    // would derive a different account for the same config.
+    const address = (owners: { account: typeof accountA }[]) =>
+      withoutHostCollation(() => {
+        const input = construction({
+          account: { type: 'hca' as const },
+          owners: { type: 'ens' as const, owners },
+        })
+        return createHcaAdapter(input).getIdentity(input).address
+      })
+
+    const expected = '0x81f7e3abb7929e2b80458bcc87e9ecf29a44c542'
+    expect(
+      address([
+        { account: collationAccountLow },
+        { account: collationAccountHigh },
+      ]),
+    ).toBe(expected)
+    expect(
+      address([
+        { account: collationAccountHigh },
+        { account: collationAccountLow },
+      ]),
+    ).toBe(expected)
   })
 
   test('HCA rejects unsupported setup and preserves opaque custom addresses', () => {

--- a/src/modules/validators/contribution.test.ts
+++ b/src/modules/validators/contribution.test.ts
@@ -1,5 +1,6 @@
 import { concat, decodeAbiParameters, type Hex, pad, toHex } from 'viem'
 import { describe, expect, test } from 'vitest'
+import { withoutHostCollation } from '../../../test/utils/locale'
 import { encodeValidatorContribution } from './contribution'
 import { encodeMultiFactorContribution } from './multi-factor'
 import { encodeEcdsaValidatorContribution } from './ownable'
@@ -202,6 +203,42 @@ describe('validator contribution codecs', () => {
       s: BigInt(`0x${'11'.repeat(32)}`),
     })
     expect(generateWebauthnCredentialId(1n, 2n, account)).toHaveLength(66)
+  })
+
+  test('orders WebAuthn credential IDs by value, not by host collation', () => {
+    const signature = {
+      authenticatorData: '0x1234' as Hex,
+      clientDataJSON: '{"type":"webauthn.get","challenge":"value"}',
+      challengeIndex: 0n,
+      typeIndex: 0n,
+      r: 1n,
+      s: 2n,
+    }
+    // 0xb1… collates before 0xaa… on Danish-family locales, but the validator
+    // requires ascending credential IDs.
+    const high = `0xb1${'11'.repeat(31)}` as Hex
+    const low = `0xaa${'22'.repeat(31)}` as Hex
+    const [credIds] = decodeAbiParameters(
+      [
+        { type: 'bytes32[]' },
+        { type: 'bool' },
+        {
+          type: 'tuple[]',
+          components: [
+            { type: 'bytes' },
+            { type: 'string' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+          ],
+        },
+      ],
+      withoutHostCollation(() =>
+        encodeWebauthnSignatures([high, low], false, [signature, signature]),
+      ),
+    )
+    expect(credIds).toEqual([low, high])
   })
 
   test('rejects malformed WebAuthn owner sets', () => {

--- a/src/modules/validators/ens.ts
+++ b/src/modules/validators/ens.ts
@@ -1,5 +1,6 @@
 import { encodeAbiParameters, maxUint48 } from 'viem'
 import type { ResolvedModule } from '../types'
+import { compareHexValues } from './ordering'
 import type { AtomicValidatorDefinition } from './types'
 
 export const ENS_HCA_MODULE =
@@ -20,7 +21,7 @@ export function resolveEnsValidator(
           : Number(maxUint48),
       }
     })
-    .sort((left, right) => left.addr.localeCompare(right.addr))
+    .sort((left, right) => compareHexValues(left.addr, right.addr))
   return {
     kind: 'validator',
     address: ENS_HCA_MODULE,

--- a/src/modules/validators/ordering.test.ts
+++ b/src/modules/validators/ordering.test.ts
@@ -1,0 +1,23 @@
+import type { Hex } from 'viem'
+import { describe, expect, test } from 'vitest'
+import { compareHexValues } from './ordering'
+
+describe('hex ordering', () => {
+  test('orders by value, not by host collation', () => {
+    expect(compareHexValues('0xaa7d', '0xb1a4')).toBe(-1)
+    expect(compareHexValues('0xb1a4', '0xaa7d')).toBe(1)
+    expect(compareHexValues('0xdd', '0xde')).toBe(-1)
+    expect(compareHexValues('0xff', '0x0100')).toBe(-1)
+  })
+
+  test('treats equal values as equal regardless of casing', () => {
+    expect(compareHexValues('0xaa7d', '0xaa7d')).toBe(0)
+    expect(compareHexValues('0xAA7D', '0xaa7d')).toBe(0)
+    expect(compareHexValues('0xAA7D', '0xb1a4')).toBe(-1)
+  })
+
+  test('sorts a list ascending', () => {
+    const values: Hex[] = ['0xb1a4', '0xaa7d', '0x01']
+    expect(values.sort(compareHexValues)).toEqual(['0x01', '0xaa7d', '0xb1a4'])
+  })
+})

--- a/src/modules/validators/ordering.ts
+++ b/src/modules/validators/ordering.ts
@@ -1,0 +1,13 @@
+import type { Hex } from 'viem'
+
+// Order by value, never by host collation: `localeCompare` sorts `0xaa…` after
+// `0xb1…` on Danish-family locales, which would change derived addresses and
+// break the validators' ascending-order requirement.
+export function compareHexValues(left: Hex, right: Hex): number {
+  const leftValue = BigInt(left)
+  const rightValue = BigInt(right)
+  if (leftValue === rightValue) {
+    return 0
+  }
+  return leftValue < rightValue ? -1 : 1
+}

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -4,8 +4,11 @@ import {
   accountA,
   accountB,
   accountC,
+  collationAccountHigh,
+  collationAccountLow,
   passkeyAccount,
 } from '../../../test/consts'
+import { withoutHostCollation } from '../../../test/utils/locale'
 import { resolveStandaloneAccountConfig } from '../../config/resolve'
 import { getValidatorCapabilities } from './capabilities'
 import { resolveEnsValidator } from './ens'
@@ -225,6 +228,48 @@ describe('validator resolution', () => {
       Number(maxUint48),
       Number(maxUint48),
     ])
+  })
+
+  test('orders ENS owners by value, not by host collation', () => {
+    const ownerAddresses = (owners: { account: typeof accountA }[]) => {
+      const ens = validator({
+        type: 'ens',
+        owners,
+        threshold: 1,
+      }) as AtomicValidatorDefinition
+      const initData = withoutHostCollation(
+        () => resolveEnsValidator(ens).initData,
+      )
+      const [, decoded] = decodeAbiParameters(
+        [
+          { name: 'threshold', type: 'uint256' },
+          {
+            name: 'owners',
+            type: 'tuple[]',
+            components: [
+              { name: 'addr', type: 'address' },
+              { name: 'expiration', type: 'uint48' },
+            ],
+          },
+        ],
+        initData,
+      )
+      return decoded.map((owner) => owner.addr)
+    }
+
+    const expected = [collationAccountLow.address, collationAccountHigh.address]
+    expect(
+      ownerAddresses([
+        { account: collationAccountLow },
+        { account: collationAccountHigh },
+      ]),
+    ).toEqual(expected)
+    expect(
+      ownerAddresses([
+        { account: collationAccountHigh },
+        { account: collationAccountLow },
+      ]),
+    ).toEqual(expected)
   })
 
   test('parses every supported WebAuthn public-key representation', () => {

--- a/src/modules/validators/webauthn.ts
+++ b/src/modules/validators/webauthn.ts
@@ -8,6 +8,7 @@ import {
   stringToBytes,
 } from 'viem'
 import type { ResolvedModule } from '../types'
+import { compareHexValues } from './ordering'
 import type { AtomicValidatorDefinition } from './types'
 
 export const WEBAUTHN_VALIDATOR_ADDRESS: Address =
@@ -142,7 +143,9 @@ export function encodeWebauthnSignatures(
       credentialId,
       signature: normalizeWebauthnSignature(signatures[index]),
     }))
-    .sort((left, right) => left.credentialId.localeCompare(right.credentialId))
+    .sort((left, right) =>
+      compareHexValues(left.credentialId, right.credentialId),
+    )
   return encodeAbiParameters(
     [
       { type: 'bytes32[]', name: 'credIds' },

--- a/src/signing/protocols/erc7739.ts
+++ b/src/signing/protocols/erc7739.ts
@@ -111,12 +111,7 @@ function encodeType(
   }
   collect(primaryType)
   dependencies.delete(primaryType)
-  return [primaryType, ...dependencies]
-    .sort((left, right) => {
-      if (left === primaryType) return -1
-      if (right === primaryType) return 1
-      return left.localeCompare(right)
-    })
+  return [primaryType, ...[...dependencies].sort()]
     .map(
       (type) =>
         `${type}(${types[type].map((field) => `${field.type} ${field.name}`).join(',')})`,

--- a/src/signing/protocols/protocols.test.ts
+++ b/src/signing/protocols/protocols.test.ts
@@ -1,5 +1,6 @@
 import { type Hex, hashTypedData, type TypedDataDefinition } from 'viem'
 import { describe, expect, test } from 'vitest'
+import { withoutHostCollation } from '../../../test/utils/locale'
 import {
   isErc6492Signature,
   unwrapErc6492Signature,
@@ -134,6 +135,44 @@ describe('signing protocol operations', () => {
         { ...message, attachment: { ...message.attachment, size: 1n } },
       ),
     ).not.toBe(hash({ Mail: mail, Person: person, Attachment: attachment }))
+  })
+
+  test('orders nested type dependencies by value, not by host collation', () => {
+    // `Aardvark` precedes `Zebra` byte-wise but follows it on Danish-family
+    // locales, where `aa` is a letter sorting after `z`.
+    const types = {
+      Note: [
+        { name: 'zebra', type: 'Zebra' },
+        { name: 'aardvark', type: 'Aardvark' },
+      ],
+      Zebra: [{ name: 'stripes', type: 'uint256' }],
+      Aardvark: [{ name: 'burrows', type: 'uint256' }],
+    }
+    const hash = withoutHostCollation(() =>
+      hashErc7739TypedData({
+        typedData: {
+          domain: {
+            name: 'TestApp',
+            version: '1',
+            chainId: 1,
+            verifyingContract: factory,
+          },
+          types,
+          primaryType: 'Note',
+          message: { zebra: { stripes: 1n }, aardvark: { burrows: 2n } },
+        } as unknown as TypedDataDefinition,
+        verifierDomain: {
+          name: 'Startale',
+          version: '1.0.0',
+          chainId: 1,
+          verifyingContract: account,
+          salt: `0x${'00'.repeat(32)}`,
+        },
+      }),
+    )
+    expect(hash).toBe(
+      '0xfe19863b25115aeca4c3c9cf35bb13bac15de5a4ddd39beef7b38eeee6d1f4f5',
+    )
   })
 
   test('hashes only the EIP-712 domain fields the app domain declares', () => {

--- a/test/consts.ts
+++ b/test/consts.ts
@@ -16,6 +16,14 @@ const accountC: Account = privateKeyToAccount(
 const accountD: Account = privateKeyToAccount(
   '0xa4aba81871b7b51fff56bfe441ea7f9a4879dd4bc8ce8c15fdb06dc92e63d1d7',
 )
+// 0xaa7d… and 0xb1a4…: byte order and Danish-family collation disagree on this
+// pair, so ordering bugs are visible in the derived address.
+const collationAccountLow: Account = privateKeyToAccount(
+  '0x20438a6e377aee6f3ecd82abbe9710ad5aa29586b54ebe2b2992171d0adbcd40',
+)
+const collationAccountHigh: Account = privateKeyToAccount(
+  '0x29b0743c3c66dd86fd3cc92b157925232de9aadef57dedd8bc079b6d92af7d87',
+)
 const passkeyAccount: WebAuthnAccount = toWebAuthnAccount({
   credential: {
     id: '9IwX9n6cn-l9SzqFzfQXvDHRuTM',
@@ -26,4 +34,13 @@ const passkeyAccount: WebAuthnAccount = toWebAuthnAccount({
 
 const MOCK_API_KEY = 'MOCK_KEY'
 
-export { accountA, accountB, accountC, accountD, passkeyAccount, MOCK_API_KEY }
+export {
+  accountA,
+  accountB,
+  accountC,
+  accountD,
+  collationAccountHigh,
+  collationAccountLow,
+  passkeyAccount,
+  MOCK_API_KEY,
+}

--- a/test/utils/locale.ts
+++ b/test/utils/locale.ts
@@ -1,0 +1,19 @@
+import { vi } from 'vitest'
+
+// The test runtime pins the default collator to en-US regardless of the
+// environment locale, so locale-sensitive ordering cannot be caught by running
+// under a Danish-family locale. Make any collation lookup throw instead.
+function withoutHostCollation<T>(run: () => T): T {
+  const spy = vi
+    .spyOn(String.prototype, 'localeCompare')
+    .mockImplementation(() => {
+      throw new Error('host collation must not be consulted')
+    })
+  try {
+    return run()
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+export { withoutHostCollation }


### PR DESCRIPTION
Sorting hex lists with `localeCompare` used the host's collation, so on Danish-family locales (`da`, `nb`, `nn`, `no`, `fo`) `0xaa…` sorted after `0xb1…`. For a two-ENS-owner HCA config that flipped the owner order and changed the derived account address (`0x81f7e3ab…` on `en-US` vs `0xd031b0cc…` on `da-DK`), and it made `encodeWebauthnSignatures` emit credential IDs in descending order, which the validator rejects.

- Add `compareHexValues` (`src/modules/validators/ordering.ts`), comparing by numeric value, and use it for the ENS owner sort and the WebAuthn credential-ID sort.
- `encodeType` in `src/signing/protocols/erc7739.ts` now prepends `primaryType` and sorts dependencies with the default comparator — output-identical, no longer locale-dependent.
- New `no-locale-sensitive-ordering` architecture rule rejecting `localeCompare`, `toLocale*Case`, and `Intl.Collator` in `src/`, plus the same cleanup in `scripts/contract/api-report.ts`, `scripts/contract/api-compat.ts`, and the checker itself.
- Regression tests pin the ordering, the two-owner HCA address, and the ERC-7739 type hash while `String.prototype.localeCompare` throws (Bun pins the collator to `en-US`, so env-locale tests can't work).

No behavior change on hosts whose collation matches byte order (all `en` locales); nothing on the public surface changes.

Closes [RHI-5958](https://linear.app/rhinestone/issue/RHI-5958)
Relates to [RHI-5963](https://linear.app/rhinestone/issue/RHI-5963) (same defect on `v1`, separate PR)
