### PR TITLE
fix: derive installable addresses for multi-passkey accounts

### DIFF
--- a/.changeset/fix-multi-passkey-undeployable-address.md
+++ b/.changeset/fix-multi-passkey-undeployable-address.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Derive multi-passkey account addresses that can actually be deployed. Credentials are now installed in a canonical, order-independent order, and the account salt is deterministically searched (starting from the salt you passed) until the derived address satisfies the WebAuthn validator's ascending credential ID rule. Passkey sets that cannot be installed — duplicates, or more than six passkeys at deployment — throw `PasskeyConfigurationNotInstallableError` instead of returning an unusable address; add the remaining passkeys after deployment with `passkeys.addOwner`.
+
+Single-passkey, ECDSA, ENS, multi-factor and every non-passkey configuration keep the exact address they derive today. A multi-passkey configuration that is deployable today but was passed in a non-canonical order moves to a new address; its old address stays reachable by pinning `initData`.

--- a/.changeset/fix-multi-passkey-undeployable-address.md
+++ b/.changeset/fix-multi-passkey-undeployable-address.md
@@ -1,7 +1,7 @@
 ---
-'@rhinestone/sdk': minor
+'@rhinestone/sdk': major
 ---
 
 Derive multi-passkey account addresses that can actually be deployed. Credentials are now installed in a canonical, order-independent order, and the account salt is deterministically searched (starting from the salt you passed) until the derived address satisfies the WebAuthn validator's ascending credential ID rule. Passkey sets that cannot be installed — duplicates, or more than six passkeys at deployment — throw `PasskeyConfigurationNotInstallableError` instead of returning an unusable address; add the remaining passkeys after deployment with `passkeys.addOwner`.
 
-Single-passkey, ECDSA, ENS, multi-factor and every non-passkey configuration keep the exact address they derive today. A multi-passkey configuration that is deployable today but was passed in a non-canonical order moves to a new address; its old address stays reachable by pinning `initData`.
+Single-passkey, ECDSA, ENS, multi-factor and every non-passkey configuration keep the exact address they derive today. A multi-passkey configuration that is deployable today but was passed in a non-canonical order derives a new address; to keep the existing account, pin its `initData` instead of letting the SDK re-derive it.

--- a/src/accounts/adapters/kernel.ts
+++ b/src/accounts/adapters/kernel.ts
@@ -13,12 +13,16 @@ import {
   stringToHex,
   toHex,
   zeroAddress,
-  zeroHash,
 } from 'viem'
 import { moduleTypeId } from '../../modules/erc7579-abi'
 import type { ResolvedModule } from '../../modules/types'
 import type { AccountAdapter } from '../adapter'
-import { type DeploymentMaterial, deploymentPlan } from '../deployment'
+import {
+  type DeploymentMaterial,
+  deploymentPlan,
+  KERNEL_SALT_DEFAULTS,
+  selectedValue,
+} from '../deployment'
 import { encodeErc7579Calls } from '../erc7579-calls'
 import type { AccountConstruction } from '../types'
 import { encodeUninstallModule } from './shared'
@@ -144,10 +148,7 @@ function kernelMaterial(input: AccountConstruction): DeploymentMaterial {
         initConfig,
       ],
     })
-    salt =
-      input.account.salt.source === 'explicit'
-        ? input.account.salt.value
-        : zeroHash
+    salt = selectedValue(input.account.salt, KERNEL_SALT_DEFAULTS)
     factoryData = encodeFunctionData({
       abi: parseAbi(['function deployWithFactory(address,bytes,bytes32)']),
       functionName: 'deployWithFactory',

--- a/src/accounts/adapters/nexus.ts
+++ b/src/accounts/adapters/nexus.ts
@@ -7,14 +7,18 @@ import {
   encodePacked,
   getContractAddress,
   type Hex,
-  keccak256,
   parseAbi,
   size,
   zeroAddress,
 } from 'viem'
 import { OWNABLE_VALIDATOR_ADDRESS } from '../../modules/validators/ownable'
 import type { AccountAdapter } from '../adapter'
-import { type DeploymentMaterial, deploymentPlan } from '../deployment'
+import {
+  type DeploymentMaterial,
+  deploymentPlan,
+  NEXUS_SALT_DEFAULTS,
+  selectedValue,
+} from '../deployment'
 import { encodeErc7579Calls } from '../erc7579-calls'
 import type { AccountConstruction } from '../types'
 import {
@@ -110,10 +114,7 @@ export function nexusMaterial(
     const deployment = getNexusDeployment(version)
     factory = deployment.factory
     implementation = deployment.implementation
-    salt =
-      input.account.salt.source === 'explicit'
-        ? input.account.salt.value
-        : keccak256('0x')
+    salt = selectedValue(input.account.salt, NEXUS_SALT_DEFAULTS)
     const defaultValidator = input.setup.validators.find(
       (module) => module.address === OWNABLE_VALIDATOR_ADDRESS,
     )

--- a/src/accounts/adapters/safe.ts
+++ b/src/accounts/adapters/safe.ts
@@ -14,7 +14,12 @@ import {
 } from 'viem'
 import { getV0Attesters } from '../../modules/legacy-core'
 import type { AccountAdapter } from '../adapter'
-import { type DeploymentMaterial, deploymentPlan } from '../deployment'
+import {
+  type DeploymentMaterial,
+  deploymentPlan,
+  SAFE_NONCE_DEFAULTS,
+  selectedValue,
+} from '../deployment'
 import { encodeErc7579Calls } from '../erc7579-calls'
 import type { AccountConstruction } from '../types'
 import {
@@ -111,8 +116,7 @@ function safeMaterial(input: AccountConstruction): DeploymentMaterial {
         zeroAddress,
       ],
     })
-    const nonce =
-      input.account.nonce.source === 'explicit' ? input.account.nonce.value : 0n
+    const nonce = selectedValue(input.account.nonce, SAFE_NONCE_DEFAULTS)
     factoryData = encodeFunctionData({
       abi: parseAbi([
         'function createProxyWithNonce(address singleton,bytes initializer,uint256 saltNonce)',
@@ -185,8 +189,7 @@ export function safeV0FactoryMaterial(
       zeroAddress,
     ],
   })
-  const nonce =
-    input.account.nonce.source === 'explicit' ? input.account.nonce.value : 0n
+  const nonce = selectedValue(input.account.nonce, SAFE_NONCE_DEFAULTS)
   return {
     factory: SAFE_FACTORY,
     factoryData: encodeFunctionData({

--- a/src/accounts/adapters/startale.ts
+++ b/src/accounts/adapters/startale.ts
@@ -15,7 +15,12 @@ import {
 import type { ModuleSetup } from '../../modules/types'
 import { K1_DEFAULT_VALIDATOR_ADDRESS } from '../../modules/validators/k1'
 import type { AccountAdapter } from '../adapter'
-import { type DeploymentMaterial, deploymentPlan } from '../deployment'
+import {
+  type DeploymentMaterial,
+  deploymentPlan,
+  STARTALE_SALT_DEFAULTS,
+  selectedValue,
+} from '../deployment'
 import { encodeErc7579Calls } from '../erc7579-calls'
 import type { AccountConstruction } from '../types'
 import {
@@ -133,10 +138,7 @@ function startaleMaterial(input: AccountConstruction): DeploymentMaterial {
       return { address: input.initData.address }
     }
   } else {
-    salt =
-      input.account.salt.source === 'explicit'
-        ? input.account.salt.value
-        : zeroHash
+    salt = selectedValue(input.account.salt, STARTALE_SALT_DEFAULTS)
     const initData = startaleInitData(input)
     factoryData = encodeFunctionData({
       abi: parseAbi(['function createAccount(bytes,bytes32)']),

--- a/src/accounts/construction.test.ts
+++ b/src/accounts/construction.test.ts
@@ -1,0 +1,270 @@
+import {
+  type Address,
+  decodeAbiParameters,
+  type Hex,
+  keccak256,
+  toHex,
+} from 'viem'
+import { toWebAuthnAccount } from 'viem/account-abstraction'
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, test } from 'vitest'
+import { accountA, passkeyAccount } from '../../test/consts'
+import type { AccountConstructionInput } from '../config/input'
+import { resolveStandaloneAccountConfig } from '../config/resolve'
+import {
+  generateWebauthnCredentialId,
+  parseWebauthnPublicKey,
+} from '../modules/validators/webauthn'
+import { createAccountConstruction } from './construction'
+import { createAccountAdapter } from './registry'
+import type { AccountConstruction } from './types'
+
+const CHAIN = { kind: 'evm', id: 1, caip2: 'eip155:1' } as const
+
+function passkey(tag: string) {
+  return toWebAuthnAccount({
+    credential: {
+      id: tag,
+      publicKey: `0x${keccak256(toHex(`x:${tag}`)).slice(2)}${keccak256(toHex(`y:${tag}`)).slice(2)}`,
+    },
+  })
+}
+
+function construct(input: AccountConstructionInput): AccountConstruction {
+  const resolved = resolveStandaloneAccountConfig(input, 'current-v2')
+  return createAccountConstruction({
+    material: {
+      account: resolved.account,
+      ...(resolved.owners ? { owner: resolved.owners } : {}),
+      modules: resolved.modules,
+      ...(resolved.initData ? { initData: resolved.initData } : {}),
+      ...(resolved.eoa ? { eoa: resolved.eoa } : {}),
+      sessions: {
+        enabled: resolved.sessions.enabled,
+        environment: resolved.sessions.environment,
+      },
+    },
+    chain: CHAIN,
+    deployed: false,
+  })
+}
+
+function deployment(input: AccountConstructionInput): {
+  readonly address: Address
+  readonly factoryData: Hex | undefined
+} {
+  const construction = construct(input)
+  const plan =
+    createAccountAdapter(construction).getDeploymentPlan(construction)
+  return { address: plan.address, factoryData: plan.factoryData }
+}
+
+function installedCredentials(validator: { readonly initData: Hex }) {
+  return decodeAbiParameters(
+    [
+      { name: 'threshold', type: 'uint256' },
+      {
+        name: 'credentials',
+        type: 'tuple[]',
+        components: [
+          { name: 'pubKeyX', type: 'uint256' },
+          { name: 'pubKeyY', type: 'uint256' },
+          { name: 'requireUV', type: 'bool' },
+        ],
+      },
+    ],
+    validator.initData,
+  )[1]
+}
+
+function credentialIds(
+  accounts: readonly { publicKey: Hex }[],
+  address: Address,
+): readonly Hex[] {
+  return accounts.map((account) => {
+    const key = parseWebauthnPublicKey(account.publicKey)
+    return generateWebauthnCredentialId(key.x, key.y, address)
+  })
+}
+
+function installable(
+  accounts: readonly { publicKey: Hex }[],
+  address: Address,
+): boolean {
+  // The order the validator sees is canonical (by public key), so that is the
+  // order whose credential IDs must be strictly ascending.
+  const canonical = [...accounts].sort((left, right) => {
+    const a = parseWebauthnPublicKey(left.publicKey)
+    const b = parseWebauthnPublicKey(right.publicKey)
+    if (a.x !== b.x) return a.x < b.x ? -1 : 1
+    return a.y < b.y ? -1 : 1
+  })
+  const ids = credentialIds(canonical, address)
+  return ids.every(
+    (id, index) => index === 0 || BigInt(ids[index - 1]) < BigInt(id),
+  )
+}
+
+describe('passkey account construction', () => {
+  test('derives the same address for every ordering of the same passkey set', () => {
+    const accounts = [passkey('a'), passkey('b'), passkey('c')]
+    const derived = [
+      accounts,
+      [...accounts].reverse(),
+      [accounts[1], accounts[2], accounts[0]],
+    ].map((order) =>
+      deployment({
+        account: { type: 'nexus' },
+        owners: { type: 'passkey', accounts: order },
+      }),
+    )
+    expect(new Set(derived.map((entry) => entry.address)).size).toBe(1)
+    expect(new Set(derived.map((entry) => entry.factoryData)).size).toBe(1)
+  })
+
+  test('derived addresses accept the credential set the validator installs', () => {
+    for (let index = 0; index < 25; index++) {
+      for (const size of [2, 3]) {
+        const accounts = Array.from({ length: size }, (_, key) =>
+          passkey(`set:${index}:${key}`),
+        )
+        const { address } = deployment({
+          account: { type: 'nexus' },
+          owners: { type: 'passkey', accounts },
+        })
+        expect(installable(accounts, address)).toBe(true)
+      }
+    }
+  })
+
+  test('installs cleanly across account kinds', () => {
+    const accounts = [passkey('kind:a'), passkey('kind:b')]
+    for (const account of [
+      { type: 'nexus' },
+      { type: 'kernel' },
+      { type: 'startale' },
+      { type: 'safe' },
+    ] as const) {
+      const { address } = deployment({
+        account,
+        owners: { type: 'passkey', accounts },
+      })
+      expect(installable(accounts, address)).toBe(true)
+    }
+  })
+
+  test('is reproducible across repeated derivations and chains', () => {
+    const accounts = [passkey('repeat:a'), passkey('repeat:b')]
+    const owners = { type: 'passkey', accounts } as const
+    const first = deployment({ account: { type: 'nexus' }, owners })
+    const second = deployment({ account: { type: 'nexus' }, owners })
+    const resolved = resolveStandaloneAccountConfig(
+      { account: { type: 'nexus' }, owners },
+      'current-v2',
+    )
+    const onAnotherChain = createAccountConstruction({
+      material: {
+        account: resolved.account,
+        owner: resolved.owners,
+        modules: resolved.modules,
+        sessions: { enabled: false, environment: 'production' },
+      },
+      chain: { kind: 'evm', id: 8453, caip2: 'eip155:8453' },
+      deployed: true,
+    })
+    expect(second).toEqual(first)
+    expect(onAnotherChain.account).toEqual(
+      construct({
+        account: { type: 'nexus' },
+        owners,
+      }).account,
+    )
+  })
+
+  test('keeps single-passkey, ECDSA and multi-factor derivations unchanged', () => {
+    const single = deployment({
+      account: { type: 'nexus' },
+      owners: { type: 'passkey', accounts: [passkeyAccount] },
+    })
+    expect(single.address).toBe('0x68484B775e4a2828A50C7404ce8530f146d5598e')
+    expect(
+      deployment({
+        account: { type: 'nexus' },
+        owners: { type: 'ecdsa', accounts: [accountA] },
+      }).address,
+    ).toBe('0xc02C600Bd93e6C86aE2Ed1D418B87Fe225171E74')
+    expect(
+      deployment({
+        account: { type: 'nexus' },
+        owners: {
+          type: 'multi-factor',
+          validators: [
+            { type: 'ecdsa', accounts: [accountA] },
+            { type: 'passkey', accounts: [passkey('mfa:a'), passkey('mfa:b')] },
+          ],
+        },
+      }).address,
+    ).toBe('0x3636f63cC6b3B68AbEEB39b7b9317896597f8bb8')
+  })
+
+  test('keeps the caller salt when it already installs', () => {
+    const accounts = [passkey('salt:a'), passkey('salt:b')]
+    const { address } = deployment({
+      account: { type: 'nexus' },
+      owners: { type: 'passkey', accounts },
+    })
+    const withExplicitSalt = deployment({
+      account: { type: 'nexus', salt: keccak256('0x') },
+      owners: { type: 'passkey', accounts },
+    })
+    expect(withExplicitSalt.address).toBe(address)
+  })
+
+  test('orders credentials against a fixed address instead of searching', () => {
+    const eoa = privateKeyToAccount(keccak256(toHex('eoa:7702')))
+    const accounts = [passkey('7702:a'), passkey('7702:b')]
+    const construction = construct({
+      account: { type: 'nexus' },
+      eoa,
+      owners: { type: 'passkey', accounts },
+    })
+    // The address is the EOA's, so the salt must not move.
+    expect(construction.account).toEqual(
+      resolveStandaloneAccountConfig(
+        { account: { type: 'nexus' }, owners: { type: 'passkey', accounts } },
+        'current-v2',
+      ).account,
+    )
+    const installed = installedCredentials(construction.setup.validators[0])
+    const ids = installed.map((credential) =>
+      generateWebauthnCredentialId(
+        credential.pubKeyX,
+        credential.pubKeyY,
+        eoa.address,
+      ),
+    )
+    expect(ids.length).toBe(2)
+    expect(BigInt(ids[0])).toBeLessThan(BigInt(ids[1]))
+  })
+
+  test('rejects duplicate passkeys and oversized deployment sets', () => {
+    const duplicate = passkey('dupe')
+    expect(() =>
+      deployment({
+        account: { type: 'nexus' },
+        owners: { type: 'passkey', accounts: [duplicate, duplicate] },
+      }),
+    ).toThrow('duplicate passkeys')
+    expect(() =>
+      deployment({
+        account: { type: 'nexus' },
+        owners: {
+          type: 'passkey',
+          accounts: Array.from({ length: 7 }, (_, index) =>
+            passkey(`many:${index}`),
+          ),
+        },
+      }),
+    ).toThrow('passkeys.addOwner')
+  })
+})

--- a/src/accounts/construction.ts
+++ b/src/accounts/construction.ts
@@ -1,9 +1,24 @@
-import type { Account } from 'viem'
+import { type Account, type Hex, keccak256, stringToHex } from 'viem'
 import type { EvmChainReference } from '../chains/types'
 import { planModuleSetup } from '../modules/plan'
 import type { ConfiguredModule, ModuleSetup } from '../modules/types'
 import { resolveValidator } from '../modules/validators/resolve'
-import type { ResolvedValidatorDefinition } from '../modules/validators/types'
+import type {
+  AtomicValidatorDefinition,
+  ResolvedValidatorDefinition,
+} from '../modules/validators/types'
+import {
+  orderWebauthnCredentials,
+  toWebauthnInstallCredentials,
+  type WebauthnCredentialOrdering,
+  webauthnDefinitionCredentials,
+} from '../modules/validators/webauthn'
+import {
+  accountSupportsSaltSearch,
+  assertPasskeySetInstallable,
+  selectPasskeyAccount,
+} from './passkey-install'
+import { createAccountAdapter } from './registry'
 import type {
   AccountConstruction,
   AccountDefinition,
@@ -24,41 +39,100 @@ export interface AccountConstructionMaterial {
   }
 }
 
+function passkeyOwner(
+  owner: ResolvedValidatorDefinition | undefined,
+): AtomicValidatorDefinition | undefined {
+  return owner?.kind === 'passkey' ? owner : undefined
+}
+
+function setupFingerprint(input: {
+  readonly account: AccountDefinition
+  readonly setup: ModuleSetup
+}): Hex {
+  return keccak256(
+    stringToHex(
+      JSON.stringify(input, (_key, value) =>
+        typeof value === 'bigint' ? `${value}n` : value,
+      ),
+    ),
+  )
+}
+
 export function createAccountConstruction(input: {
   readonly material: AccountConstructionMaterial
   readonly chain: EvmChainReference
   readonly deployed: boolean
   readonly setup?: ModuleSetup
 }): AccountConstruction {
-  const ownerModule = input.material.owner
-    ? resolveValidator(input.material.owner)
+  const material = input.material
+  const passkey = passkeyOwner(material.owner)
+  // Caller-pinned init data carrying a factory is used verbatim, so neither the
+  // credential order nor the salt has any effect on the deployed account.
+  const pinned =
+    material.initData !== undefined && 'factory' in material.initData
+  const knownAddress = material.eoa?.address ?? material.initData?.address
+  const credentials =
+    passkey && !pinned
+      ? toWebauthnInstallCredentials(webauthnDefinitionCredentials(passkey))
+      : undefined
+  const searchable =
+    credentials !== undefined &&
+    credentials.length > 1 &&
+    knownAddress === undefined &&
+    accountSupportsSaltSearch(material.account)
+  if (credentials && (knownAddress !== undefined || searchable)) {
+    assertPasskeySetInstallable({ credentials, atDeployment: searchable })
+  }
+  const ordering: WebauthnCredentialOrdering | undefined = knownAddress
+    ? // The address is already fixed (EIP-7702 adoption or a caller-supplied
+      // address), so the exact order the validator requires is computable.
+      { kind: 'credential-id', account: knownAddress }
+    : searchable
+      ? { kind: 'canonical' }
+      : undefined
+  const ownerModule = material.owner
+    ? resolveValidator(material.owner, ordering)
     : undefined
-  if (!ownerModule && input.material.account.kind !== 'eoa') {
+  if (!ownerModule && material.account.kind !== 'eoa') {
     throw new Error('Smart account owner is required')
   }
   const setup =
     input.setup ??
     (ownerModule
       ? planModuleSetup({
-          accountKind: input.material.account.kind,
+          accountKind: material.account.kind,
           owner: ownerModule,
-          configured: input.material.modules,
-          environment: input.material.sessions.environment,
-          sessions: input.material.sessions,
+          configured: material.modules,
+          environment: material.sessions.environment,
+          sessions: material.sessions,
         })
       : { validators: [], executors: [], hooks: [], fallbacks: [] })
-  return {
-    account: input.material.account,
-    ...(input.material.owner ? { owner: input.material.owner } : {}),
-    modules: input.material.modules,
+  const base: AccountConstruction = {
+    account: material.account,
+    ...(material.owner ? { owner: material.owner } : {}),
+    modules: material.modules,
     setup,
     sessions: {
-      enabled: input.material.sessions.enabled,
-      environment: input.material.sessions.environment,
+      enabled: material.sessions.enabled,
+      environment: material.sessions.environment,
     },
-    ...(input.material.initData ? { initData: input.material.initData } : {}),
-    ...(input.material.eoa ? { eoa: input.material.eoa } : {}),
+    ...(material.initData ? { initData: material.initData } : {}),
+    ...(material.eoa ? { eoa: material.eoa } : {}),
     chain: input.chain,
     deployed: input.deployed,
   }
+  if (!searchable || !credentials) return base
+  // The module setup is salt-independent, so only the account definition varies
+  // across attempts.
+  const account = selectPasskeyAccount({
+    account: material.account,
+    credentials: orderWebauthnCredentials(credentials, { kind: 'canonical' }),
+    fingerprint: setupFingerprint({ account: material.account, setup }),
+    deriveAddress: (candidate) => {
+      const construction = { ...base, account: candidate }
+      return createAccountAdapter(construction).getIdentity(construction)
+        .address
+    },
+  })
+  return { ...base, account }
 }

--- a/src/accounts/deployment.ts
+++ b/src/accounts/deployment.ts
@@ -1,4 +1,4 @@
-import type { Address, Hex } from 'viem'
+import { type Address, type Hex, keccak256, zeroHash } from 'viem'
 import type {
   AccountDefinition,
   AccountDeploymentPlan,
@@ -11,6 +11,17 @@ export interface DeploymentMaterial {
   readonly factory?: Address
   readonly factoryData?: Hex
 }
+
+// Salt/nonce defaults live here rather than in the adapters so the passkey salt
+// search grinds the same values the adapters derive addresses from.
+export const NEXUS_SALT_DEFAULTS = {
+  'nexus-empty-calldata-salt': keccak256('0x'),
+} as const
+export const KERNEL_SALT_DEFAULTS = { 'kernel-zero-salt': zeroHash } as const
+export const STARTALE_SALT_DEFAULTS = {
+  'startale-zero-salt': zeroHash,
+} as const
+export const SAFE_NONCE_DEFAULTS = { 'safe-zero-nonce': 0n } as const
 
 export function selectedValue<Value, Profile extends string>(
   selection: AccountValueSelection<Value, Profile>,

--- a/src/accounts/error.ts
+++ b/src/accounts/error.ts
@@ -196,6 +196,18 @@ class OwnersFieldRequiredError extends AccountError {
   }
 }
 
+class PasskeyConfigurationNotInstallableError extends AccountError {
+  constructor(
+    reason: string,
+    params?: { context?: any; errorType?: string; traceId?: string },
+  ) {
+    super({
+      message: `Passkey owner set cannot be installed on a new account: ${reason}`,
+      ...params,
+    })
+  }
+}
+
 class Eip712DomainNotAvailableError extends AccountError {
   constructor(message: string) {
     super({
@@ -241,4 +253,5 @@ export {
   EoaSigningNotSupportedError,
   EoaSigningMethodNotConfiguredError,
   OwnersFieldRequiredError,
+  PasskeyConfigurationNotInstallableError,
 }

--- a/src/accounts/passkey-install.test.ts
+++ b/src/accounts/passkey-install.test.ts
@@ -1,0 +1,168 @@
+import { type Address, keccak256, toHex } from 'viem'
+import { describe, expect, test } from 'vitest'
+import type { WebauthnInstallCredential } from '../modules/validators/webauthn'
+import { webauthnCredentialsAreAscending } from '../modules/validators/webauthn'
+import { PasskeyConfigurationNotInstallableError } from './error'
+import {
+  accountSupportsSaltSearch,
+  accountWithSaltAttempt,
+  assertPasskeySetInstallable,
+  MAX_DEPLOYMENT_PASSKEYS,
+  selectPasskeyAccount,
+} from './passkey-install'
+import type { AccountDefinition } from './types'
+
+const nexus: AccountDefinition = {
+  kind: 'nexus',
+  version: { source: 'default', profile: 'nexus-current-version' },
+  salt: { source: 'default', profile: 'nexus-empty-calldata-salt' },
+}
+const safe: AccountDefinition = {
+  kind: 'safe',
+  version: { source: 'default', profile: 'safe-current-version' },
+  adapter: { source: 'default', profile: 'safe-current-adapter' },
+  nonce: { source: 'default', profile: 'safe-zero-nonce' },
+}
+
+function credentials(count: number): WebauthnInstallCredential[] {
+  return Array.from({ length: count }, (_, index) => ({
+    pubKeyX: BigInt(keccak256(toHex(`x:${index}`))),
+    pubKeyY: BigInt(keccak256(toHex(`y:${index}`))),
+    requireUV: false,
+  }))
+}
+
+// Stands in for the account adapters: a deterministic address per candidate
+// definition, so the search logic is exercised without deriving real accounts.
+function fakeAddress(account: AccountDefinition): Address {
+  const salt =
+    account.kind === 'nexus' && account.salt.source === 'explicit'
+      ? account.salt.value
+      : account.kind === 'safe' && account.nonce.source === 'explicit'
+        ? toHex(account.nonce.value, { size: 32 })
+        : toHex(0, { size: 32 })
+  return `0x${keccak256(salt).slice(26)}`
+}
+
+describe('passkey install selection', () => {
+  test('attempt zero keeps the caller salt and later attempts are deterministic', () => {
+    expect(accountWithSaltAttempt(nexus, 0)).toBe(nexus)
+    const first = accountWithSaltAttempt(nexus, 1)
+    expect(first).toEqual(accountWithSaltAttempt(nexus, 1))
+    expect(first).not.toEqual(accountWithSaltAttempt(nexus, 2))
+    if (first.kind !== 'nexus' || first.salt.source !== 'explicit') {
+      throw new Error('expected an explicit nexus salt')
+    }
+    const explicit = accountWithSaltAttempt(
+      { ...nexus, salt: { source: 'explicit', value: keccak256('0x') } },
+      1,
+    )
+    expect(explicit).toEqual(first)
+
+    for (const account of [
+      {
+        kind: 'kernel',
+        version: { source: 'default', profile: 'kernel-current-version' },
+        salt: { source: 'default', profile: 'kernel-zero-salt' },
+      },
+      {
+        kind: 'startale',
+        salt: { source: 'default', profile: 'startale-zero-salt' },
+      },
+    ] as const satisfies readonly AccountDefinition[]) {
+      const attempt = accountWithSaltAttempt(account, 1)
+      if (attempt.kind === 'hca' || attempt.kind === 'eoa') {
+        throw new Error('expected a salted account')
+      }
+      expect(attempt).toEqual(accountWithSaltAttempt(account, 1))
+      expect(attempt).not.toEqual(account)
+    }
+
+    const safeAttempt = accountWithSaltAttempt(safe, 3)
+    if (
+      safeAttempt.kind !== 'safe' ||
+      safeAttempt.nonce.source !== 'explicit'
+    ) {
+      throw new Error('expected an explicit safe nonce')
+    }
+    expect(safeAttempt.nonce.value).toBeGreaterThan(0n)
+  })
+
+  test('accounts without a salt knob cannot be searched', () => {
+    const hca: AccountDefinition = {
+      kind: 'hca',
+      factory: { source: 'default', profile: 'hca-canonical-factory' },
+    }
+    expect(accountSupportsSaltSearch(hca)).toBe(false)
+    expect(accountSupportsSaltSearch({ kind: 'eoa' })).toBe(false)
+    expect(accountSupportsSaltSearch(nexus)).toBe(true)
+    expect(() => accountWithSaltAttempt(hca, 1)).toThrow(
+      PasskeyConfigurationNotInstallableError,
+    )
+  })
+
+  test('rejects duplicates and oversized deployment sets', () => {
+    const [single] = credentials(1)
+    expect(() =>
+      assertPasskeySetInstallable({
+        credentials: [single, single],
+        atDeployment: true,
+      }),
+    ).toThrow('duplicate passkeys')
+    expect(() =>
+      assertPasskeySetInstallable({
+        credentials: credentials(MAX_DEPLOYMENT_PASSKEYS + 1),
+        atDeployment: true,
+      }),
+    ).toThrow('passkeys.addOwner')
+    expect(() =>
+      assertPasskeySetInstallable({
+        credentials: credentials(MAX_DEPLOYMENT_PASSKEYS + 1),
+        atDeployment: false,
+      }),
+    ).not.toThrow()
+    expect(() =>
+      assertPasskeySetInstallable({
+        credentials: credentials(33),
+        atDeployment: false,
+      }),
+    ).toThrow('at most 32 passkeys')
+  })
+
+  test('selects a salt whose address makes the set ascending', () => {
+    const set = credentials(3)
+    const selected = selectPasskeyAccount({
+      account: nexus,
+      credentials: set,
+      fingerprint: keccak256(toHex('select')),
+      deriveAddress: fakeAddress,
+    })
+    expect(webauthnCredentialsAreAscending(set, fakeAddress(selected))).toBe(
+      true,
+    )
+    // Same inputs, same choice — the search must not depend on run order.
+    expect(
+      selectPasskeyAccount({
+        account: nexus,
+        credentials: set,
+        fingerprint: keccak256(toHex('select:repeat')),
+        deriveAddress: fakeAddress,
+      }),
+    ).toEqual(selected)
+  })
+
+  test('throws when no attempt in the budget installs the set', () => {
+    const [duplicate] = credentials(1)
+    expect(() =>
+      selectPasskeyAccount({
+        account: nexus,
+        // No address makes the same credential ascending against itself, so the
+        // search runs out of attempts.
+        credentials: [duplicate, duplicate],
+        fingerprint: keccak256(toHex('exhausted')),
+        deriveAddress: fakeAddress,
+        maxAttempts: 64,
+      }),
+    ).toThrow(PasskeyConfigurationNotInstallableError)
+  })
+})

--- a/src/accounts/passkey-install.ts
+++ b/src/accounts/passkey-install.ts
@@ -1,0 +1,169 @@
+import { type Address, encodeAbiParameters, type Hex, keccak256 } from 'viem'
+import {
+  hasDuplicateWebauthnCredentials,
+  type WebauthnInstallCredential,
+  webauthnCredentialsAreAscending,
+} from '../modules/validators/webauthn'
+import {
+  KERNEL_SALT_DEFAULTS,
+  NEXUS_SALT_DEFAULTS,
+  SAFE_NONCE_DEFAULTS,
+  STARTALE_SALT_DEFAULTS,
+  selectedValue,
+} from './deployment'
+import { PasskeyConfigurationNotInstallableError } from './error'
+import type { AccountDefinition } from './types'
+
+// The validator's install data must list credentials with strictly ascending
+// `keccak(x, y, account)`, so the number of salts that have to be tried grows
+// with the factorial of the credential count. Six passkeys is ~0.2s of
+// synchronous work in the worst realistic case; beyond that the remaining
+// passkeys are added after deployment, which the validator accepts in any order.
+export const MAX_DEPLOYMENT_PASSKEYS = 6
+// The validator's own `MAX_CREDENTIALS`.
+export const MAX_PASSKEY_CREDENTIALS = 32
+// A fixed attempt count, never a wall-clock budget: a slower host must derive
+// the same address as a faster one.
+export const MAX_PASSKEY_SALT_ATTEMPTS = 65_536
+
+const MEMO_LIMIT = 256
+const memo = new Map<Hex, AccountDefinition>()
+
+export function accountSupportsSaltSearch(account: AccountDefinition): boolean {
+  return (
+    account.kind === 'nexus' ||
+    account.kind === 'kernel' ||
+    account.kind === 'startale' ||
+    account.kind === 'safe'
+  )
+}
+
+function saltAttempt(base: Hex, attempt: number): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [{ type: 'bytes32' }, { type: 'uint256' }],
+      [base, BigInt(attempt)],
+    ),
+  )
+}
+
+// Attempt 0 is the caller's own salt, so a configuration that already installs
+// cleanly keeps the address it derives today.
+export function accountWithSaltAttempt(
+  account: AccountDefinition,
+  attempt: number,
+): AccountDefinition {
+  if (attempt === 0) return account
+  switch (account.kind) {
+    case 'nexus':
+      return {
+        ...account,
+        salt: {
+          source: 'explicit',
+          value: saltAttempt(
+            selectedValue(account.salt, NEXUS_SALT_DEFAULTS),
+            attempt,
+          ),
+        },
+      }
+    case 'kernel':
+      return {
+        ...account,
+        salt: {
+          source: 'explicit',
+          value: saltAttempt(
+            selectedValue(account.salt, KERNEL_SALT_DEFAULTS),
+            attempt,
+          ),
+        },
+      }
+    case 'startale':
+      return {
+        ...account,
+        salt: {
+          source: 'explicit',
+          value: saltAttempt(
+            selectedValue(account.salt, STARTALE_SALT_DEFAULTS),
+            attempt,
+          ),
+        },
+      }
+    case 'safe': {
+      const nonce = selectedValue(account.nonce, SAFE_NONCE_DEFAULTS)
+      return {
+        ...account,
+        nonce: {
+          source: 'explicit',
+          value: BigInt(
+            keccak256(
+              encodeAbiParameters(
+                [{ type: 'uint256' }, { type: 'uint256' }],
+                [nonce, BigInt(attempt)],
+              ),
+            ),
+          ),
+        },
+      }
+    }
+    case 'hca':
+    case 'eoa':
+      throw new PasskeyConfigurationNotInstallableError(
+        `${account.kind} accounts have no salt to search`,
+      )
+  }
+}
+
+export function assertPasskeySetInstallable(input: {
+  readonly credentials: readonly WebauthnInstallCredential[]
+  readonly atDeployment: boolean
+}): void {
+  if (hasDuplicateWebauthnCredentials(input.credentials)) {
+    throw new PasskeyConfigurationNotInstallableError(
+      'the owner set contains duplicate passkeys',
+    )
+  }
+  if (input.credentials.length > MAX_PASSKEY_CREDENTIALS) {
+    throw new PasskeyConfigurationNotInstallableError(
+      `the WebAuthn validator supports at most ${MAX_PASSKEY_CREDENTIALS} passkeys, received ${input.credentials.length}`,
+    )
+  }
+  if (
+    input.atDeployment &&
+    input.credentials.length > MAX_DEPLOYMENT_PASSKEYS
+  ) {
+    throw new PasskeyConfigurationNotInstallableError(
+      `at most ${MAX_DEPLOYMENT_PASSKEYS} passkeys can be installed at deployment, received ${input.credentials.length}. Deploy with ${MAX_DEPLOYMENT_PASSKEYS} or fewer and add the rest with \`passkeys.addOwner\``,
+    )
+  }
+}
+
+/**
+ * Picks the account salt whose derived address makes the (canonically ordered)
+ * passkey set installable. Deterministic: the same inputs select the same salt
+ * on every host and in every run.
+ */
+export function selectPasskeyAccount(input: {
+  readonly account: AccountDefinition
+  readonly credentials: readonly WebauthnInstallCredential[]
+  readonly fingerprint: Hex
+  readonly deriveAddress: (account: AccountDefinition) => Address
+  // Test seam only: production callers must use the fixed budget so a slower
+  // host cannot derive a different address.
+  readonly maxAttempts?: number
+}): AccountDefinition {
+  const cached = memo.get(input.fingerprint)
+  if (cached) return cached
+  const maxAttempts = input.maxAttempts ?? MAX_PASSKEY_SALT_ATTEMPTS
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const candidate = accountWithSaltAttempt(input.account, attempt)
+    const address = input.deriveAddress(candidate)
+    if (webauthnCredentialsAreAscending(input.credentials, address)) {
+      if (memo.size >= MEMO_LIMIT) memo.clear()
+      memo.set(input.fingerprint, candidate)
+      return candidate
+    }
+  }
+  throw new PasskeyConfigurationNotInstallableError(
+    `no account salt in ${maxAttempts} attempts installs these ${input.credentials.length} passkeys. Deploy with fewer passkeys and add the rest with \`passkeys.addOwner\``,
+  )
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -12,6 +12,7 @@ import {
   isAccountError,
   ModuleInstallationNotSupportedError,
   OwnersFieldRequiredError,
+  PasskeyConfigurationNotInstallableError,
   SigningNotSupportedForAccountError,
   WalletClientNoConnectedAccountError,
 } from '../accounts/error'
@@ -80,6 +81,7 @@ export {
   FactoryArgsNotAvailableError,
   ModuleInstallationNotSupportedError,
   OwnersFieldRequiredError,
+  PasskeyConfigurationNotInstallableError,
   SigningNotSupportedForAccountError,
   WalletClientNoConnectedAccountError,
   // Execution

--- a/src/modules/validators/resolve.ts
+++ b/src/modules/validators/resolve.ts
@@ -6,10 +6,14 @@ import type {
   AtomicValidatorDefinition,
   ResolvedValidatorDefinition,
 } from './types'
-import { resolveWebauthnValidator } from './webauthn'
+import {
+  resolveWebauthnValidator,
+  type WebauthnCredentialOrdering,
+} from './webauthn'
 
 export function resolveAtomicValidator(
   definition: AtomicValidatorDefinition,
+  webauthnOrdering?: WebauthnCredentialOrdering,
 ): ResolvedModule {
   switch (definition.kind) {
     case 'ecdsa':
@@ -17,17 +21,21 @@ export function resolveAtomicValidator(
     case 'ens':
       return resolveEnsValidator(definition)
     case 'passkey':
-      return resolveWebauthnValidator(definition)
+      return resolveWebauthnValidator(definition, webauthnOrdering)
     case 'k1':
     case 'smart-session':
       throw new Error(`Validator ${definition.kind} requires feature input`)
   }
 }
 
+// `webauthnOrdering` only applies to a top-level passkey validator: multi-factor
+// stores its sub-validator data without ever calling the sub-validator's
+// `onInstall`, so the ascending rule never runs and its bytes must not move.
 export function resolveValidator(
   definition: ResolvedValidatorDefinition,
+  webauthnOrdering?: WebauthnCredentialOrdering,
 ): ResolvedModule {
   return definition.kind === 'multi-factor'
     ? resolveMultiFactorValidator(definition, resolveAtomicValidator)
-    : resolveAtomicValidator(definition)
+    : resolveAtomicValidator(definition, webauthnOrdering)
 }

--- a/src/modules/validators/webauthn.test.ts
+++ b/src/modules/validators/webauthn.test.ts
@@ -1,0 +1,139 @@
+import { type Address, decodeAbiParameters, keccak256, toHex } from 'viem'
+import { describe, expect, test } from 'vitest'
+import {
+  generateWebauthnCredentialId,
+  hasDuplicateWebauthnCredentials,
+  orderWebauthnCredentials,
+  resolveWebauthnCredentials,
+  type WebauthnInstallCredential,
+  webauthnCredentialsAreAscending,
+} from './webauthn'
+
+const ACCOUNT: Address = '0x44C3Ec6c98f39Fb0a406ea2A948f923E60aF80C5'
+
+function credential(x: bigint, y: bigint): WebauthnInstallCredential {
+  return { pubKeyX: x, pubKeyY: y, requireUV: false }
+}
+
+function publicKeyBytes(tag: string): `0x${string}` {
+  return `0x${keccak256(toHex(`x:${tag}`)).slice(2)}${keccak256(toHex(`y:${tag}`)).slice(2)}`
+}
+
+function installedCredentials(initData: `0x${string}`) {
+  return decodeAbiParameters(
+    [
+      { name: 'threshold', type: 'uint256' },
+      {
+        name: 'credentials',
+        type: 'tuple[]',
+        components: [
+          { name: 'pubKeyX', type: 'uint256' },
+          { name: 'pubKeyY', type: 'uint256' },
+          { name: 'requireUV', type: 'bool' },
+        ],
+      },
+    ],
+    initData,
+  )[1]
+}
+
+describe('WebAuthn credential ordering', () => {
+  test('canonical ordering is by public key value and permutation independent', () => {
+    const credentials = [
+      credential(3n, 1n),
+      credential(1n, 9n),
+      credential(1n, 2n),
+    ]
+    const canonical = orderWebauthnCredentials(credentials, {
+      kind: 'canonical',
+    })
+    expect(canonical.map((entry) => [entry.pubKeyX, entry.pubKeyY])).toEqual([
+      [1n, 2n],
+      [1n, 9n],
+      [3n, 1n],
+    ])
+    expect(
+      orderWebauthnCredentials([...credentials].reverse(), {
+        kind: 'canonical',
+      }),
+    ).toEqual(canonical)
+  })
+
+  test('credential-id ordering matches the validator ascending rule', () => {
+    const credentials = [
+      credential(11n, 12n),
+      credential(13n, 14n),
+      credential(15n, 16n),
+    ]
+    const ordered = orderWebauthnCredentials(credentials, {
+      kind: 'credential-id',
+      account: ACCOUNT,
+    })
+    expect(webauthnCredentialsAreAscending(ordered, ACCOUNT)).toBe(true)
+    const ids = ordered.map((entry) =>
+      generateWebauthnCredentialId(entry.pubKeyX, entry.pubKeyY, ACCOUNT),
+    )
+    expect([...ids].sort()).toEqual(ids)
+  })
+
+  test('ascending predicate rejects unsorted and duplicate credentials', () => {
+    const first = credential(11n, 12n)
+    const second = credential(13n, 14n)
+    const ascending = orderWebauthnCredentials([first, second], {
+      kind: 'credential-id',
+      account: ACCOUNT,
+    })
+    expect(webauthnCredentialsAreAscending(ascending, ACCOUNT)).toBe(true)
+    expect(
+      webauthnCredentialsAreAscending([...ascending].reverse(), ACCOUNT),
+    ).toBe(false)
+    expect(webauthnCredentialsAreAscending([first, first], ACCOUNT)).toBe(false)
+    expect(hasDuplicateWebauthnCredentials([first, second, first])).toBe(true)
+    expect(hasDuplicateWebauthnCredentials([first, second])).toBe(false)
+  })
+
+  test('the same key sorts identically in compressed and uncompressed form', () => {
+    const raw = publicKeyBytes('a')
+    const other = publicKeyBytes('b')
+    const asProvided = resolveWebauthnCredentials({
+      credentials: [
+        { pubKey: raw, authenticatorId: 'a' },
+        { pubKey: other, authenticatorId: 'b' },
+      ],
+      threshold: 1,
+      ordering: { kind: 'canonical' },
+    })
+    const prefixed = resolveWebauthnCredentials({
+      credentials: [
+        { pubKey: `0x04${other.slice(2)}`, authenticatorId: 'b' },
+        { pubKey: `0x04${raw.slice(2)}`, authenticatorId: 'a' },
+      ],
+      threshold: 1,
+      ordering: { kind: 'canonical' },
+    })
+    expect(prefixed.initData).toBe(asProvided.initData)
+  })
+
+  test('resolution keeps the caller order unless an ordering is requested', () => {
+    const credentials = [
+      { pubKey: publicKeyBytes('high'), authenticatorId: 'high' },
+      { pubKey: publicKeyBytes('low'), authenticatorId: 'low' },
+    ]
+    const asProvided = installedCredentials(
+      resolveWebauthnCredentials({ credentials, threshold: 1 }).initData,
+    )
+    const canonical = installedCredentials(
+      resolveWebauthnCredentials({
+        credentials,
+        threshold: 1,
+        ordering: { kind: 'canonical' },
+      }).initData,
+    )
+    expect(asProvided.map((entry) => entry.pubKeyX)).toEqual(
+      credentials.map((entry) => BigInt(entry.pubKey.slice(0, 66))),
+    )
+    expect(
+      [...canonical].sort((a, b) => (a.pubKeyX < b.pubKeyX ? -1 : 1)),
+    ).toEqual([...canonical])
+  })
+})

--- a/src/modules/validators/webauthn.ts
+++ b/src/modules/validators/webauthn.ts
@@ -261,12 +261,26 @@ export function encodeWebauthnValidatorContribution(input: {
   )
 }
 
-export function resolveWebauthnCredentials(input: {
-  readonly credentials: readonly WebauthnCredential[]
-  readonly threshold: number
-  readonly address?: `0x${string}`
-}): ResolvedModule {
-  const credentials = input.credentials.map((credential) => {
+export interface WebauthnInstallCredential {
+  readonly pubKeyX: bigint
+  readonly pubKeyY: bigint
+  readonly requireUV: boolean
+}
+
+// How the credentials are laid out in the validator's install data. The
+// validator requires `keccak(x, y, account)` strictly ascending, but that order
+// depends on the account address, which depends on the install data — so the
+// address-independent `canonical` order is what the salt search grinds against,
+// and `credential-id` is only usable once the address is already fixed.
+export type WebauthnCredentialOrdering =
+  | { readonly kind: 'as-provided' }
+  | { readonly kind: 'canonical' }
+  | { readonly kind: 'credential-id'; readonly account: Address }
+
+export function toWebauthnInstallCredentials(
+  credentials: readonly WebauthnCredential[],
+): readonly WebauthnInstallCredential[] {
+  return credentials.map((credential) => {
     const publicKey =
       typeof credential.pubKey === 'object' &&
       !(credential.pubKey instanceof Uint8Array)
@@ -278,6 +292,86 @@ export function resolveWebauthnCredentials(input: {
       requireUV: false,
     }
   })
+}
+
+function comparePublicKeys(
+  left: WebauthnInstallCredential,
+  right: WebauthnInstallCredential,
+): number {
+  if (left.pubKeyX !== right.pubKeyX) {
+    return left.pubKeyX < right.pubKeyX ? -1 : 1
+  }
+  if (left.pubKeyY === right.pubKeyY) return 0
+  return left.pubKeyY < right.pubKeyY ? -1 : 1
+}
+
+export function orderWebauthnCredentials(
+  credentials: readonly WebauthnInstallCredential[],
+  ordering: WebauthnCredentialOrdering,
+): readonly WebauthnInstallCredential[] {
+  switch (ordering.kind) {
+    case 'as-provided':
+      return credentials
+    case 'canonical':
+      return [...credentials].sort(comparePublicKeys)
+    case 'credential-id': {
+      const account = ordering.account
+      return [...credentials].sort((left, right) =>
+        compareHexValues(
+          generateWebauthnCredentialId(left.pubKeyX, left.pubKeyY, account),
+          generateWebauthnCredentialId(right.pubKeyX, right.pubKeyY, account),
+        ),
+      )
+    }
+  }
+}
+
+// The validator's `onInstall` predicate: credential IDs strictly ascending,
+// which also rules out duplicates.
+export function webauthnCredentialsAreAscending(
+  credentials: readonly WebauthnInstallCredential[],
+  account: Address,
+): boolean {
+  let previous: Hex | undefined
+  for (const credential of credentials) {
+    const credentialId = generateWebauthnCredentialId(
+      credential.pubKeyX,
+      credential.pubKeyY,
+      account,
+    )
+    if (
+      previous !== undefined &&
+      compareHexValues(previous, credentialId) >= 0
+    ) {
+      return false
+    }
+    previous = credentialId
+  }
+  return true
+}
+
+export function hasDuplicateWebauthnCredentials(
+  credentials: readonly WebauthnInstallCredential[],
+): boolean {
+  const seen = new Set<string>()
+  for (const credential of credentials) {
+    const key = `${credential.pubKeyX}:${credential.pubKeyY}`
+    if (seen.has(key)) return true
+    seen.add(key)
+  }
+  return false
+}
+
+export function resolveWebauthnCredentials(input: {
+  readonly credentials: readonly WebauthnCredential[]
+  readonly threshold: number
+  readonly address?: `0x${string}`
+  readonly ordering?: WebauthnCredentialOrdering
+}): ResolvedModule {
+  const credentials = orderWebauthnCredentials(
+    toWebauthnInstallCredentials(input.credentials),
+    input.ordering ?? { kind: 'as-provided' },
+  )
   return {
     kind: 'validator',
     address: input.address ?? WEBAUTHN_VALIDATOR_ADDRESS,
@@ -294,17 +388,17 @@ export function resolveWebauthnCredentials(input: {
           ],
         },
       ],
-      [BigInt(input.threshold), credentials],
+      [BigInt(input.threshold), [...credentials]],
     ),
     deInitData: '0x',
     additionalContext: '0x',
   }
 }
 
-export function resolveWebauthnValidator(
+export function webauthnDefinitionCredentials(
   definition: AtomicValidatorDefinition,
-): ResolvedModule {
-  const credentials = definition.owners.map((owner) => {
+): readonly WebauthnCredential[] {
+  return definition.owners.map((owner) => {
     if (owner.kind !== 'webauthn') {
       throw new Error('WebAuthn validator contains a non-WebAuthn owner')
     }
@@ -313,12 +407,19 @@ export function resolveWebauthnValidator(
       authenticatorId: owner.account.id,
     }
   })
+}
+
+export function resolveWebauthnValidator(
+  definition: AtomicValidatorDefinition,
+  ordering?: WebauthnCredentialOrdering,
+): ResolvedModule {
   return resolveWebauthnCredentials({
-    credentials,
+    credentials: webauthnDefinitionCredentials(definition),
     threshold: definition.threshold,
     address:
       definition.module.source === 'explicit'
         ? definition.module.address
         : WEBAUTHN_VALIDATOR_ADDRESS,
+    ...(ordering ? { ordering } : {}),
   })
 }

--- a/test/vectors/accounts/account-deployment.json
+++ b/test/vectors/accounts/account-deployment.json
@@ -41,6 +41,18 @@
       "address": "0x97068bf8c80ba2971a236f55d01becc090d22ef2",
       "factory": "0x358680728dedb552adaa9f5eb5d4395b291cf943",
       "factoryDataHash": "0xc2a5ea9f0f0cd5ca05419494bb1d08eca99190ad4d43d9349e61ae92f4448c09"
+    },
+    {
+      "id": "nexus-passkey-single",
+      "address": "0x68484B775e4a2828A50C7404ce8530f146d5598e",
+      "factory": "0x0000000099d5576c73a3b190dabeeaa0f128ce6b",
+      "factoryDataHash": "0x8a379c1110f143d10cf88de7af5edfac4bacf03f63bc18de412ebd49d157d4e1"
+    },
+    {
+      "id": "nexus-passkey-multi",
+      "address": "0x0fAcFCB27c608DE3530bF7fEd87806c451181119",
+      "factory": "0x0000000099d5576c73a3b190dabeeaa0f128ce6b",
+      "factoryDataHash": "0x3cd697ee5c465154221ebd497183f07ca151a7b3e13d0fd136dff1dce6d6d40e"
     }
   ]
 }

--- a/test/vectors/accounts/account-deployment.test.ts
+++ b/test/vectors/accounts/account-deployment.test.ts
@@ -1,16 +1,24 @@
-import { keccak256 } from 'viem'
+import { keccak256, toHex } from 'viem'
+import { toWebAuthnAccount } from 'viem/account-abstraction'
 import { describe, expect, test } from 'vitest'
+import { createAccountConstruction } from '../../../src/accounts/construction'
 import { createAccountAdapter } from '../../../src/accounts/registry'
-import type { AccountConstruction } from '../../../src/accounts/types'
 import {
   resolveAccountConfig,
   resolveSdkConfig,
 } from '../../../src/config/resolve'
 import { type RhinestoneAccountConfig, RhinestoneSDK } from '../../../src/index'
-import { planModuleSetup } from '../../../src/modules/plan'
-import { resolveValidator } from '../../../src/modules/validators/resolve'
-import { accountA } from '../../consts'
+import { accountA, passkeyAccount } from '../../consts'
 import vector from './account-deployment.json'
+
+function passkey(tag: string) {
+  return toWebAuthnAccount({
+    credential: {
+      id: tag,
+      publicKey: `0x${keccak256(toHex(`x:${tag}`)).slice(2)}${keccak256(toHex(`y:${tag}`)).slice(2)}`,
+    },
+  })
+}
 
 const configurations: Record<string, () => RhinestoneAccountConfig> = {
   'safe-1.4.1-adapter-1': () => ({
@@ -36,6 +44,20 @@ const configurations: Record<string, () => RhinestoneAccountConfig> = {
   hca: () => ({
     account: { type: 'hca' },
     owners: { type: 'ens', owners: [{ account: accountA }] },
+  }),
+  // Regression guard: production passkey accounts install exactly one
+  // credential, and their addresses must not move.
+  'nexus-passkey-single': () => ({
+    account: { type: 'nexus' },
+    owners: { type: 'passkey', accounts: [passkeyAccount] },
+  }),
+  // Multi-passkey addresses come from the deterministic salt search.
+  'nexus-passkey-multi': () => ({
+    account: { type: 'nexus' },
+    owners: {
+      type: 'passkey',
+      accounts: [passkey('vector:a'), passkey('vector:b')],
+    },
   }),
 }
 
@@ -69,7 +91,6 @@ describe('rewritten account adapter deployment vectors', () => {
     if (!configuration) throw new Error(`Missing vector input ${expected.id}`)
     const resolved = resolveAccountConfig(sdk, configuration())
     if (!resolved.owners) throw new Error(`Missing vector owner ${expected.id}`)
-    const owner = resolveValidator(resolved.owners)
     const sessionModule =
       resolved.sessions.module.source === 'explicit'
         ? resolved.sessions.module.address
@@ -78,30 +99,23 @@ describe('rewritten account adapter deployment vectors', () => {
       resolved.sessions.compatibilityFallback.source === 'explicit'
         ? resolved.sessions.compatibilityFallback.address
         : undefined
-    const construction: AccountConstruction = {
-      account: resolved.account,
-      owner: resolved.owners,
-      modules: resolved.modules,
-      setup: planModuleSetup({
-        accountKind: resolved.account.kind,
-        owner,
-        configured: resolved.modules,
-        environment: resolved.sessions.environment,
+    const construction = createAccountConstruction({
+      material: {
+        account: resolved.account,
+        owner: resolved.owners,
+        modules: resolved.modules,
+        ...(resolved.initData ? { initData: resolved.initData } : {}),
+        ...(resolved.eoa ? { eoa: resolved.eoa } : {}),
         sessions: {
           enabled: resolved.sessions.enabled,
+          environment: resolved.sessions.environment,
           ...(sessionModule ? { module: sessionModule } : {}),
           ...(compatibilityFallback ? { compatibilityFallback } : {}),
         },
-      }),
-      sessions: {
-        enabled: resolved.sessions.enabled,
-        environment: resolved.sessions.environment,
       },
-      ...(resolved.initData ? { initData: resolved.initData } : {}),
-      ...(resolved.eoa ? { eoa: resolved.eoa } : {}),
       chain: { kind: 'evm', id: 1, caip2: 'eip155:1' },
       deployed: false,
-    }
+    })
     const plan =
       createAccountAdapter(construction).getDeploymentPlan(construction)
 


### PR DESCRIPTION
Multi-passkey accounts could derive an address that no one can deploy: the WebAuthn validator's `onInstall` requires credential IDs (`keccak256(pubKeyX, pubKeyY, account)`) to be strictly ascending, but the credential ID depends on the account address, which itself depends on the credential order — so no client-side sort fixes it. For ~25% of key pairs neither ordering worked.

- Credentials are ordered canonically by parsed public key, so the address is a function of the passkey *set* (`[a, b]` and `[b, a]` derive the same address).
- The account salt is then deterministically searched (attempt 0 = the caller's salt, `salt_k = keccak(baseSalt, k)`) until the derived address makes the credentials ascending. Budget is a fixed constant, never wall-clock, so hosts can't fork addresses.
- Where the address is already fixed (EIP-7702 adoption, caller-supplied `initData.address`), credentials are ordered by credential ID against that address and no search runs.
- Unusable configurations now throw `PasskeyConfigurationNotInstallableError` (duplicates, or more than six passkeys at deployment) instead of returning a dead address; the message points at `passkeys.addOwner`, which the validator accepts in any order.
- Everything flows through the single chokepoint `createAccountConstruction`; signature encoding, multi-factor and smart-session data are untouched (they never reach `onInstall`).

Compatibility:

- Single-passkey, ECDSA, ENS, multi-factor and non-passkey configurations derive byte-identical addresses and factory data — 1auth and production passkey accounts are unaffected (pinned vector `nexus-passkey-single` guards this).
- A multi-passkey configuration that is deployable today but was passed in a non-canonical order moves to a new address; the old one stays reachable by pinning `initData`. Integrators on an older SDK derive the old address for such configs.
- `experimental_getV0InitData` / `experimental_getRhinestoneInitData` reconstruct through the same chokepoint, so a legacy multi-passkey configuration reconstructed without pinned init data resolves to the new (installable) address.

Verified against the bench repro on Base Sepolia: both orderings derive the same address, the factory call succeeds for both, and the 25-pair survey reports 0 unusable pairs.

Closes [RHI-5957](https://linear.app/rhinestone/issue/RHI-5957)
