### PR TITLE
chore: release multi-passkey address fix as a patch

### DIFF
--- a/.changeset/fix-multi-passkey-undeployable-address.md
+++ b/.changeset/fix-multi-passkey-undeployable-address.md
@@ -1,5 +1,5 @@
 ---
-'@rhinestone/sdk': major
+'@rhinestone/sdk': patch
 ---
 
 Derive multi-passkey account addresses that can actually be deployed. Credentials are now installed in a canonical, order-independent order, and the account salt is deterministically searched (starting from the salt you passed) until the derived address satisfies the WebAuthn validator's ascending credential ID rule. Passkey sets that cannot be installed — duplicates, or more than six passkeys at deployment — throw `PasskeyConfigurationNotInstallableError` instead of returning an unusable address; add the remaining passkeys after deployment with `passkeys.addOwner`.


### PR DESCRIPTION
Downgrades the `fix-multi-passkey-undeployable-address` changeset from `major` to `patch`. The changeset has not been released — `main` only publishes `0.0.0-dev-*` snapshots, which don't consume changesets, and no promotion to `release` has happened — so no published version is affected.

- The break is narrow: only a multi-passkey config that is deployable today *and* was passed in a non-canonical order re-derives. Single-passkey, ECDSA, ENS, multi-factor and non-passkey configs are byte-identical.
- The change is a bug fix for addresses that were unrecoverable, so holding it behind a 3.0.0 costs every consumer more than the re-derivation costs the few affected.
- Body text is unchanged, so the compatibility caveat still ships in the changelog for anyone pinning `initData`.

Relates to [RHI-5957](https://linear.app/rhinestone/issue/RHI-5957)