### PR TITLE
test(accounts): property-test invariant account derivation, fix Safe owner order

### DIFF
--- a/.changeset/fix-safe-owner-order-address.md
+++ b/.changeset/fix-safe-owner-order-address.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Derive one Safe account address regardless of the order its owners were listed in. A Safe with two or more ECDSA or ENS owners used to derive a different address for every ordering, because the owner list is baked into the Safe `setup` call that determines the account address. Owners are now installed in canonical, value-based order.
+
+A multi-owner Safe that was previously passed in a non-canonical order derives a new address; to keep the existing account, pin its `initData` instead of letting the SDK re-derive it. Single-owner, passkey and multi-factor Safe configurations, every other account type, and the legacy v0 reconstruction path keep the exact address they derive today.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,8 +80,12 @@ order of modules of the same kind, and the order of multi-factor factors.
 Documented exceptions, also asserted so they cannot drift: ENS-HCA accounts
 derive from their lowest-sorted ENS owner alone, so configurations sharing that
 owner share an address; EOA, EIP-7702, and caller-pinned `initData` pass an
-address through; the legacy v0 factory args keep their owner-order sensitivity;
-and a multi-credential passkey factor nested in a multi-factor owner set is
+address through; the legacy v0 factory args keep their owner-order sensitivity,
+and the `address` `experimental_getV0InitData` reports comes from the current
+derivation path rather than from those factory args, so the two describe
+different accounts (reconstruction is unaffected — passing the result back as
+`initData` re-derives the address from `factoryData`); and a multi-credential
+passkey factor nested in a multi-factor owner set is
 still installed in caller order, because the salt search only runs for a
 top-level passkey owner.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,6 +59,36 @@ To recalibrate against another ref, add a worktree of it, symlink
 `test/consts.ts` and `scripts/vectors/generate.ts` into it, and run the
 generator there with `SDK_VECTORS_OUT` pointing at this checkout's baseline.
 
+## Derivation invariants
+
+`test/vectors/accounts/invariants.test.ts` guards the *shape* of the same
+promise with generated configurations (fast-check): which caller-visible
+differences must never move a derived address, and which must.
+
+Invariant: the order owners, recovery guardians, and multi-factor factor members
+are listed in; reordering modules across kinds while each kind keeps its relative
+order; spelling out a default (`threshold: 1`, `sessions: { enabled: false }`,
+`modules: []`); address and passkey public key casing and the uncompressed point
+prefix; the chain the address is requested for and whether the account is
+deployed; repeated derivation, derivation order across accounts, and host
+collation. Derivation never mutates the caller's configuration.
+
+Sensitive by design, and asserted as such: owner set membership, threshold,
+account type, version, salt, nonce, sessions, recovery, installed modules, the
+order of modules of the same kind, and the order of multi-factor factors.
+
+Documented exceptions, also asserted so they cannot drift: ENS-HCA accounts
+derive from their lowest-sorted ENS owner alone, so configurations sharing that
+owner share an address; EOA, EIP-7702, and caller-pinned `initData` pass an
+address through; the legacy v0 factory args keep their owner-order sensitivity;
+and a multi-credential passkey factor nested in a multi-factor owner set is
+still installed in caller order, because the salt search only runs for a
+top-level passkey owner.
+
+Properties run on a fixed seed so a counterexample reproduces on any host.
+`SDK_PROPERTY_SEED` and `SDK_PROPERTY_RUNS` override the seed and run count for
+exploration — never commit a configuration that depends on them.
+
 ## Package contract
 
 `bun run test:contract` builds and packs both `origin/release` and the current

--- a/src/accounts/adapters/contract.test.ts
+++ b/src/accounts/adapters/contract.test.ts
@@ -34,6 +34,7 @@ import {
 import { createNexusAdapter, nexusMaterial } from './nexus'
 import { createSafeAdapter, safeV0FactoryMaterial } from './safe'
 import {
+  canonicalOwnerAddresses,
   encodeAddressEnvelope,
   primaryOwnerAddresses,
   primaryThreshold,
@@ -246,6 +247,23 @@ describe('account adapter contract', () => {
     expect(primaryThreshold(passkey)).toBe(1n)
     expect(() =>
       primaryOwnerAddresses({
+        ...owner,
+        owners: [{ ...owner.owners[0], kind: 'webauthn' }],
+      } as ResolvedValidatorDefinition),
+    ).toThrow('does not expose an address')
+    const unsorted = {
+      ...owner,
+      owners: [
+        { ...owner.owners[0], account: collationAccountHigh },
+        { ...owner.owners[0], account: collationAccountLow },
+      ],
+    } as ResolvedValidatorDefinition
+    expect(canonicalOwnerAddresses(unsorted)).toEqual([
+      collationAccountLow.address,
+      collationAccountHigh.address,
+    ])
+    expect(() =>
+      canonicalOwnerAddresses({
         ...owner,
         owners: [{ ...owner.owners[0], kind: 'webauthn' }],
       } as ResolvedValidatorDefinition),

--- a/src/accounts/adapters/safe.ts
+++ b/src/accounts/adapters/safe.ts
@@ -23,6 +23,7 @@ import {
 import { encodeErc7579Calls } from '../erc7579-calls'
 import type { AccountConstruction } from '../types'
 import {
+  canonicalOwnerAddresses,
   encodeAddressEnvelope,
   encodeInstallModule,
   encodeUninstallModule,
@@ -106,7 +107,7 @@ function safeMaterial(input: AccountConstruction): DeploymentMaterial {
       ]),
       functionName: 'setup',
       args: [
-        [...primaryOwnerAddresses(input.owner)],
+        [...canonicalOwnerAddresses(input.owner)],
         primaryThreshold(input.owner),
         SAFE_LAUNCHPAD,
         addSafe7579,
@@ -179,6 +180,8 @@ export function safeV0FactoryMaterial(
     ]),
     functionName: 'setup',
     args: [
+      // Caller order, not canonical order: this path reconstructs accounts that
+      // SDK v0 already deployed from the owner list as it was supplied.
       [...primaryOwnerAddresses(input.owner)],
       primaryThreshold(input.owner),
       SAFE_V0_LAUNCHPAD,

--- a/src/accounts/adapters/shared.ts
+++ b/src/accounts/adapters/shared.ts
@@ -1,6 +1,7 @@
 import { encodeFunctionData, encodePacked, type Hex, zeroAddress } from 'viem'
 import { moduleTypeId } from '../../modules/erc7579-abi'
 import type { ResolvedModule } from '../../modules/types'
+import { compareHexValues } from '../../modules/validators/ordering'
 import type { ResolvedValidatorDefinition } from '../../modules/validators/types'
 
 export function primaryOwnerAddresses(
@@ -15,6 +16,15 @@ export function primaryOwnerAddresses(
     }
     return owner.account.address
   })
+}
+
+// Safe keeps owners in a linked list and imposes no order on them, but the
+// owner array is part of the `setup` initializer that becomes the account's
+// CREATE2 salt — so it must be ordered by value, never by caller order.
+export function canonicalOwnerAddresses(
+  validator: ResolvedValidatorDefinition,
+): readonly `0x${string}`[] {
+  return [...primaryOwnerAddresses(validator)].sort(compareHexValues)
 }
 
 export function primaryThreshold(

--- a/src/accounts/construction.test.ts
+++ b/src/accounts/construction.test.ts
@@ -5,9 +5,9 @@ import {
   keccak256,
   toHex,
 } from 'viem'
-import { toWebAuthnAccount } from 'viem/account-abstraction'
 import { privateKeyToAccount } from 'viem/accounts'
 import { describe, expect, test } from 'vitest'
+import { passkey } from '../../test/utils/passkeys'
 import type { AccountConstructionInput } from '../config/input'
 import { resolveStandaloneAccountConfig } from '../config/resolve'
 import {
@@ -19,15 +19,6 @@ import { createAccountAdapter } from './registry'
 import type { AccountConstruction } from './types'
 
 const CHAIN = { kind: 'evm', id: 1, caip2: 'eip155:1' } as const
-
-function passkey(tag: string) {
-  return toWebAuthnAccount({
-    credential: {
-      id: tag,
-      publicKey: `0x${keccak256(toHex(`x:${tag}`)).slice(2)}${keccak256(toHex(`y:${tag}`)).slice(2)}`,
-    },
-  })
-}
 
 function construct(input: AccountConstructionInput): AccountConstruction {
   const resolved = resolveStandaloneAccountConfig(input, 'current-v2')

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -3,6 +3,7 @@ import { encodeAbiParameters, toHex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { describe, expect, test, vi } from 'vitest'
 import { passkeyAccount } from '../../test/consts'
+import { propertyParameters } from '../../test/utils/property'
 import type { AccountInput } from '../accounts/types'
 import { SOCIAL_RECOVERY_VALIDATOR_ADDRESS } from '../modules/validators/social-recovery'
 import { currentV2Defaults } from './defaults'
@@ -21,8 +22,6 @@ const accountB = privateKeyToAccount(`0x${'22'.repeat(32)}`)
 const accountC = privateKeyToAccount(`0x${'33'.repeat(32)}`)
 const addressA = accountA.address
 const addressB = accountB.address
-const propertySeed = Number(process.env.SDK_PROPERTY_SEED ?? 0x5d4c3b2a)
-const propertyParameters = { seed: propertySeed, numRuns: 100, verbose: true }
 
 const hashArbitrary = fc
   .uint8Array({ minLength: 32, maxLength: 32 })
@@ -629,7 +628,7 @@ describe('config resolution properties', () => {
           expect(serializeInput(accountInput)).toBe(accountBefore)
         },
       ),
-      propertyParameters,
+      propertyParameters(),
     )
   })
 
@@ -654,7 +653,7 @@ describe('config resolution properties', () => {
           expect(leftFirst.modules).not.toBe(leftSecond.modules)
         },
       ),
-      propertyParameters,
+      propertyParameters(),
     )
   })
 

--- a/test/utils/passkeys.ts
+++ b/test/utils/passkeys.ts
@@ -1,0 +1,18 @@
+import { keccak256, toHex } from 'viem'
+import {
+  toWebAuthnAccount,
+  type WebAuthnAccount,
+} from 'viem/account-abstraction'
+
+// Deterministic passkey credentials: the same tag always yields the same public
+// key, so derived addresses stay stable across runs and machines.
+function passkey(tag: string): WebAuthnAccount {
+  return toWebAuthnAccount({
+    credential: {
+      id: tag,
+      publicKey: `0x${keccak256(toHex(`x:${tag}`)).slice(2)}${keccak256(toHex(`y:${tag}`)).slice(2)}`,
+    },
+  })
+}
+
+export { passkey }

--- a/test/utils/property.ts
+++ b/test/utils/property.ts
@@ -1,0 +1,24 @@
+// Property suites run on a fixed seed so a counterexample reproduces on any
+// host. `SDK_PROPERTY_SEED` and `SDK_PROPERTY_RUNS` are exploration overrides —
+// never commit a configuration that depends on them.
+const DEFAULT_SEED = 0x5d4c3b2a
+const DEFAULT_RUNS = 100
+
+interface PropertyParameters {
+  readonly seed: number
+  readonly numRuns: number
+  readonly verbose: boolean
+}
+
+function propertyParameters(
+  overrides: Partial<PropertyParameters> = {},
+): PropertyParameters {
+  return {
+    seed: Number(process.env.SDK_PROPERTY_SEED ?? DEFAULT_SEED),
+    numRuns: Number(process.env.SDK_PROPERTY_RUNS ?? DEFAULT_RUNS),
+    verbose: true,
+    ...overrides,
+  }
+}
+
+export { propertyParameters }

--- a/test/vectors/accounts/account-deployment.json
+++ b/test/vectors/accounts/account-deployment.json
@@ -296,6 +296,50 @@
       "factoryDataHash": "0x061b5a8e2cdebe61392e9ef0295fcda20c3ef9a1e5e16f364d26adbdaf725403"
     },
     {
+      "id": "safe-ecdsa-collation-pair",
+      "address": "0x2411301Aac5BF2a7bB8a508Afb69B5E241C2D243",
+      "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
+      "factoryDataHash": "0xf7208459e2cd8afa3f3f2529b20a4a865fb39b77becf98d30283b9dd36f2d895",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "Safe installs owners in canonical order, so the derived address no longer depends on the order they were listed in"
+      }
+    },
+    {
+      "id": "safe-ecdsa-three-threshold-2",
+      "address": "0xa6D075ba2981eC6615f1FCB1c82ebc30046aEf56",
+      "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
+      "factoryDataHash": "0xa451767a6bcd536ce082819fb22dcd73abafcdf169bf4534b1c02e768ce31c0b",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "Safe installs owners in canonical order, so the derived address no longer depends on the order they were listed in"
+      }
+    },
+    {
+      "id": "safe-ecdsa-two-default-threshold",
+      "address": "0xeAf1dFC596bdeB2e223cAaaBCCbaBc90b7a8573D",
+      "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
+      "factoryDataHash": "0x9a9e833952c540e6373792409a5c4b319a762eff6465cbdbbc1e0fe647f27d1d",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "Safe installs owners in canonical order, so the derived address no longer depends on the order they were listed in"
+      }
+    },
+    {
+      "id": "safe-ens-two",
+      "address": "0x41064d2486c71796000AE8a7E35dC10e1cD983eC",
+      "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
+      "factoryDataHash": "0x47395331e743eef6609ea746ae53fbf64dace5320fa7dc14a05836ff6f01f776",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "Safe installs owners in canonical order, so the derived address no longer depends on the order they were listed in"
+      }
+    },
+    {
       "id": "safe-multi-factor",
       "address": "0xbd352153856c2aF987D8CfAE3e74c286B8aff76F",
       "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
@@ -390,9 +434,14 @@
     },
     {
       "id": "v0-safe-ecdsa-three-threshold-2",
-      "address": "0x92249a7fb7a8a25b04e2A9680171299909458079",
+      "address": "0xa6D075ba2981eC6615f1FCB1c82ebc30046aEf56",
       "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
-      "factoryDataHash": "0x3c8024369627cd061d1479ff870ed78aac13f9781c6bc10b1c28b1e2f49374f0"
+      "factoryDataHash": "0x3c8024369627cd061d1479ff870ed78aac13f9781c6bc10b1c28b1e2f49374f0",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "Safe installs owners in canonical order, so the derived address no longer depends on the order they were listed in"
+      }
     },
     {
       "id": "v0-safe-multi-factor",

--- a/test/vectors/accounts/invariants.test.ts
+++ b/test/vectors/accounts/invariants.test.ts
@@ -1,0 +1,1059 @@
+import fc from 'fast-check'
+import { type Account, type Address, checksumAddress, type Hex } from 'viem'
+import {
+  toWebAuthnAccount,
+  type WebAuthnAccount,
+} from 'viem/account-abstraction'
+import { describe, expect, test } from 'vitest'
+import type { EvmChainReference } from '../../../src/chains/types'
+import { createStaticAccountRuntime } from '../../../src/config/account-runtime'
+import { resolveStandaloneAccountConfig } from '../../../src/config/resolve'
+import { type RhinestoneAccountConfig, RhinestoneSDK } from '../../../src/index'
+import type { ModuleInput } from '../../../src/modules/types'
+import { compareHexValues } from '../../../src/modules/validators/ordering'
+import type { OwnerSet } from '../../../src/modules/validators/types'
+import { experimental_getV0InitData } from '../../../src/utils/index'
+import {
+  accountA,
+  accountB,
+  accountC,
+  accountD,
+  collationAccountHigh,
+  collationAccountLow,
+} from '../../consts'
+import { withoutHostCollation } from '../../utils/locale'
+import { passkey } from '../../utils/passkeys'
+import { propertyParameters } from '../../utils/property'
+
+// Derivation outcomes are compared as values, so an unsupported configuration
+// is a meaningful input (both sides reject identically) rather than something
+// the generators have to exclude.
+type Outcome =
+  | {
+      readonly kind: 'derived'
+      readonly address: string
+      readonly factory?: string
+      readonly factoryData?: string
+      readonly initDataError?: string
+    }
+  | { readonly kind: 'rejected'; readonly message: string }
+
+const MAINNET: EvmChainReference = { kind: 'evm', id: 1, caip2: 'eip155:1' }
+const CHAINS: readonly EvmChainReference[] = [
+  MAINNET,
+  { kind: 'evm', id: 8453, caip2: 'eip155:8453' },
+  { kind: 'evm', id: 42161, caip2: 'eip155:42161' },
+]
+
+const sdk = new RhinestoneSDK({ apiKey: 'vector-only' })
+
+function lower(value: string): string {
+  return value.toLowerCase()
+}
+
+function failure(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function deriveStatic(
+  config: RhinestoneAccountConfig,
+  options: { chain?: EvmChainReference; deployed?: boolean } = {},
+): Outcome {
+  try {
+    const resolved = resolveStandaloneAccountConfig(config, 'current-v2')
+    const runtime = createStaticAccountRuntime(
+      resolved,
+      options.chain ?? MAINNET,
+      options.deployed ?? false,
+    )
+    const plan = runtime.adapter.getDeploymentPlan(runtime.construction)
+    return {
+      kind: 'derived',
+      address: lower(runtime.identity.address),
+      ...(plan.factory ? { factory: lower(plan.factory) } : {}),
+      ...(plan.factoryData ? { factoryData: lower(plan.factoryData) } : {}),
+    }
+  } catch (error) {
+    return { kind: 'rejected', message: failure(error) }
+  }
+}
+
+async function derivePublic(config: RhinestoneAccountConfig): Promise<Outcome> {
+  let address: string
+  try {
+    const account = await sdk.createAccount(config)
+    address = lower(account.getAddress())
+    try {
+      const initData = account.getInitData()
+      return {
+        kind: 'derived',
+        address,
+        factory: lower(initData.factory),
+        factoryData: lower(initData.factoryData),
+      }
+    } catch (error) {
+      return { kind: 'derived', address, initDataError: failure(error) }
+    }
+  } catch (error) {
+    return { kind: 'rejected', message: failure(error) }
+  }
+}
+
+function deriveV0(config: RhinestoneAccountConfig): Outcome {
+  try {
+    const initData = experimental_getV0InitData(config)
+    return {
+      kind: 'derived',
+      address: lower(initData.address),
+      factory: lower(initData.factory),
+      factoryData: lower(initData.factoryData),
+    }
+  } catch (error) {
+    return { kind: 'rejected', message: failure(error) }
+  }
+}
+
+function derived(
+  outcome: Outcome,
+): outcome is Extract<Outcome, { kind: 'derived' }> {
+  return outcome.kind === 'derived'
+}
+
+function replaceOpaque(_key: string, value: unknown): unknown {
+  if (typeof value === 'bigint') return `${value}n`
+  if (typeof value === 'function') return '[function]'
+  return value
+}
+
+// `Account` holds functions, so `structuredClone` cannot snapshot a config.
+function serializeConfig(config: RhinestoneAccountConfig): string {
+  return JSON.stringify(config, replaceOpaque)
+}
+
+// Seeded Fisher-Yates: one generated number reorders owner lists of any length,
+// and the seed is what a counterexample reports.
+function permute<T>(items: readonly T[], seed: number): T[] {
+  const shuffled = [...items]
+  // MINSTD, whose products stay inside the safe integer range.
+  let state = (seed % 2147483646) + 1
+  for (let index = shuffled.length - 1; index > 0; index--) {
+    state = (state * 48271) % 2147483647
+    const target = state % (index + 1)
+    const left = shuffled[index] as T
+    const right = shuffled[target] as T
+    shuffled[index] = right
+    shuffled[target] = left
+  }
+  return shuffled
+}
+
+type Reorder = <T>(items: readonly T[]) => T[]
+
+const reverse: Reorder = (items) => [...items].reverse()
+const seededReorder =
+  (seed: number): Reorder =>
+  (items) =>
+    permute(items, seed)
+
+function reorderOwners(owners: OwnerSet, reorder: Reorder): OwnerSet {
+  switch (owners.type) {
+    case 'ecdsa':
+      return { ...owners, accounts: reorder(owners.accounts) }
+    case 'passkey':
+      return { ...owners, accounts: reorder(owners.accounts) }
+    case 'ens':
+      return { ...owners, owners: reorder(owners.owners) }
+    case 'multi-factor':
+      return {
+        ...owners,
+        validators: owners.validators.map(
+          (factor) =>
+            reorderOwners(
+              factor,
+              reorder,
+            ) as (typeof owners.validators)[number],
+        ),
+      }
+  }
+}
+
+function ownerCount(owners: OwnerSet): number {
+  switch (owners.type) {
+    case 'ecdsa':
+    case 'passkey':
+      return owners.accounts.length
+    case 'ens':
+      return owners.owners.length
+    case 'multi-factor':
+      return Math.max(...owners.validators.map(ownerCount))
+  }
+}
+
+type Casing = 'lower' | 'checksum'
+
+function withAddressCasing(account: Account, casing: Casing): Account {
+  const address =
+    casing === 'lower'
+      ? (lower(account.address) as Address)
+      : checksumAddress(account.address)
+  return { ...account, address }
+}
+
+function recaseOwners(owners: OwnerSet, casing: Casing): OwnerSet {
+  switch (owners.type) {
+    case 'ecdsa':
+      return {
+        ...owners,
+        accounts: owners.accounts.map((account) =>
+          withAddressCasing(account, casing),
+        ),
+      }
+    case 'ens':
+      return {
+        ...owners,
+        owners: owners.owners.map((owner) => ({
+          ...owner,
+          account: withAddressCasing(owner.account, casing),
+        })),
+      }
+    case 'passkey':
+      return {
+        ...owners,
+        accounts: owners.accounts.map((account) =>
+          recasePasskey(account, casing),
+        ),
+      }
+    case 'multi-factor':
+      return {
+        ...owners,
+        validators: owners.validators.map(
+          (factor) =>
+            recaseOwners(factor, casing) as (typeof owners.validators)[number],
+        ),
+      }
+  }
+}
+
+function recasePasskey(
+  account: WebAuthnAccount,
+  casing: Casing,
+): WebAuthnAccount {
+  const key = account.publicKey.slice(2)
+  return toWebAuthnAccount({
+    credential: {
+      id: account.id,
+      publicKey:
+        `0x${casing === 'lower' ? key.toLowerCase() : key.toUpperCase()}` as Hex,
+    },
+  })
+}
+
+const OWNER_ACCOUNTS: readonly Account[] = [
+  accountA,
+  accountB,
+  accountC,
+  accountD,
+  collationAccountLow,
+  collationAccountHigh,
+]
+const PASSKEYS: readonly WebAuthnAccount[] = [
+  passkey('property:a'),
+  passkey('property:b'),
+  passkey('property:c'),
+]
+
+// Arbitrary but fixed addresses: they only need to be stable derivation inputs.
+const MODULE_POOL: readonly ModuleInput[] = [
+  { type: 'validator', address: '0x00000000000000000000000000000000000000d1' },
+  { type: 'executor', address: '0x00000000000000000000000000000000000000d2' },
+  { type: 'hook', address: '0x00000000000000000000000000000000000000d3' },
+  { type: 'fallback', address: '0x00000000000000000000000000000000000000d4' },
+  { type: 'executor', address: '0x00000000000000000000000000000000000000d5' },
+  { type: 'executor', address: '0x00000000000000000000000000000000000000d6' },
+]
+
+type AccountConfig = NonNullable<RhinestoneAccountConfig['account']>
+
+const safeAccountArbitrary: fc.Arbitrary<AccountConfig> = fc
+  .record({
+    adapter: fc.constantFrom(undefined, '1.0.0' as const, '2.0.0' as const),
+    version: fc.constantFrom(undefined, '1.4.1' as const),
+    nonce: fc.constantFrom(undefined, 0n, 7n),
+  })
+  .map(({ adapter, version, nonce }) => ({
+    type: 'safe' as const,
+    ...(adapter ? { adapter } : {}),
+    ...(version ? { version } : {}),
+    ...(nonce === undefined ? {} : { nonce }),
+  }))
+
+const saltArbitrary = fc.constantFrom(
+  undefined,
+  `0x${'11'.repeat(32)}` as Hex,
+  `0x${'22'.repeat(32)}` as Hex,
+)
+
+const erc7579AccountArbitrary: fc.Arbitrary<AccountConfig> = fc
+  .record({
+    type: fc.constantFrom(
+      'nexus' as const,
+      'kernel' as const,
+      'startale' as const,
+    ),
+    nexusVersion: fc.constantFrom(
+      undefined,
+      '1.2.0' as const,
+      '1.2.1' as const,
+    ),
+    salt: saltArbitrary,
+  })
+  .map(({ type, nexusVersion, salt }) =>
+    type === 'nexus'
+      ? {
+          type,
+          ...(nexusVersion ? { version: nexusVersion } : {}),
+          ...(salt ? { salt } : {}),
+        }
+      : { type, ...(salt ? { salt } : {}) },
+  )
+
+const hcaAccountArbitrary: fc.Arbitrary<AccountConfig> = fc
+  .constantFrom(
+    undefined,
+    '0x00000000000000000000000000000000000000e1' as const,
+  )
+  .map((factory) => ({
+    type: 'hca' as const,
+    ...(factory ? { factory } : {}),
+  }))
+
+const accountArbitrary: fc.Arbitrary<AccountConfig> = fc.oneof(
+  safeAccountArbitrary,
+  erc7579AccountArbitrary,
+  hcaAccountArbitrary,
+  fc.constant({ type: 'eoa' as const }),
+)
+
+const thresholdArbitrary = fc.constantFrom(undefined, 1, 2)
+
+function accountsArbitrary(max: number) {
+  return fc
+    .uniqueArray(fc.constantFrom(...OWNER_ACCOUNTS), {
+      minLength: 1,
+      maxLength: max,
+    })
+    .map((accounts) => accounts as Account[])
+}
+
+const ecdsaOwnersArbitrary: fc.Arbitrary<OwnerSet> = fc
+  .record({ accounts: accountsArbitrary(4), threshold: thresholdArbitrary })
+  .map(({ accounts, threshold }) => ({
+    type: 'ecdsa' as const,
+    accounts,
+    ...(threshold === undefined ? {} : { threshold }),
+  }))
+
+const ensOwnersArbitrary: fc.Arbitrary<OwnerSet> = fc
+  .record({
+    accounts: accountsArbitrary(4),
+    threshold: thresholdArbitrary,
+    expiring: fc.boolean(),
+  })
+  .map(({ accounts, threshold, expiring }) => ({
+    type: 'ens' as const,
+    owners: accounts.map((account, index) => ({
+      account,
+      ...(expiring && index % 2 === 0
+        ? { expiration: new Date('2030-01-01T00:00:00.000Z') }
+        : {}),
+    })),
+    ...(threshold === undefined ? {} : { threshold }),
+  }))
+
+// Capped at three credentials: the multi-passkey salt search is factorial in
+// the credential count, and four already costs milliseconds per derivation.
+const passkeyOwnersArbitrary: fc.Arbitrary<OwnerSet> = fc
+  .record({
+    accounts: fc.uniqueArray(fc.constantFrom(...PASSKEYS), {
+      minLength: 1,
+      maxLength: 3,
+      selector: (account) => account.id,
+    }),
+    threshold: thresholdArbitrary,
+  })
+  .map(({ accounts, threshold }) => ({
+    type: 'passkey' as const,
+    accounts: accounts as WebAuthnAccount[],
+    ...(threshold === undefined ? {} : { threshold }),
+  }))
+
+// A multi-passkey factor nested in a multi-factor owner set is still installed
+// in caller order (see the exception below), so nested passkey factors carry a
+// single credential.
+type MultiFactorValidators = Extract<
+  OwnerSet,
+  { type: 'multi-factor' }
+>['validators']
+
+// Factors are drawn from templates that own disjoint key sets, so reversing the
+// factor list is always a real change — two factors that merely spell the same
+// owner set differently would resolve to the same module and make the factor
+// order sensitivity check vacuous. Each passkey template carries one credential
+// because nested multi-credential factors are still order sensitive (see the
+// exception below).
+const FACTOR_TEMPLATES: MultiFactorValidators = [
+  { type: 'ecdsa', accounts: [accountA] },
+  { type: 'ecdsa', accounts: [accountB, accountC] },
+  { type: 'ens', owners: [{ account: accountD }] },
+  {
+    type: 'ens',
+    owners: [
+      { account: collationAccountLow },
+      { account: collationAccountHigh },
+    ],
+  },
+  { type: 'passkey', accounts: [PASSKEYS[0] as WebAuthnAccount] },
+  { type: 'passkey', accounts: [PASSKEYS[1] as WebAuthnAccount] },
+]
+
+const multiFactorOwnersArbitrary: fc.Arbitrary<OwnerSet> = fc
+  .record({
+    validators: fc.uniqueArray(fc.constantFrom(...FACTOR_TEMPLATES), {
+      minLength: 2,
+      maxLength: 3,
+    }),
+    threshold: thresholdArbitrary,
+  })
+  .map(({ validators, threshold }) => ({
+    type: 'multi-factor' as const,
+    validators: validators as MultiFactorValidators,
+    ...(threshold === undefined ? {} : { threshold }),
+  }))
+
+const ownersArbitrary = fc.oneof(
+  ecdsaOwnersArbitrary,
+  ensOwnersArbitrary,
+  passkeyOwnersArbitrary,
+  multiFactorOwnersArbitrary,
+)
+
+const modulesArbitrary = fc.uniqueArray(fc.constantFrom(...MODULE_POOL), {
+  maxLength: 4,
+  selector: (module) => module.address,
+})
+
+const configArbitrary: fc.Arbitrary<RhinestoneAccountConfig> = fc
+  .record({
+    account: accountArbitrary,
+    owners: ownersArbitrary,
+    ensOwners: ensOwnersArbitrary,
+    sessions: fc.constantFrom(undefined, false, true),
+    guardians: fc.uniqueArray(fc.constantFrom(...OWNER_ACCOUNTS), {
+      maxLength: 3,
+    }),
+    recoveryThreshold: thresholdArbitrary,
+    modules: modulesArbitrary,
+  })
+  .map(
+    ({
+      account,
+      owners,
+      ensOwners,
+      sessions,
+      guardians,
+      recoveryThreshold,
+      modules,
+    }): RhinestoneAccountConfig => {
+      // HCA installs nothing and only accepts ENS owners; an EOA account needs
+      // the EOA it adopts. Every other shape is generated freely.
+      if (account.type === 'hca') {
+        return { account, owners: ensOwners }
+      }
+      return {
+        account,
+        owners,
+        ...(account.type === 'eoa' ? { eoa: accountD } : {}),
+        ...(sessions === undefined ? {} : { sessions: { enabled: sessions } }),
+        ...(guardians.length > 0
+          ? {
+              recovery: {
+                guardians: guardians as Account[],
+                ...(recoveryThreshold === undefined
+                  ? {}
+                  : { threshold: recoveryThreshold }),
+              },
+            }
+          : {}),
+        ...(modules.length > 0 ? { modules: modules as ModuleInput[] } : {}),
+      }
+    },
+  )
+
+const seedArbitrary = fc.nat({ max: 1_000_000 })
+
+describe('derivation is invariant under owner order', () => {
+  test('the static derivation ignores the order owners are listed in', () => {
+    fc.assert(
+      fc.property(configArbitrary, seedArbitrary, (config, seed) => {
+        if (!config.owners) return
+        const baseline = deriveStatic(config)
+        for (const reorder of [reverse, seededReorder(seed)]) {
+          const permuted = {
+            ...config,
+            owners: reorderOwners(config.owners, reorder),
+          }
+          expect(deriveStatic(permuted)).toEqual(baseline)
+        }
+      }),
+      propertyParameters({ numRuns: 50 }),
+    )
+  })
+
+  test('the public API ignores the order owners are listed in', async () => {
+    await fc.assert(
+      fc.asyncProperty(configArbitrary, seedArbitrary, async (config, seed) => {
+        if (!config.owners) return
+        const baseline = await derivePublic(config)
+        const permuted = await derivePublic({
+          ...config,
+          owners: reorderOwners(config.owners, seededReorder(seed)),
+        })
+        expect(permuted).toEqual(baseline)
+      }),
+      propertyParameters({ numRuns: 50 }),
+    )
+  })
+
+  test('owner order is ignored with host collation unavailable', () => {
+    fc.assert(
+      fc.property(configArbitrary, (config) => {
+        const owners = config.owners
+        if (!owners) return
+        withoutHostCollation(() => {
+          const baseline = deriveStatic(config)
+          const permuted = deriveStatic({
+            ...config,
+            owners: reorderOwners(owners, reverse),
+          })
+          expect(permuted).toEqual(baseline)
+        })
+      }),
+      propertyParameters({ numRuns: 25 }),
+    )
+  })
+
+  test('the order recovery guardians are listed in is ignored', () => {
+    fc.assert(
+      fc.property(configArbitrary, seedArbitrary, (config, seed) => {
+        if (!config.recovery) return
+        const baseline = deriveStatic(config)
+        for (const reorder of [reverse, seededReorder(seed)]) {
+          const permuted = {
+            ...config,
+            recovery: {
+              ...config.recovery,
+              guardians: reorder(config.recovery.guardians),
+            },
+          }
+          expect(deriveStatic(permuted)).toEqual(baseline)
+        }
+      }),
+      propertyParameters({ numRuns: 50 }),
+    )
+  })
+})
+
+// Stable sort by a permuted kind ranking: the cross-kind order changes while
+// each kind keeps its relative order, which is what install order is built from.
+function reorderModulesAcrossKinds(
+  modules: readonly ModuleInput[],
+  kindOrder: readonly ModuleInput['type'][],
+): ModuleInput[] {
+  return [...modules].sort(
+    (left, right) =>
+      kindOrder.indexOf(left.type) - kindOrder.indexOf(right.type),
+  )
+}
+
+const kindOrderArbitrary = fc.shuffledSubarray(
+  ['validator', 'executor', 'fallback', 'hook'] as const,
+  { minLength: 4, maxLength: 4 },
+)
+
+describe('derivation is invariant under module and default spelling', () => {
+  test('reordering modules across kinds is ignored', () => {
+    fc.assert(
+      fc.property(
+        configArbitrary,
+        kindOrderArbitrary,
+        kindOrderArbitrary,
+        (config, leftOrder, rightOrder) => {
+          if (!config.modules) return
+          const left = deriveStatic({
+            ...config,
+            modules: reorderModulesAcrossKinds(config.modules, leftOrder),
+          })
+          const right = deriveStatic({
+            ...config,
+            modules: reorderModulesAcrossKinds(config.modules, rightOrder),
+          })
+          expect(right).toEqual(left)
+        },
+      ),
+      propertyParameters({ numRuns: 50 }),
+    )
+  })
+
+  test('spelling out a default derives the same account', () => {
+    fc.assert(
+      fc.property(configArbitrary, (config) => {
+        const {
+          sessions: _sessions,
+          modules: _modules,
+          ...withoutDefaults
+        } = config
+        const baseline = deriveStatic(withoutDefaults)
+        expect(
+          deriveStatic({ ...withoutDefaults, sessions: { enabled: false } }),
+        ).toEqual(baseline)
+        expect(deriveStatic({ ...withoutDefaults, modules: [] })).toEqual(
+          baseline,
+        )
+        if (withoutDefaults.owners) {
+          const { threshold: _threshold, ...owners } = withoutDefaults.owners
+          const implicit = deriveStatic({
+            ...withoutDefaults,
+            owners: owners as OwnerSet,
+          })
+          expect(
+            deriveStatic({
+              ...withoutDefaults,
+              owners: { ...owners, threshold: 1 } as OwnerSet,
+            }),
+          ).toEqual(implicit)
+        }
+      }),
+      propertyParameters(),
+    )
+  })
+
+  test('address and public key casing is ignored', () => {
+    fc.assert(
+      fc.property(configArbitrary, (config) => {
+        if (!config.owners) return
+        const baseline = deriveStatic({
+          ...config,
+          owners: recaseOwners(config.owners, 'lower'),
+        })
+        expect(
+          deriveStatic({
+            ...config,
+            owners: recaseOwners(config.owners, 'checksum'),
+          }),
+        ).toEqual(baseline)
+      }),
+      propertyParameters(),
+    )
+  })
+
+  test('an uncompressed point prefix on a passkey key is ignored', () => {
+    const base = passkey('property:prefix')
+    const prefixed = toWebAuthnAccount({
+      credential: {
+        id: base.id,
+        publicKey: `0x04${base.publicKey.slice(2)}` as Hex,
+      },
+    })
+    for (const type of ['safe', 'nexus', 'kernel', 'startale'] as const) {
+      const config = (accounts: WebAuthnAccount[]) => ({
+        account: { type },
+        owners: { type: 'passkey' as const, accounts },
+      })
+      expect(deriveStatic(config([prefixed]))).toEqual(
+        deriveStatic(config([base])),
+      )
+    }
+  })
+})
+
+describe('derivation is invariant under chain, deployment and repetition', () => {
+  test('the derived account does not depend on chain or deployment state', () => {
+    fc.assert(
+      fc.property(
+        configArbitrary,
+        fc.constantFrom(...CHAINS),
+        fc.boolean(),
+        (config, chain, deployed) => {
+          expect(deriveStatic(config, { chain, deployed })).toEqual(
+            deriveStatic(config),
+          )
+        },
+      ),
+      propertyParameters(),
+    )
+  })
+
+  test('derivation is deterministic, order independent, and leaves the config alone', () => {
+    fc.assert(
+      fc.property(configArbitrary, configArbitrary, (left, right) => {
+        const leftBefore = serializeConfig(left)
+        const rightBefore = serializeConfig(right)
+
+        const leftFirst = deriveStatic(left)
+        const rightSecond = deriveStatic(right)
+        const rightFirst = deriveStatic(right)
+        const leftSecond = deriveStatic(left)
+
+        expect(leftSecond).toEqual(leftFirst)
+        expect(rightSecond).toEqual(rightFirst)
+        expect(serializeConfig(left)).toBe(leftBefore)
+        expect(serializeConfig(right)).toBe(rightBefore)
+      }),
+      propertyParameters(),
+    )
+  })
+})
+
+type Mutation = {
+  readonly name: string
+  readonly apply: (
+    config: RhinestoneAccountConfig,
+  ) => RhinestoneAccountConfig | undefined
+}
+
+function replaceOwnerAccounts(
+  owners: OwnerSet,
+  replace: (accounts: Account[]) => Account[] | undefined,
+): OwnerSet | undefined {
+  if (owners.type === 'ecdsa') {
+    const accounts = replace(owners.accounts)
+    return accounts ? { ...owners, accounts } : undefined
+  }
+  if (owners.type === 'ens') {
+    const accounts = replace(owners.owners.map((owner) => owner.account))
+    return accounts
+      ? { ...owners, owners: accounts.map((account) => ({ account })) }
+      : undefined
+  }
+  return undefined
+}
+
+const mutations: readonly Mutation[] = [
+  {
+    name: 'adds an owner',
+    apply: (config) => {
+      if (!config.owners) return undefined
+      const owners = replaceOwnerAccounts(config.owners, (accounts) => {
+        const extra = OWNER_ACCOUNTS.find(
+          (candidate) =>
+            !accounts.some((account) => account.address === candidate.address),
+        )
+        return extra ? [...accounts, extra] : undefined
+      })
+      return owners ? { ...config, owners } : undefined
+    },
+  },
+  {
+    name: 'drops an owner',
+    apply: (config) => {
+      if (!config.owners) return undefined
+      const owners = replaceOwnerAccounts(config.owners, (accounts) =>
+        accounts.length > 1 ? accounts.slice(1) : undefined,
+      )
+      return owners ? { ...config, owners } : undefined
+    },
+  },
+  {
+    name: 'raises the owner threshold',
+    apply: (config) => {
+      if (!config.owners) return undefined
+      if (ownerCount(config.owners) < 2) return undefined
+      if (config.owners.threshold === 2) return undefined
+      return {
+        ...config,
+        owners: { ...config.owners, threshold: 2 },
+      }
+    },
+  },
+  {
+    name: 'swaps two modules of the same kind',
+    apply: (config) => {
+      if (!config.modules) return undefined
+      const executors = config.modules.filter(
+        (module) => module.type === 'executor',
+      )
+      if (executors.length < 2) return undefined
+      let seen = 0
+      return {
+        ...config,
+        modules: config.modules.map((module) => {
+          if (module.type !== 'executor') return module
+          const swapped = executors[executors.length - 1 - seen] as ModuleInput
+          seen += 1
+          return swapped
+        }),
+      }
+    },
+  },
+  {
+    name: 'swaps two multi-factor factors',
+    apply: (config) => {
+      const owners = config.owners
+      if (owners?.type !== 'multi-factor') return undefined
+      return {
+        ...config,
+        owners: {
+          ...owners,
+          validators: reverse(owners.validators) as typeof owners.validators,
+        },
+      }
+    },
+  },
+  {
+    name: 'toggles sessions',
+    apply: (config) => ({
+      ...config,
+      sessions: { enabled: !config.sessions?.enabled },
+    }),
+  },
+  {
+    name: 'adds a guardian',
+    apply: (config) => {
+      const guardians = config.recovery?.guardians ?? []
+      const extra = OWNER_ACCOUNTS.find(
+        (candidate) =>
+          !guardians.some((guardian) => guardian.address === candidate.address),
+      )
+      if (!extra) return undefined
+      return {
+        ...config,
+        recovery: { ...config.recovery, guardians: [...guardians, extra] },
+      }
+    },
+  },
+  {
+    name: 'changes the account salt or nonce',
+    apply: (config) => {
+      const account = config.account
+      if (!account) return undefined
+      if (account.type === 'safe') {
+        return {
+          ...config,
+          account: { ...account, nonce: (account.nonce ?? 0n) + 1n },
+        }
+      }
+      if (
+        account.type === 'nexus' ||
+        account.type === 'kernel' ||
+        account.type === 'startale'
+      ) {
+        return {
+          ...config,
+          account: { ...account, salt: `0x${'33'.repeat(32)}` as Hex },
+        }
+      }
+      return undefined
+    },
+  },
+]
+
+const mutationArbitrary = fc.constantFrom(...mutations)
+
+describe('derivation is sensitive to the configuration it is given', () => {
+  test('a meaningful configuration change derives a different account', () => {
+    fc.assert(
+      fc.property(configArbitrary, mutationArbitrary, (config, mutation) => {
+        // HCA derives from its lowest ENS owner alone, and EOA accounts pass an
+        // address through — both are asserted as exceptions below instead.
+        fc.pre(config.account?.type !== 'hca' && config.account?.type !== 'eoa')
+        const mutated = mutation.apply(config)
+        fc.pre(mutated !== undefined)
+        const baseline = deriveStatic(config)
+        const changed = deriveStatic(mutated as RhinestoneAccountConfig)
+        fc.pre(derived(baseline) && derived(changed))
+        expect(changed, mutation.name).not.toEqual(baseline)
+      }),
+      propertyParameters(),
+    )
+  })
+})
+
+describe('documented derivation exceptions', () => {
+  const [lowOwner, highOwner] =
+    compareHexValues(
+      collationAccountLow.address,
+      collationAccountHigh.address,
+    ) < 0
+      ? [collationAccountLow, collationAccountHigh]
+      : [collationAccountHigh, collationAccountLow]
+
+  test('HCA configurations sharing their lowest ENS owner share an address', () => {
+    const single = deriveStatic({
+      account: { type: 'hca' },
+      owners: { type: 'ens', owners: [{ account: lowOwner }] },
+    })
+    const pair = deriveStatic({
+      account: { type: 'hca' },
+      owners: {
+        type: 'ens',
+        owners: [{ account: lowOwner }, { account: highOwner }],
+      },
+    })
+    if (!derived(single) || !derived(pair)) {
+      throw new Error('HCA configurations must derive')
+    }
+    expect(pair.address).toBe(single.address)
+    expect(pair.factoryData).not.toBe(single.factoryData)
+  })
+
+  test('EOA and pinned init data pass an address through', () => {
+    fc.assert(
+      fc.property(ownersArbitrary, ownersArbitrary, (left, right) => {
+        const eoaLeft = deriveStatic({
+          account: { type: 'eoa' },
+          eoa: accountD,
+          owners: left,
+        })
+        const eoaRight = deriveStatic({
+          account: { type: 'eoa' },
+          eoa: accountD,
+          owners: right,
+        })
+        expect(eoaRight).toEqual(eoaLeft)
+
+        const pinned = { address: accountC.address }
+        expect(
+          deriveStatic({
+            account: { type: 'nexus' },
+            owners: right,
+            initData: pinned,
+          }),
+        ).toEqual(
+          deriveStatic({
+            account: { type: 'nexus' },
+            owners: left,
+            initData: pinned,
+          }),
+        )
+      }),
+      propertyParameters({ numRuns: 50 }),
+    )
+  })
+
+  // Known gap, pinned so it cannot widen: the salt search that makes a
+  // multi-credential passkey set order independent only runs for a top-level
+  // passkey owner, so credentials nested in a multi-factor factor are still
+  // installed in caller order.
+  test('multi-passkey factors nested in a multi-factor set stay order sensitive', () => {
+    const factors = (accounts: WebAuthnAccount[]) => ({
+      account: { type: 'nexus' as const },
+      owners: {
+        type: 'multi-factor' as const,
+        validators: [
+          { type: 'passkey' as const, accounts },
+          { type: 'ecdsa' as const, accounts: [accountA] },
+        ],
+      },
+    })
+    const first = passkey('property:nested-a')
+    const second = passkey('property:nested-b')
+    const baseline = deriveStatic(factors([first, second]))
+    const swapped = deriveStatic(factors([second, first]))
+    if (!derived(baseline) || !derived(swapped)) {
+      throw new Error('multi-factor configurations must derive')
+    }
+    expect(swapped.address).not.toBe(baseline.address)
+  })
+
+  // `getV0InitData` reports the current path's address with the v0 factory
+  // args, so only the reconstructed `factoryData` follows the caller's order.
+  test('the legacy v0 Safe factory args keep their owner-order sensitivity', () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.constantFrom(...OWNER_ACCOUNTS), {
+          minLength: 2,
+          maxLength: 4,
+        }),
+        (accounts) => {
+          const owners = { type: 'ecdsa' as const, accounts: accounts.slice() }
+          const baseline = deriveV0({ account: { type: 'safe' }, owners })
+          const reversed = deriveV0({
+            account: { type: 'safe' },
+            owners: { ...owners, accounts: reverse(accounts) },
+          })
+          if (!derived(baseline) || !derived(reversed)) {
+            throw new Error('v0 Safe configurations must derive')
+          }
+          expect(reversed.address).toBe(baseline.address)
+          expect(reversed.factoryData).not.toBe(baseline.factoryData)
+        },
+      ),
+      propertyParameters({ numRuns: 25 }),
+    )
+  })
+})
+
+describe('Safe multi-owner derivation', () => {
+  test('a Safe derives one address for every ordering of its owners', () => {
+    const accounts = [accountA, accountB, accountC]
+    const baseline = deriveStatic({
+      account: { type: 'safe' },
+      owners: { type: 'ecdsa', accounts },
+    })
+    for (const ordering of [
+      [accountC, accountB, accountA],
+      [accountB, accountA, accountC],
+      [accountA, accountC, accountB],
+    ]) {
+      expect(
+        deriveStatic({
+          account: { type: 'safe' },
+          owners: { type: 'ecdsa', accounts: ordering },
+        }),
+      ).toEqual(baseline)
+    }
+  })
+
+  test('a Safe owner list is installed in value order, not host collation order', () => {
+    const sorted = [collationAccountLow, collationAccountHigh].sort(
+      (left, right) => compareHexValues(left.address, right.address),
+    )
+    const baseline = deriveStatic({
+      account: { type: 'safe' },
+      owners: { type: 'ecdsa', accounts: sorted },
+    })
+    withoutHostCollation(() => {
+      expect(
+        deriveStatic({
+          account: { type: 'safe' },
+          owners: { type: 'ecdsa', accounts: reverse(sorted) },
+        }),
+      ).toEqual(baseline)
+    })
+  })
+
+  test('checksummed and lowercase Safe owners derive the same address', () => {
+    const accounts = [accountA, accountB]
+    const baseline = deriveStatic({
+      account: { type: 'safe' },
+      owners: {
+        type: 'ecdsa',
+        accounts: accounts.map((account) => ({
+          ...account,
+          address: checksumAddress(account.address),
+        })),
+      },
+    })
+    expect(
+      deriveStatic({
+        account: { type: 'safe' },
+        owners: {
+          type: 'ecdsa',
+          accounts: accounts.map((account) =>
+            withAddressCasing(account, 'lower'),
+          ),
+        },
+      }),
+    ).toEqual(baseline)
+  })
+})

--- a/test/vectors/accounts/invariants.test.ts
+++ b/test/vectors/accounts/invariants.test.ts
@@ -991,6 +991,37 @@ describe('documented derivation exceptions', () => {
       propertyParameters({ numRuns: 25 }),
     )
   })
+
+  // Known gap, independent of owner order and of the Safe fix: the `address`
+  // `getV0InitData` reports comes from the current path, while its factory args
+  // rebuild the v0 launchpad and adapter, so the two describe different
+  // accounts for every Safe including a single-owner one. Reconstruction is
+  // unaffected because passing the result back as `initData` re-derives the
+  // address from `factoryData`. Pinned so it cannot widen unnoticed.
+  test('the v0 address field does not match the account its factory args deploy', () => {
+    for (const accounts of [[accountA], [accountA, accountB, accountC]]) {
+      const owners = { type: 'ecdsa' as const, accounts }
+      const reported = deriveV0({ account: { type: 'safe' }, owners })
+      if (!derived(reported)) {
+        throw new Error('v0 Safe configurations must derive')
+      }
+      const reconstructed = deriveStatic({
+        account: { type: 'safe' },
+        owners,
+        initData: {
+          address: reported.address as Address,
+          factory: reported.factory as Address,
+          factoryData: reported.factoryData as Hex,
+          intentExecutorInstalled: true,
+        },
+      })
+      if (!derived(reconstructed)) {
+        throw new Error('reconstruction from v0 init data must derive')
+      }
+      expect(reconstructed.factoryData).toBe(reported.factoryData)
+      expect(reconstructed.address).not.toBe(reported.address)
+    }
+  })
 })
 
 describe('Safe multi-owner derivation', () => {

--- a/test/vectors/accounts/matrix.ts
+++ b/test/vectors/accounts/matrix.ts
@@ -1,5 +1,4 @@
 import { keccak256, toHex } from 'viem'
-import { toWebAuthnAccount } from 'viem/account-abstraction'
 import type { RhinestoneAccountConfig } from '../../../src/index'
 import {
   accountA,
@@ -10,6 +9,7 @@ import {
   collationAccountLow,
   passkeyAccount,
 } from '../../consts'
+import { passkey } from '../../utils/passkeys'
 
 export type VectorCase = {
   readonly id: string
@@ -24,15 +24,6 @@ export type VectorCase = {
   readonly config: RhinestoneAccountConfig
   /** Builds `initData` from another case's derived deployment plan. */
   readonly pinnedFrom?: string
-}
-
-function passkey(tag: string) {
-  return toWebAuthnAccount({
-    credential: {
-      id: tag,
-      publicKey: `0x${keccak256(toHex(`x:${tag}`)).slice(2)}${keccak256(toHex(`y:${tag}`)).slice(2)}`,
-    },
-  })
 }
 
 const passkeyA = passkey('vector:a')
@@ -242,6 +233,32 @@ const accountVariants: VectorCase[] = [
 
 // Owner-set variants: multi-owner, thresholds, module overrides, multi-factor.
 const ownerVariants: VectorCase[] = [
+  deployment('safe-ecdsa-two-default-threshold', {
+    account: { type: 'safe' },
+    owners: { type: 'ecdsa', accounts: [accountA, accountB] },
+  }),
+  deployment('safe-ecdsa-three-threshold-2', {
+    account: { type: 'safe' },
+    owners: {
+      type: 'ecdsa',
+      accounts: [accountA, accountB, accountC],
+      threshold: 2,
+    },
+  }),
+  deployment('safe-ens-two', {
+    account: { type: 'safe' },
+    owners: {
+      type: 'ens',
+      owners: [{ account: accountA }, { account: accountB }],
+    },
+  }),
+  deployment('safe-ecdsa-collation-pair', {
+    account: { type: 'safe' },
+    owners: {
+      type: 'ecdsa',
+      accounts: [collationAccountLow, collationAccountHigh],
+    },
+  }),
   deployment('nexus-ecdsa-three-threshold-2', {
     account: { type: 'nexus' },
     owners: {


### PR DESCRIPTION
Adds a generated-input (fast-check) suite that asserts the shape of the SDK's address-derivation promise, and fixes the one real violation it surfaced.

- **Fix:** a Safe with two or more ECDSA/ENS owners derived a different address per owner ordering — the owner array feeds Safe's `setup` initializer, which becomes the CREATE2 salt. New `canonicalOwnerAddresses` sorts it with `compareHexValues`; used by `safeMaterial` only. The legacy v0 reconstruction path keeps caller order (it reconstructs accounts already deployed by SDK v0).
- **New suite** `test/vectors/accounts/invariants.test.ts` (18 properties, 3 drivers: `createStaticAccountRuntime`, the public `createAccount().getAddress()/getInitData()`, and `experimental_getV0InitData`). Covers what must not move an address (owner/guardian order, cross-kind module reorder, default spellings, casing and uncompressed key prefix, chain, `deployed`, determinism, host collation), the converse sensitivities via a mutation set, and the documented exceptions. Verified to have teeth: before the fix it failed on exactly the Safe multi-owner cases.
- Four multi-owner Safe vector cases pin the new addresses; `patch` changeset carries the "pin `initData` to keep an existing account" migration note.
- Test-only: two shared helpers (`test/utils/property.ts`, `test/utils/passkeys.ts`) replace three duplicated passkey/seed copies.

Two things reviewers should know:

1. The suite surfaced a second, **pre-existing** order sensitivity: a passkey factor with ≥2 credentials *nested inside a multi-factor owner set* derives a different address per credential order, because the canonical ordering and salt search in `createAccountConstruction` only apply to a top-level passkey owner. Fixing it would move addresses beyond Safe, which this ticket lists as a non-goal — so it is pinned by a named exception test and documented, and needs its own ticket and release decision.
2. `v0-safe-ecdsa-three-threshold-2` moved because `getV0InitData` returns the *current* path's address alongside the v0 factory args. That is the same Safe change, not a v0 behavior change; its `factoryData` stays caller-ordered.

Closes [RHI-5965](https://linear.app/rhinestone/issue/RHI-5965)

---

### On the v0 init-data address (raised in review)

`experimental_getV0InitData` returns an `address` that does not correspond to the v0 `factoryData` it returns — and that is true on `main`, for every Safe, independent of owner order. The `address` comes from the current derivation path (`SAFE_LAUNCHPAD` / `SAFE_ADAPTER`), while the factory args rebuild the v0 initializer (`SAFE_V0_LAUNCHPAD` / `SAFE_V0_ADAPTER`), so the two salts cannot agree. Measured on `origin/main` with a **single** ECDSA owner: reported `0x6903edC0…`, address the returned `factoryData` actually deploys `0x585EAa48…`.

Reconstruction is unaffected: the documented flow passes the result back as `initData`, and that path re-derives the address from `factoryData`, so callers get the real v0 account both before and after this PR. This PR only changes which (already unrelated) address is reported for multi-owner Safes; `factoryData` is untouched.

Out of scope here — the ticket's non-goal is moving addresses beyond the Safe owner-order fix, and correcting the reported address is a behavior change affecting every Safe. Pinned by a named test and documented in `docs/testing.md` so it cannot widen unnoticed; it needs its own ticket.
