### PR TITLE
feat: support weighted Quorum Signers

### DIFF
--- a/.changeset/support-quorum-signer.md
+++ b/.changeset/support-quorum-signer.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Support weighted Quorum Signer validators through `owners: { type: 'quorum', module, thresholdWeight, owners }`, including installation data, raw digest signing, packed weighted signatures, cross-chain Merkle-root signing for multi-origin intents, UserOperation stub signatures, and public headless ERC-1271 helpers under `@rhinestone/sdk/signing/quorum`.

--- a/.size-limit.ts
+++ b/.size-limit.ts
@@ -54,6 +54,13 @@ const limits = [
     ignore: viem,
   },
   {
+    name: '@rhinestone/sdk/signing/quorum',
+    path: `${packageRoot}/signing/quorum.js`,
+    limit: '2 kB',
+    import: '*',
+    ignore: viem,
+  },
+  {
     name: '@rhinestone/sdk/actions/smart-sessions',
     path: `${packageRoot}/actions/smart-sessions.js`,
     limit: '27 kB',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,9 +46,9 @@ enforced by `scripts/architecture/check.ts`:
 - **`accounts/`** — account adapters (Safe, Kernel, Nexus, Startale, HCA, EOA).
   Each maps resolved config to that account's init data, module layout, and
   signature envelope. The registry selects the adapter by kind.
-- **`modules/`** — module planning and validators (ECDSA, ENS, WebAuthn,
-  multi-factor, K1, social recovery), including the Smart Sessions subsystem
-  (`modules/validators/smart-sessions/`).
+- **`modules/`** — module planning and validators (ECDSA, weighted Quorum
+  Signer, ENS, WebAuthn, multi-factor, K1, social recovery), including the Smart
+  Sessions subsystem (`modules/validators/smart-sessions/`).
 - **`signing/`** — the signing pipeline: signing plans, signer invocation,
   protocol codecs (ERC-6492/7739), and intent-plan assembly.
 - **`transactions/`** — an organizational namespace, not a shared protocol. The
@@ -86,6 +86,17 @@ the relayer market; the SDK signs and submits.
    `TransactionResult` (an intent id).
 5. `waitForExecution(result)` — polls the orchestrator until the intent reaches
    a terminal state; throws `IntentFailedError` on failure.
+
+Weighted Quorum Signer accounts collapse multi-origin intent signing into one
+chain-agnostic EIP-712 `WeightedMerkleRoot` signature. Each origin receives an
+account-bound Merkle proof, so the owner quorum signs once while every chain
+still receives a distinct validator envelope.
+
+Headless ERC-1271 integrations can import the same primitives from
+`@rhinestone/sdk/signing/quorum`: derive the account-bound digest, build a
+Merkle signing tree, derive its EIP-712 root hash, pack weighted owner
+signatures, and finally encode either a regular or proof-bearing validator
+signature.
 
 ```mermaid
 sequenceDiagram

--- a/src/accounts/adapters/contract.test.ts
+++ b/src/accounts/adapters/contract.test.ts
@@ -19,6 +19,7 @@ import type { ResolvedModule } from '../../modules/types'
 import type { ResolvedValidatorDefinition } from '../../modules/validators/types'
 import { createAccountConstruction } from '../construction'
 import { ModuleInstallationNotSupportedError } from '../error'
+import { wrapKernelMessageHash } from '../kernel-signing'
 import type {
   AccountConstruction,
   AccountKind,
@@ -26,11 +27,7 @@ import type {
 } from '../types'
 import { createEoaAdapter } from './eoa'
 import { createHcaAdapter } from './hca'
-import {
-  createKernelAdapter,
-  kernelInstallData,
-  wrapKernelMessageHash,
-} from './kernel'
+import { createKernelAdapter, kernelInstallData } from './kernel'
 import { createNexusAdapter, nexusMaterial } from './nexus'
 import { createSafeAdapter, safeV0FactoryMaterial } from './safe'
 import {

--- a/src/accounts/adapters/kernel.ts
+++ b/src/accounts/adapters/kernel.ts
@@ -1,16 +1,13 @@
 import {
   concat,
-  concatHex,
   decodeAbiParameters,
   decodeFunctionData,
-  domainSeparator,
   encodeAbiParameters,
   encodeFunctionData,
   getContractAddress,
   type Hex,
   keccak256,
   parseAbi,
-  stringToHex,
   toHex,
   zeroAddress,
 } from 'viem'
@@ -37,24 +34,6 @@ const KERNEL_BYTECODE =
   '0x603d3d8160223d3973d6cedde84be40893d153be9d467cd6ad37875b2860095155f3363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3' as const
 const HOOK_INSTALLED_ADDRESS =
   '0x0000000000000000000000000000000000000001' as const
-
-export function wrapKernelMessageHash(messageHash: Hex, account: Hex): Hex {
-  const separator = domainSeparator({
-    domain: {
-      name: 'Kernel',
-      version: '0.3.3',
-      chainId: 0,
-      verifyingContract: account,
-    },
-  })
-  const structHash = keccak256(
-    encodeAbiParameters(
-      [{ type: 'bytes32' }, { type: 'bytes32' }],
-      [keccak256(stringToHex('Kernel(bytes32 hash)')), messageHash],
-    ),
-  )
-  return keccak256(concatHex(['0x1901', separator, structHash]))
-}
 
 export function kernelInstallData(module: ResolvedModule): readonly Hex[] {
   const install = (initData: Hex) =>

--- a/src/accounts/kernel-signing.ts
+++ b/src/accounts/kernel-signing.ts
@@ -1,0 +1,26 @@
+import {
+  concatHex,
+  domainSeparator,
+  encodeAbiParameters,
+  type Hex,
+  keccak256,
+  stringToHex,
+} from 'viem'
+
+export function wrapKernelMessageHash(messageHash: Hex, account: Hex): Hex {
+  const separator = domainSeparator({
+    domain: {
+      name: 'Kernel',
+      version: '0.3.3',
+      chainId: 0,
+      verifyingContract: account,
+    },
+  })
+  const structHash = keccak256(
+    encodeAbiParameters(
+      [{ type: 'bytes32' }, { type: 'bytes32' }],
+      [keccak256(stringToHex('Kernel(bytes32 hash)')), messageHash],
+    ),
+  )
+  return keccak256(concatHex(['0x1901', separator, structHash]))
+}

--- a/src/api/direct-signing.ts
+++ b/src/api/direct-signing.ts
@@ -11,6 +11,7 @@ import type { AccountRuntime } from '../accounts/adapter'
 import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
 import type { EvmChainReference } from '../chains/types'
 import { defineValidator } from '../modules/validators/definition'
+import { getQuorumSignableHash } from '../modules/validators/quorum'
 import { getPermissionId } from '../modules/validators/smart-sessions/digest'
 import { getSmartSessionEmissaryAddress } from '../modules/validators/smart-sessions/module'
 import type { ResolvedSessionSignerSet } from '../modules/validators/smart-sessions/types'
@@ -59,10 +60,20 @@ export async function signRuntimeMessage(
   })
   const topology = signingTopology(context.validator, selection?.signerIds)
   const payload = hashMessage(input.message)
+  const validatorHash =
+    context.validator.kind === 'quorum'
+      ? getQuorumSignableHash({
+          validator:
+            context.validatorCapabilities.compatibilityKey.moduleAddress,
+          chainId: input.chain.id,
+          account: context.account.address,
+          hash: payload,
+        })
+      : payload
   const accountHash =
     input.runtime.construction.account.kind === 'kernel'
-      ? wrapKernelMessageHash(payload, context.account.address)
-      : payload
+      ? wrapKernelMessageHash(validatorHash, context.account.address)
+      : validatorHash
   const signingMaterial = input.session
     ? {
         kind: 'message' as const,
@@ -75,7 +86,8 @@ export async function signRuntimeMessage(
           }),
         },
       }
-    : input.runtime.construction.account.kind === 'kernel'
+    : input.runtime.construction.account.kind === 'kernel' ||
+        context.validator.kind === 'quorum'
       ? {
           kind: 'message' as const,
           message: { raw: accountHash },

--- a/src/api/direct-signing.ts
+++ b/src/api/direct-signing.ts
@@ -9,10 +9,9 @@ import {
   zeroHash,
 } from 'viem'
 import type { AccountRuntime } from '../accounts/adapter'
-import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
+import { wrapKernelMessageHash } from '../accounts/kernel-signing'
 import type { EvmChainReference } from '../chains/types'
 import { defineValidator } from '../modules/validators/definition'
-import { getQuorumSignableHash } from '../modules/validators/quorum'
 import { getPermissionId } from '../modules/validators/smart-sessions/digest'
 import { getSmartSessionEmissaryAddress } from '../modules/validators/smart-sessions/module'
 import type { ResolvedSessionSignerSet } from '../modules/validators/smart-sessions/types'
@@ -22,6 +21,7 @@ import {
   getAccountSignatureRoute,
   getSigningValidatorCodec,
 } from '../signing/context'
+import { resolveAccountValidatorSignableHash } from '../signing/hash'
 import { signAccountMessage } from '../signing/message'
 import { createValidatorSigningTasks, signingTopology } from '../signing/plan'
 import {
@@ -72,26 +72,18 @@ export async function signRuntimeMessage(
     input.selection?.signerIds,
   )
   const payload = hashMessage(input.message)
-  const validatorHash =
-    context.validator.kind === 'quorum'
-      ? getQuorumSignableHash({
-          validator:
-            context.validatorCapabilities.compatibilityKey.moduleAddress,
-          chainId: input.chain.id,
-          account: context.account.address,
-          hash: payload,
-        })
-      : payload
-  const accountHash =
-    input.runtime.construction.account.kind === 'kernel'
-      ? wrapKernelMessageHash(validatorHash, context.account.address)
-      : validatorHash
   const signingMaterial =
     input.runtime.construction.account.kind === 'kernel' ||
     context.validator.kind === 'quorum'
       ? {
           kind: 'message' as const,
-          message: { raw: accountHash },
+          message: {
+            raw: resolveAccountValidatorSignableHash({
+              hash: payload,
+              chain: input.chain,
+              context,
+            }),
+          },
         }
       : undefined
   const route = getAccountSignatureRoute(input.runtime, context)

--- a/src/api/direct-signing.ts
+++ b/src/api/direct-signing.ts
@@ -12,6 +12,7 @@ import type { AccountRuntime } from '../accounts/adapter'
 import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
 import type { EvmChainReference } from '../chains/types'
 import { defineValidator } from '../modules/validators/definition'
+import { getQuorumSignableHash } from '../modules/validators/quorum'
 import { getPermissionId } from '../modules/validators/smart-sessions/digest'
 import { getSmartSessionEmissaryAddress } from '../modules/validators/smart-sessions/module'
 import type { ResolvedSessionSignerSet } from '../modules/validators/smart-sessions/types'
@@ -71,12 +72,23 @@ export async function signRuntimeMessage(
     input.selection?.signerIds,
   )
   const payload = hashMessage(input.message)
+  const validatorHash =
+    context.validator.kind === 'quorum'
+      ? getQuorumSignableHash({
+          validator:
+            context.validatorCapabilities.compatibilityKey.moduleAddress,
+          chainId: input.chain.id,
+          account: context.account.address,
+          hash: payload,
+        })
+      : payload
   const accountHash =
     input.runtime.construction.account.kind === 'kernel'
-      ? wrapKernelMessageHash(payload, context.account.address)
-      : payload
+      ? wrapKernelMessageHash(validatorHash, context.account.address)
+      : validatorHash
   const signingMaterial =
-    input.runtime.construction.account.kind === 'kernel'
+    input.runtime.construction.account.kind === 'kernel' ||
+    context.validator.kind === 'quorum'
       ? {
           kind: 'message' as const,
           message: { raw: accountHash },

--- a/src/api/signer-selection.ts
+++ b/src/api/signer-selection.ts
@@ -110,6 +110,19 @@ function adaptOwnerSelection(
         signerIds,
       }
     }
+    case 'quorum': {
+      const signerIds = signers.accounts.map(ecdsaSignerId)
+      if (!account.owners || account.owners.kind !== 'quorum') {
+        throw new Error(
+          'Quorum signer selection requires configured quorum owners',
+        )
+      }
+      return {
+        kind: 'owner',
+        validator: replaceValidatorAccounts(account.owners, signers.accounts),
+        signerIds,
+      }
+    }
     case 'passkey': {
       const signerIds = signers.accounts.map(webauthnSignerId)
       return {

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -88,6 +88,25 @@ interface OwnableValidatorConfig {
   module?: Address
 }
 
+/** One Quorum Signer owner and its non-zero voting weight. */
+interface QuorumOwner {
+  /** Viem account used to sign this owner's raw operation digest. */
+  account: Account
+  /** Weight contributed by a valid signature from this owner. */
+  weight: bigint
+}
+
+/** Configure a weighted Quorum Signer validator deployed at `module`. */
+interface QuorumValidatorConfig {
+  type: 'quorum'
+  /** Weighted EOA or EIP-1271 owners. The SDK can sign configured EOA accounts. */
+  owners: QuorumOwner[]
+  /** Minimum combined owner weight required to authorize an operation. */
+  thresholdWeight: bigint
+  /** Deployed Quorum Signer validator address shared by the account's chains. */
+  module: Address
+}
+
 interface ENSValidatorConfig {
   type: 'ens'
   /** Each owner with an optional expiry. Omit `expiration` to never expire. */
@@ -140,6 +159,7 @@ type PaymasterConfig =
 
 type OwnerSet =
   | OwnableValidatorConfig
+  | QuorumValidatorConfig
   | ENSValidatorConfig
   | WebauthnValidatorConfig
   | MultiFactorValidatorConfig
@@ -782,6 +802,11 @@ type OwnerSignerSet =
     }
   | {
       type: 'owner'
+      kind: 'quorum'
+      accounts: Account[]
+    }
+  | {
+      type: 'owner'
       kind: 'passkey'
       accounts: WebAuthnAccount[]
       module?: Address
@@ -977,6 +1002,8 @@ export type {
   SourceAssetInput,
   OwnerSet,
   OwnableValidatorConfig,
+  QuorumOwner,
+  QuorumValidatorConfig,
   ENSValidatorConfig,
   WebauthnValidatorConfig,
   MultiFactorValidatorConfig,

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -97,6 +97,25 @@ interface OwnableValidatorConfig {
   module?: Address
 }
 
+/** One Quorum Signer owner and its non-zero voting weight. */
+interface QuorumOwner {
+  /** Viem account used to sign this owner's raw operation digest. */
+  account: Account
+  /** Weight contributed by a valid signature from this owner. */
+  weight: bigint
+}
+
+/** Configure a weighted Quorum Signer validator deployed at `module`. */
+interface QuorumValidatorConfig {
+  type: 'quorum'
+  /** Weighted EOA or EIP-1271 owners. The SDK can sign configured EOA accounts. */
+  owners: QuorumOwner[]
+  /** Minimum combined owner weight required to authorize an operation. */
+  thresholdWeight: bigint
+  /** Deployed Quorum Signer validator address shared by the account's chains. */
+  module: Address
+}
+
 interface ENSValidatorConfig {
   type: 'ens'
   /** Each owner with an optional expiry. Omit `expiration` to never expire. */
@@ -149,6 +168,7 @@ type PaymasterConfig =
 
 type OwnerSet =
   | OwnableValidatorConfig
+  | QuorumValidatorConfig
   | ENSValidatorConfig
   | WebauthnValidatorConfig
   | MultiFactorValidatorConfig
@@ -828,6 +848,11 @@ type OwnerSignerSet =
     }
   | {
       type: 'owner'
+      kind: 'quorum'
+      accounts: Account[]
+    }
+  | {
+      type: 'owner'
       kind: 'passkey'
       accounts: WebAuthnAccount[]
       module?: Address
@@ -1023,6 +1048,8 @@ export type {
   SourceAssetInput,
   OwnerSet,
   OwnableValidatorConfig,
+  QuorumOwner,
+  QuorumValidatorConfig,
   ENSValidatorConfig,
   WebauthnValidatorConfig,
   MultiFactorValidatorConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,8 @@ export type {
   Permit2ClaimPolicy,
   Policy,
   ProviderConfig,
+  QuorumOwner,
+  QuorumValidatorConfig,
   Recovery,
   RhinestoneAccountConfig,
   Session,

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ export type {
   Permit2ClaimPolicy,
   Policy,
   ProviderConfig,
+  QuorumOwner,
+  QuorumValidatorConfig,
   Recovery,
   RhinestoneAccountConfig,
   Session,

--- a/src/modules/validators/capabilities.ts
+++ b/src/modules/validators/capabilities.ts
@@ -48,9 +48,9 @@ export function getValidatorCapabilities(
     signatureModes: ['owner'],
     signerTopology: nested
       ? 'nested-threshold'
-      : definition.owners.length === 1
-        ? 'single'
-        : 'threshold',
+      : definition.kind === 'quorum' || definition.owners.length > 1
+        ? 'threshold'
+        : 'single',
     supportsIndependentSigning:
       definition.kind !== 'smart-session' &&
       module.address.toLowerCase() !==
@@ -66,12 +66,42 @@ export function getValidatorCapabilities(
           factorOrder: definition.validators.map((factor) => factor.id),
           threshold: definition.threshold,
         }
-      : {
-          kind: 'ordered-threshold',
-          validator: module,
-          ownerOrder: definition.owners.map((owner) => owner.id),
-          threshold: definition.threshold,
-          recoveryEncoding: validatorRecovery,
-        },
+      : definition.kind === 'quorum'
+        ? {
+            kind: 'weighted-quorum',
+            validator: module,
+            owners: definition.owners.map((owner) => {
+              if (owner.kind === 'webauthn' || owner.weight === undefined) {
+                throw new Error(
+                  'Quorum validator requires weighted ECDSA owners',
+                )
+              }
+              return {
+                ownerId: owner.id,
+                signer: owner.account.address,
+                weight: owner.weight,
+              }
+            }),
+            thresholdWeight: requireQuorumThreshold(definition),
+          }
+        : {
+            kind: 'ordered-threshold',
+            validator: module,
+            ownerOrder: definition.owners.map((owner) => owner.id),
+            threshold: definition.threshold,
+            recoveryEncoding: validatorRecovery,
+          },
   }
+}
+
+function requireQuorumThreshold(
+  definition: ResolvedValidatorDefinition,
+): bigint {
+  if (
+    definition.kind !== 'quorum' ||
+    definition.thresholdWeight === undefined
+  ) {
+    throw new Error('Quorum validator threshold weight is missing')
+  }
+  return definition.thresholdWeight
 }

--- a/src/modules/validators/contribution.ts
+++ b/src/modules/validators/contribution.ts
@@ -1,6 +1,7 @@
 import type { Hex } from 'viem'
 import { encodeMultiFactorContribution } from './multi-factor'
 import { encodeEcdsaValidatorContribution } from './ownable'
+import { encodeQuorumValidatorContribution } from './quorum'
 import { encodeSmartSessionContribution } from './smart-sessions/signature'
 import type {
   ValidatorContributionCodec,
@@ -41,6 +42,19 @@ export function encodeValidatorContribution(
         ownerOrder: codec.ownerOrder,
         threshold: codec.threshold,
         recoveryEncoding: codec.recoveryEncoding,
+        contributions: ecdsa,
+      })
+    }
+    case 'weighted-quorum': {
+      const ecdsa = contributions.filter(
+        (contribution) => contribution.kind === 'ecdsa',
+      )
+      if (ecdsa.length !== contributions.length) {
+        throw new Error('Quorum validator received a non-ECDSA contribution')
+      }
+      return encodeQuorumValidatorContribution({
+        owners: codec.owners,
+        thresholdWeight: codec.thresholdWeight,
         contributions: ecdsa,
       })
     }

--- a/src/modules/validators/definition.ts
+++ b/src/modules/validators/definition.ts
@@ -41,6 +41,26 @@ function defineAtomicValidator(
         ),
         threshold: input.threshold ?? 1,
       }
+    case 'quorum': {
+      const owners = input.owners.map(
+        (owner, index): ValidatorOwner => ({
+          kind: 'ecdsa',
+          id: ownerId(index),
+          signerId: ecdsaSignerId(owner.account),
+          account: owner.account,
+          weight: owner.weight,
+        }),
+      )
+      return {
+        kind: 'quorum',
+        id,
+        publicId,
+        module: { source: 'explicit', address: input.module },
+        owners,
+        threshold: owners.length,
+        thresholdWeight: input.thresholdWeight,
+      }
+    }
     case 'ens':
       return {
         kind: 'ens',

--- a/src/modules/validators/quorum.test.ts
+++ b/src/modules/validators/quorum.test.ts
@@ -1,0 +1,222 @@
+import { zeroAddress } from 'viem'
+import { describe, expect, test } from 'vitest'
+import { accountA, accountB } from '../../../test/consts'
+import { encodeQuorumErc1271Signature } from '../../signing/quorum'
+import {
+  buildQuorumMerkleTree,
+  encodeQuorumMerkleEnvelope,
+  encodeQuorumMockSignature,
+  encodeQuorumValidatorContribution,
+  resolveQuorumValidator,
+} from './quorum'
+import type { AtomicValidatorDefinition } from './types'
+
+const moduleAddress = '0x0000000000000000000000000000000000000042'
+const signature = `0x${'11'.repeat(64)}1b` as const
+
+function definition(
+  input: {
+    owners?: AtomicValidatorDefinition['owners']
+    thresholdWeight?: bigint
+    kind?: AtomicValidatorDefinition['kind']
+    explicitModule?: boolean
+  } = {},
+): AtomicValidatorDefinition {
+  return {
+    kind: input.kind ?? 'quorum',
+    id: 'quorum',
+    publicId: 0,
+    module:
+      input.explicitModule === false
+        ? { source: 'default', profile: 'ownable' }
+        : { source: 'explicit', address: moduleAddress },
+    owners: input.owners ?? [
+      {
+        kind: 'ecdsa',
+        id: 'owner/a',
+        signerId: `ecdsa:${accountA.address.toLowerCase()}`,
+        account: accountA,
+        weight: 1n,
+      },
+    ],
+    threshold: 1,
+    thresholdWeight: input.thresholdWeight ?? 1n,
+  }
+}
+
+describe('Quorum validator encoding', () => {
+  test('builds odd-sized trees and rejects a one-operation batch', () => {
+    expect(() =>
+      buildQuorumMerkleTree([
+        { account: accountA.address, digest: `0x${'11'.repeat(32)}` },
+      ]),
+    ).toThrow('at least two operations')
+
+    const tree = buildQuorumMerkleTree([
+      { account: accountA.address, digest: `0x${'11'.repeat(32)}` },
+      { account: accountA.address, digest: `0x${'22'.repeat(32)}` },
+      { account: accountA.address, digest: `0x${'33'.repeat(32)}` },
+    ])
+    expect(tree.operations[2].proof).toHaveLength(1)
+  })
+
+  test('rejects incompatible resolver definitions', () => {
+    expect(() => resolveQuorumValidator(definition({ kind: 'ecdsa' }))).toThrow(
+      'non-quorum',
+    )
+    expect(() =>
+      resolveQuorumValidator(definition({ explicitModule: false })),
+    ).toThrow('deployed module address')
+    expect(() =>
+      encodeQuorumMockSignature(definition({ kind: 'ecdsa' })),
+    ).toThrow('requires a quorum validator')
+  })
+
+  test('rejects malformed owner policies', () => {
+    expect(() => resolveQuorumValidator(definition({ owners: [] }))).toThrow(
+      'owners length',
+    )
+    expect(() =>
+      resolveQuorumValidator(
+        definition({
+          owners: Array.from({ length: 33 }, (_, index) => ({
+            kind: 'ecdsa' as const,
+            id: `owner/${index}`,
+            signerId: `ecdsa:${index}`,
+            account: {
+              ...accountA,
+              address: `0x${(index + 1).toString(16).padStart(40, '0')}`,
+            },
+            weight: 1n,
+          })),
+          thresholdWeight: 1n,
+        }),
+      ),
+    ).toThrow('owners length')
+    expect(() =>
+      resolveQuorumValidator(
+        definition({
+          owners: [
+            {
+              kind: 'ecdsa',
+              id: 'zero',
+              signerId: 'zero',
+              account: { ...accountA, address: zeroAddress },
+              weight: 1n,
+            },
+          ],
+        }),
+      ),
+    ).toThrow('zero address')
+    expect(() =>
+      resolveQuorumValidator(
+        definition({
+          owners: [
+            {
+              kind: 'ecdsa',
+              id: 'zero-weight',
+              signerId: 'zero-weight',
+              account: accountA,
+              weight: 0n,
+            },
+          ],
+        }),
+      ),
+    ).toThrow('fit uint96')
+    expect(() =>
+      resolveQuorumValidator(
+        definition({
+          owners: [
+            {
+              kind: 'ecdsa',
+              id: 'huge-weight',
+              signerId: 'huge-weight',
+              account: accountA,
+              weight: 1n << 96n,
+            },
+          ],
+        }),
+      ),
+    ).toThrow('fit uint96')
+  })
+
+  test('rejects invalid contributions and signature entries', () => {
+    const owners = [
+      { ownerId: 'owner/a', signer: accountA.address, weight: 1n },
+      { ownerId: 'owner/b', signer: accountB.address, weight: 1n },
+    ]
+    expect(() =>
+      encodeQuorumValidatorContribution({
+        owners,
+        thresholdWeight: 1n,
+        contributions: [
+          {
+            kind: 'ecdsa',
+            ownerId: 'unknown',
+            signature,
+            encoding: 'raw-signer',
+          },
+        ],
+      }),
+    ).toThrow('Unknown validator owner')
+    expect(() =>
+      encodeQuorumValidatorContribution({
+        owners,
+        thresholdWeight: 1n,
+        contributions: [
+          {
+            kind: 'ecdsa',
+            ownerId: 'owner/a',
+            signature,
+            encoding: 'raw-signer',
+          },
+          {
+            kind: 'ecdsa',
+            ownerId: 'owner/a',
+            signature,
+            encoding: 'raw-signer',
+          },
+        ],
+      }),
+    ).toThrow('Duplicate validator owner')
+    expect(() =>
+      encodeQuorumValidatorContribution({
+        owners: [owners[0]],
+        thresholdWeight: 1n,
+        contributions: [
+          {
+            kind: 'ecdsa',
+            ownerId: 'owner/a',
+            signature: `0x${'11'.repeat(65_536)}`,
+            encoding: 'raw-signer',
+          },
+        ],
+      }),
+    ).toThrow('exceeds 65535')
+  })
+
+  test('rejects malformed Merkle envelopes', () => {
+    const proof = { root: `0x${'11'.repeat(32)}`, proof: [] }
+    expect(() =>
+      encodeQuorumMerkleEnvelope({ proof, signatures: signature }),
+    ).toThrow('between 1 and 32')
+    expect(() =>
+      encodeQuorumMerkleEnvelope({
+        proof: {
+          ...proof,
+          proof: Array.from({ length: 33 }, () => `0x${'22'.repeat(32)}`),
+        },
+        signatures: signature,
+      }),
+    ).toThrow('between 1 and 32')
+    expect(() =>
+      encodeQuorumMerkleEnvelope({
+        proof: { ...proof, proof: [`0x${'22'.repeat(32)}`] },
+        signatures: '0x',
+      }),
+    ).toThrow('must not be empty')
+    expect(() => encodeQuorumErc1271Signature({ signatures: '0x' })).toThrow(
+      'must not be empty',
+    )
+  })
+})

--- a/src/modules/validators/quorum.test.ts
+++ b/src/modules/validators/quorum.test.ts
@@ -1,4 +1,4 @@
-import { zeroAddress } from 'viem'
+import { type Hex, zeroAddress } from 'viem'
 import { describe, expect, test } from 'vitest'
 import { accountA, accountB } from '../../../test/consts'
 import { encodeQuorumErc1271Signature } from '../../signing/quorum'
@@ -196,7 +196,7 @@ describe('Quorum validator encoding', () => {
   })
 
   test('rejects malformed Merkle envelopes', () => {
-    const proof = { root: `0x${'11'.repeat(32)}`, proof: [] }
+    const proof = { root: `0x${'11'.repeat(32)}` as Hex, proof: [] as Hex[] }
     expect(() =>
       encodeQuorumMerkleEnvelope({ proof, signatures: signature }),
     ).toThrow('between 1 and 32')
@@ -204,7 +204,10 @@ describe('Quorum validator encoding', () => {
       encodeQuorumMerkleEnvelope({
         proof: {
           ...proof,
-          proof: Array.from({ length: 33 }, () => `0x${'22'.repeat(32)}`),
+          proof: Array.from(
+            { length: 33 },
+            () => `0x${'22'.repeat(32)}` as Hex,
+          ),
         },
         signatures: signature,
       }),

--- a/src/modules/validators/quorum.ts
+++ b/src/modules/validators/quorum.ts
@@ -1,0 +1,371 @@
+import {
+  type Address,
+  concat,
+  encodeAbiParameters,
+  type Hex,
+  hashTypedData,
+  keccak256,
+  size,
+  toHex,
+} from 'viem'
+import { compareHexValues } from './ordering'
+import type { ResolvedModule } from '../types'
+import type {
+  AtomicValidatorDefinition,
+  ValidatorContributionInput,
+} from './types'
+
+const MAX_QUORUM_OWNERS = 32
+const MAX_UINT96 = (1n << 96n) - 1n
+const QUORUM_MESSAGE_TYPEHASH = keccak256(
+  toHex(
+    'WeightedOwnableValidatorMessage(address validator,uint256 chainId,address account,bytes32 hash)',
+  ),
+)
+
+/** Bind an ERC-1271 digest to its Quorum module, chain, and smart account. */
+export function getQuorumSignableHash(input: {
+  readonly validator: Address
+  readonly chainId: number
+  readonly account: Address
+  readonly hash: Hex
+}): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        { type: 'bytes32' },
+        { type: 'address' },
+        { type: 'uint256' },
+        { type: 'address' },
+        { type: 'bytes32' },
+      ],
+      [
+        QUORUM_MESSAGE_TYPEHASH,
+        input.validator,
+        BigInt(input.chainId),
+        input.account,
+        input.hash,
+      ],
+    ),
+  )
+}
+
+export interface QuorumMerkleProof {
+  readonly root: Hex
+  readonly proof: readonly Hex[]
+}
+
+export interface QuorumMerkleOperation extends QuorumMerkleProof {
+  readonly account: Address
+  readonly digest: Hex
+  readonly leaf: Hex
+}
+
+/** Build account-bound leaves and Solady-compatible sorted-pair proofs. */
+export function buildQuorumMerkleTree(
+  operations: readonly {
+    readonly account: Address
+    readonly digest: Hex
+  }[],
+): {
+  readonly root: Hex
+  readonly operations: readonly QuorumMerkleOperation[]
+} {
+  if (operations.length < 2) {
+    throw new Error('Quorum Merkle signing requires at least two operations')
+  }
+  const leaves = operations.map(({ account, digest }) =>
+    keccak256(
+      encodeAbiParameters(
+        [{ type: 'address' }, { type: 'bytes32' }],
+        [account, digest],
+      ),
+    ),
+  )
+  const layers: Hex[][] = [leaves]
+  while (layers.at(-1)!.length > 1) {
+    const current = layers.at(-1)!
+    const next: Hex[] = []
+    for (let index = 0; index < current.length; index += 2) {
+      next.push(
+        index + 1 < current.length
+          ? hashQuorumMerklePair(current[index], current[index + 1])
+          : current[index],
+      )
+    }
+    layers.push(next)
+  }
+  const root = layers.at(-1)![0]
+  return {
+    root,
+    operations: operations.map(({ account, digest }, leafIndex) => {
+      const proof: Hex[] = []
+      let index = leafIndex
+      for (const layer of layers.slice(0, -1)) {
+        const siblingIndex = index % 2 === 0 ? index + 1 : index - 1
+        if (siblingIndex < layer.length) proof.push(layer[siblingIndex])
+        index = Math.floor(index / 2)
+      }
+      return { account, digest, leaf: leaves[leafIndex], root, proof }
+    }),
+  }
+}
+
+/** Hash the chain-agnostic EIP-712 root message signed by every owner. */
+export function getQuorumMerkleRootSignableHash(input: {
+  readonly validator: Address
+  readonly root: Hex
+}): Hex {
+  return hashTypedData({
+    domain: {
+      name: 'Quorum Signer',
+      version: '1',
+      verifyingContract: input.validator,
+    },
+    types: {
+      WeightedMerkleRoot: [{ name: 'root', type: 'bytes32' }],
+    },
+    primaryType: 'WeightedMerkleRoot',
+    message: { root: input.root },
+  })
+}
+
+function hashQuorumMerklePair(left: Hex, right: Hex): Hex {
+  return compareHexValues(left, right) < 0
+    ? keccak256(concat([left, right]))
+    : keccak256(concat([right, left]))
+}
+const MAX_SIGNATURE_LENGTH = 65_535
+const QUORUM_MOCK_SIGNATURE = `0x${'00'.repeat(64)}1b` as const
+
+/** Resolve Quorum Signer installation data from a weighted owner definition. */
+export function resolveQuorumValidator(
+  definition: AtomicValidatorDefinition,
+): ResolvedModule {
+  if (definition.kind !== 'quorum') {
+    throw new Error('Quorum resolver received a non-quorum validator')
+  }
+  const owners = resolveOwners(definition)
+  const thresholdWeight = requireThresholdWeight(definition)
+  validateQuorumConfig(owners, thresholdWeight)
+  if (definition.module.source !== 'explicit') {
+    throw new Error('Quorum validator requires a deployed module address')
+  }
+  return {
+    kind: 'validator',
+    address: definition.module.address,
+    initData: encodeAbiParameters(
+      [
+        { name: 'thresholdWeight', type: 'uint256' },
+        {
+          name: 'owners',
+          type: 'tuple[]',
+          components: [
+            { name: 'addr', type: 'address' },
+            { name: 'weight', type: 'uint96' },
+          ],
+        },
+      ],
+      [
+        thresholdWeight,
+        owners.map(({ signer, weight }) => ({ addr: signer, weight })),
+      ],
+    ),
+    deInitData: '0x',
+    additionalContext: '0x',
+  }
+}
+
+/** Encode a regular Quorum Signer envelope from owner signature contributions. */
+export function encodeQuorumValidatorContribution(input: {
+  readonly owners: readonly {
+    readonly ownerId: string
+    readonly signer: Address
+    readonly weight: bigint
+  }[]
+  readonly thresholdWeight: bigint
+  readonly contributions: readonly Extract<
+    ValidatorContributionInput,
+    { readonly kind: 'ecdsa' }
+  >[]
+}): Hex {
+  return concat(['0x00', encodeSelectedQuorumSignatures(input)])
+}
+
+function encodeSelectedQuorumSignatures(input: {
+  readonly owners: readonly {
+    readonly ownerId: string
+    readonly signer: Address
+    readonly weight: bigint
+  }[]
+  readonly thresholdWeight: bigint
+  readonly contributions: readonly Extract<
+    ValidatorContributionInput,
+    { readonly kind: 'ecdsa' }
+  >[]
+}): Hex {
+  validateQuorumConfig(input.owners, input.thresholdWeight)
+  const configured = new Map(
+    input.owners.map((owner) => [owner.ownerId, owner]),
+  )
+  const contributions = new Map<string, Hex>()
+  for (const contribution of input.contributions) {
+    if (!configured.has(contribution.ownerId)) {
+      throw new Error(`Unknown validator owner ${contribution.ownerId}`)
+    }
+    if (contributions.has(contribution.ownerId)) {
+      throw new Error(`Duplicate validator owner ${contribution.ownerId}`)
+    }
+    contributions.set(contribution.ownerId, contribution.signature)
+  }
+  const selected = input.owners
+    .filter((owner) => contributions.has(owner.ownerId))
+    .sort((left, right) => compareAddresses(left.signer, right.signer))
+  const signedWeight = selected.reduce((sum, owner) => sum + owner.weight, 0n)
+  if (signedWeight < input.thresholdWeight) {
+    throw new Error(
+      `Insufficient validator contribution weight: required ${input.thresholdWeight}, received ${signedWeight}`,
+    )
+  }
+  return encodeQuorumEntries(
+    selected.map((owner) => ({
+      signer: owner.signer,
+      signature: contributions.get(owner.ownerId)!,
+    })),
+  )
+}
+
+/** Encode one Merkle proof with an already packed weighted quorum. */
+export function encodeQuorumMerkleEnvelope(input: {
+  readonly proof: QuorumMerkleProof
+  readonly signatures: Hex
+}): Hex {
+  if (input.proof.proof.length < 1 || input.proof.proof.length > 32) {
+    throw new Error('Quorum Merkle proof length must be between 1 and 32')
+  }
+  if (input.signatures === '0x') {
+    throw new Error('Quorum Merkle signatures must not be empty')
+  }
+  return concat([
+    toHex(input.proof.proof.length, { size: 1 }),
+    input.proof.root,
+    ...input.proof.proof,
+    input.signatures,
+  ])
+}
+
+/** Encode weighted entries without the regular or Merkle envelope prefix. */
+export function encodeQuorumWeightedSignatures(input: {
+  readonly owners: readonly {
+    readonly ownerId: string
+    readonly signer: Address
+    readonly weight: bigint
+  }[]
+  readonly thresholdWeight: bigint
+  readonly contributions: readonly Extract<
+    ValidatorContributionInput,
+    { readonly kind: 'ecdsa' }
+  >[]
+}): Hex {
+  return encodeSelectedQuorumSignatures(input)
+}
+
+/** Build a structurally valid maximum-cost signature for bundler gas estimation. */
+export function encodeQuorumMockSignature(
+  definition: AtomicValidatorDefinition,
+): Hex {
+  if (definition.kind !== 'quorum') {
+    throw new Error('Quorum mock signature requires a quorum validator')
+  }
+  const owners = resolveOwners(definition)
+  validateQuorumConfig(owners, requireThresholdWeight(definition))
+  return concat([
+    '0x00',
+    encodeQuorumEntries(
+      owners
+        .map(({ signer }) => ({ signer, signature: QUORUM_MOCK_SIGNATURE }))
+        .sort((left, right) => compareAddresses(left.signer, right.signer)),
+    ),
+  ])
+}
+
+function encodeQuorumEntries(
+  entries: readonly { readonly signer: Address; readonly signature: Hex }[],
+): Hex {
+  if (entries.length === 0)
+    throw new Error('Quorum signature must not be empty')
+  let previous: Address | undefined
+  const packed = entries.map(({ signer, signature }) => {
+    if (previous && compareAddresses(previous, signer) >= 0) {
+      throw new Error(
+        'Quorum signer addresses must be strictly sorted and unique',
+      )
+    }
+    previous = signer
+    const signatureLength = size(signature)
+    if (signatureLength > MAX_SIGNATURE_LENGTH) {
+      throw new Error(
+        `Quorum inner signature exceeds ${MAX_SIGNATURE_LENGTH} bytes`,
+      )
+    }
+    return concat([signer, toHex(signatureLength, { size: 2 }), signature])
+  })
+  return concat(packed)
+}
+
+function resolveOwners(definition: AtomicValidatorDefinition) {
+  return definition.owners.map((owner) => {
+    if (owner.kind === 'webauthn' || owner.weight === undefined) {
+      throw new Error('Quorum validator requires weighted ECDSA owners')
+    }
+    return {
+      ownerId: owner.id,
+      signer: owner.account.address,
+      weight: owner.weight,
+    }
+  })
+}
+
+function requireThresholdWeight(definition: AtomicValidatorDefinition): bigint {
+  if (definition.thresholdWeight === undefined) {
+    throw new Error('Quorum validator threshold weight is missing')
+  }
+  return definition.thresholdWeight
+}
+
+function validateQuorumConfig(
+  owners: readonly { readonly signer: Address; readonly weight: bigint }[],
+  thresholdWeight: bigint,
+): void {
+  if (owners.length < 1 || owners.length > MAX_QUORUM_OWNERS) {
+    throw new Error(
+      `Quorum owners length must be between 1 and ${MAX_QUORUM_OWNERS}`,
+    )
+  }
+  const seen = new Set<string>()
+  let totalWeight = 0n
+  for (const [index, owner] of owners.entries()) {
+    const signer = owner.signer.toLowerCase()
+    if (signer === '0x0000000000000000000000000000000000000000') {
+      throw new Error(`Quorum owner ${index} cannot be the zero address`)
+    }
+    if (seen.has(signer))
+      throw new Error(`Duplicate quorum owner ${owner.signer}`)
+    seen.add(signer)
+    if (owner.weight <= 0n || owner.weight > MAX_UINT96) {
+      throw new Error(
+        `Quorum owner ${owner.signer} weight must fit uint96 and be non-zero`,
+      )
+    }
+    totalWeight += owner.weight
+  }
+  if (thresholdWeight <= 0n || thresholdWeight > totalWeight) {
+    throw new Error(
+      `Quorum threshold weight must be between 1 and total owner weight ${totalWeight}`,
+    )
+  }
+}
+
+function compareAddresses(left: Address, right: Address): number {
+  return compareHexValues(left, right)
+}

--- a/src/modules/validators/quorum.ts
+++ b/src/modules/validators/quorum.ts
@@ -8,8 +8,8 @@ import {
   size,
   toHex,
 } from 'viem'
-import { compareHexValues } from './ordering'
 import type { ResolvedModule } from '../types'
+import { compareHexValues } from './ordering'
 import type {
   AtomicValidatorDefinition,
   ValidatorContributionInput,

--- a/src/modules/validators/quorum.ts
+++ b/src/modules/validators/quorum.ts
@@ -145,7 +145,9 @@ export function resolveQuorumValidator(
   if (definition.kind !== 'quorum') {
     throw new Error('Quorum resolver received a non-quorum validator')
   }
-  const owners = resolveOwners(definition)
+  const owners = resolveOwners(definition).sort((left, right) =>
+    compareHexValues(left.signer, right.signer),
+  )
   const thresholdWeight = requireThresholdWeight(definition)
   validateQuorumConfig(owners, thresholdWeight)
   if (definition.module.source !== 'explicit') {

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -1,4 +1,4 @@
-import { decodeAbiParameters, maxUint48, size } from 'viem'
+import { decodeAbiParameters, maxUint48, size, slice } from 'viem'
 import { describe, expect, test } from 'vitest'
 import {
   accountA,
@@ -10,6 +10,14 @@ import {
 } from '../../../test/consts'
 import { withoutHostCollation } from '../../../test/utils/locale'
 import { resolveStandaloneAccountConfig } from '../../config/resolve'
+import {
+  buildQuorumSigningTree,
+  encodeQuorumErc1271Signature,
+  encodeQuorumMerkleSignature,
+  encodeQuorumOwnerSignatures,
+  getQuorumErc1271SignableHash,
+  getQuorumSigningTreeHash,
+} from '../../signing/quorum'
 import { getValidatorCapabilities } from './capabilities'
 import { resolveEnsValidator } from './ens'
 import { MULTI_FACTOR_VALIDATOR_ADDRESS } from './multi-factor'
@@ -18,6 +26,13 @@ import {
   OWNABLE_V0_VALIDATOR_ADDRESS,
   resolveOwnableValidator,
 } from './ownable'
+import {
+  buildQuorumMerkleTree,
+  encodeQuorumMerkleEnvelope,
+  encodeQuorumValidatorContribution,
+  getQuorumMerkleRootSignableHash,
+  getQuorumSignableHash,
+} from './quorum'
 import { resolveAtomicValidator, resolveValidator } from './resolve'
 import type { AtomicValidatorDefinition } from './types'
 import {
@@ -49,6 +64,228 @@ describe('validator resolution', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000030000000000000000000000006092086a3dc0020cd604a68fcf5d430007d51bb7000000000000000000000000c27b7578151c5ef713c62c65db09763d57ac3596000000000000000000000000f6c02c78ded62973b43bfa523b247da099486936',
     )
     expect(size(encodeOwnableMockSignature(3))).toBe(195)
+  })
+
+  test('encodes weighted quorum installation and sorted signature envelopes', () => {
+    const moduleAddress = '0x0000000000000000000000000000000000000042'
+    const definition = validator({
+      type: 'quorum',
+      module: moduleAddress,
+      thresholdWeight: 50n,
+      owners: [
+        { account: accountA, weight: 50n },
+        { account: accountB, weight: 25n },
+      ],
+    })
+    const module = resolveValidator(definition)
+    expect(module.address).toBe(moduleAddress)
+    const [threshold, owners] = decodeAbiParameters(
+      [
+        { type: 'uint256' },
+        {
+          type: 'tuple[]',
+          components: [
+            { name: 'addr', type: 'address' },
+            { name: 'weight', type: 'uint96' },
+          ],
+        },
+      ],
+      module.initData,
+    )
+    expect(threshold).toBe(50n)
+    expect(owners).toEqual([
+      { addr: accountA.address, weight: 50n },
+      { addr: accountB.address, weight: 25n },
+    ])
+
+    const signatureA = `0x${'11'.repeat(64)}1b` as const
+    const signatureB = `0x${'22'.repeat(64)}1c` as const
+    if (definition.kind !== 'quorum')
+      throw new Error('missing quorum definition')
+    const codec = getValidatorCapabilities(
+      definition,
+      module,
+      'nexus',
+      'user-operation',
+      true,
+    ).contributionCodec
+    if (codec.kind !== 'weighted-quorum')
+      throw new Error('missing quorum codec')
+    const contribution = encodeQuorumValidatorContribution({
+      ...codec,
+      contributions: definition.owners.map((owner) => {
+        if (owner.kind === 'webauthn') throw new Error('unexpected passkey')
+        return {
+          kind: 'ecdsa' as const,
+          ownerId: owner.id,
+          signature:
+            owner.account.address === accountA.address
+              ? signatureA
+              : signatureB,
+          encoding: 'raw-signer' as const,
+        }
+      }),
+    })
+    expect(slice(contribution, 0, 1)).toBe('0x00')
+    expect(
+      getQuorumSignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    ).not.toBe(
+      getQuorumSignableHash({
+        validator: moduleAddress,
+        chainId: 2,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    )
+    const sortedAddresses = [accountA.address, accountB.address].sort()
+    expect(slice(contribution, 1, 21)).toBe(sortedAddresses[0])
+    expect(slice(contribution, 88, 108)).toBe(sortedAddresses[1])
+    const tree = buildQuorumMerkleTree([
+      { account: accountA.address, digest: `0x${'44'.repeat(32)}` },
+      { account: accountB.address, digest: `0x${'55'.repeat(32)}` },
+    ])
+    expect(tree.operations).toHaveLength(2)
+    expect(tree.operations.every(({ root }) => root === tree.root)).toBe(true)
+    expect(
+      getQuorumMerkleRootSignableHash({
+        validator: moduleAddress,
+        root: tree.root,
+      }),
+    ).toMatch(/^0x[0-9a-f]{64}$/u)
+    const merkleEnvelope = encodeQuorumMerkleEnvelope({
+      proof: tree.operations[0],
+      signatures: contribution.slice(4) as `0x${string}`,
+    })
+    expect(slice(merkleEnvelope, 0, 1)).toBe('0x01')
+    expect(slice(merkleEnvelope, 1, 33)).toBe(tree.root)
+
+    const publicTree = buildQuorumSigningTree([
+      { account: accountA.address, digest: `0x${'44'.repeat(32)}` },
+      { account: accountB.address, digest: `0x${'55'.repeat(32)}` },
+    ])
+    const publicRootHash = getQuorumSigningTreeHash({
+      validator: moduleAddress,
+      root: publicTree.root,
+    })
+    expect(publicRootHash).toBe(
+      getQuorumMerkleRootSignableHash({
+        validator: moduleAddress,
+        root: publicTree.root,
+      }),
+    )
+    expect(
+      getQuorumErc1271SignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    ).toBe(
+      getQuorumSignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    )
+    const publicOwners = definition.owners.map((owner) => {
+      if (owner.kind === 'webauthn' || owner.weight === undefined) {
+        throw new Error('unexpected quorum owner')
+      }
+      return {
+        ownerId: owner.id,
+        signer: owner.account.address,
+        weight: owner.weight,
+      }
+    })
+    const publicWeighted = encodeQuorumOwnerSignatures({
+      owners: publicOwners,
+      thresholdWeight: 50n,
+      signatures: definition.owners.map((owner) => ({
+        ownerId: owner.id,
+        signature:
+          owner.kind !== 'webauthn' &&
+          owner.account.address === accountA.address
+            ? signatureA
+            : signatureB,
+      })),
+    })
+    expect(encodeQuorumErc1271Signature({ signatures: publicWeighted })).toBe(
+      contribution,
+    )
+    expect(
+      encodeQuorumMerkleSignature({
+        operation: publicTree.operations[0],
+        signatures: publicWeighted,
+      }),
+    ).toBe(merkleEnvelope)
+  })
+
+  test('rejects unreachable, duplicate, and underweight quorum policies', () => {
+    const module = '0x0000000000000000000000000000000000000042'
+    expect(() =>
+      resolveValidator(
+        validator({
+          type: 'quorum',
+          module,
+          thresholdWeight: 2n,
+          owners: [{ account: accountA, weight: 1n }],
+        }),
+      ),
+    ).toThrow('total owner weight')
+    expect(() =>
+      resolveValidator(
+        validator({
+          type: 'quorum',
+          module,
+          thresholdWeight: 1n,
+          owners: [
+            { account: accountA, weight: 1n },
+            { account: accountA, weight: 1n },
+          ],
+        }),
+      ),
+    ).toThrow('Duplicate quorum owner')
+
+    const definition = validator({
+      type: 'quorum',
+      module,
+      thresholdWeight: 2n,
+      owners: [
+        { account: accountA, weight: 1n },
+        { account: accountB, weight: 1n },
+      ],
+    })
+    if (definition.kind !== 'quorum')
+      throw new Error('missing quorum definition')
+    expect(() =>
+      encodeQuorumValidatorContribution({
+        owners: definition.owners.map((owner) => {
+          if (owner.kind === 'webauthn' || owner.weight === undefined) {
+            throw new Error('unexpected quorum owner')
+          }
+          return {
+            ownerId: owner.id,
+            signer: owner.account.address,
+            weight: owner.weight,
+          }
+        }),
+        thresholdWeight: 2n,
+        contributions: [
+          {
+            kind: 'ecdsa',
+            ownerId: definition.owners[0].id,
+            signature: `0x${'11'.repeat(64)}1b`,
+            encoding: 'raw-signer',
+          },
+        ],
+      }),
+    ).toThrow('received 1')
   })
 
   test('matches exact WebAuthn module bytes and mock schema', () => {

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -96,10 +96,27 @@ describe('validator resolution', () => {
       module.initData,
     )
     expect(threshold).toBe(50n)
-    expect(owners).toEqual([
-      { addr: accountA.address, weight: 50n },
-      { addr: accountB.address, weight: 25n },
-    ])
+    expect(owners).toEqual(
+      [
+        { addr: accountA.address, weight: 50n },
+        { addr: accountB.address, weight: 25n },
+      ].sort((left, right) =>
+        BigInt(left.addr) < BigInt(right.addr) ? -1 : 1,
+      ),
+    )
+    expect(
+      resolveValidator(
+        validator({
+          type: 'quorum',
+          module: moduleAddress,
+          thresholdWeight: 50n,
+          owners: [
+            { account: accountB, weight: 25n },
+            { account: accountA, weight: 50n },
+          ],
+        }),
+      ).initData,
+    ).toBe(module.initData)
 
     const signatureA = `0x${'11'.repeat(64)}1b` as const
     const signatureB = `0x${'22'.repeat(64)}1c` as const

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -289,6 +289,28 @@ describe('validator resolution', () => {
         ],
       }),
     ).toThrow('received 1')
+    const invalidQuorum = {
+      ...definition,
+      owners: [{ ...definition.owners[0], weight: undefined }],
+    } as AtomicValidatorDefinition
+    expect(() =>
+      getValidatorCapabilities(
+        invalidQuorum,
+        resolveValidator(definition),
+        'nexus',
+        'intent',
+        true,
+      ),
+    ).toThrow('weighted ECDSA owners')
+    expect(() =>
+      getValidatorCapabilities(
+        { ...definition, thresholdWeight: undefined },
+        resolveValidator(definition),
+        'nexus',
+        'intent',
+        true,
+      ),
+    ).toThrow('threshold weight is missing')
   })
 
   test('matches exact WebAuthn module bytes and mock schema', () => {

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -286,6 +286,28 @@ describe('validator resolution', () => {
         ],
       }),
     ).toThrow('received 1')
+    const invalidQuorum = {
+      ...definition,
+      owners: [{ ...definition.owners[0], weight: undefined }],
+    } as AtomicValidatorDefinition
+    expect(() =>
+      getValidatorCapabilities(
+        invalidQuorum,
+        resolveValidator(definition),
+        'nexus',
+        'intent',
+        true,
+      ),
+    ).toThrow('weighted ECDSA owners')
+    expect(() =>
+      getValidatorCapabilities(
+        { ...definition, thresholdWeight: undefined },
+        resolveValidator(definition),
+        'nexus',
+        'intent',
+        true,
+      ),
+    ).toThrow('threshold weight is missing')
   })
 
   test('matches exact WebAuthn module bytes and mock schema', () => {

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -9,6 +9,7 @@ import {
   passkeyAccount,
 } from '../../../test/consts'
 import { withoutHostCollation } from '../../../test/utils/locale'
+import { wrapKernelMessageHash } from '../../accounts/kernel-signing'
 import { resolveStandaloneAccountConfig } from '../../config/resolve'
 import {
   buildQuorumSigningTree,
@@ -198,19 +199,36 @@ describe('validator resolution', () => {
         root: publicTree.root,
       }),
     )
+    const applicationHash = `0x${'33'.repeat(32)}` as const
     expect(
       getQuorumErc1271SignableHash({
         validator: moduleAddress,
         chainId: 1,
         account: accountA.address,
-        hash: `0x${'33'.repeat(32)}`,
+        hash: applicationHash,
       }),
     ).toBe(
       getQuorumSignableHash({
         validator: moduleAddress,
         chainId: 1,
         account: accountA.address,
-        hash: `0x${'33'.repeat(32)}`,
+        hash: applicationHash,
+      }),
+    )
+    expect(
+      getQuorumErc1271SignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        accountType: 'kernel',
+        hash: applicationHash,
+      }),
+    ).toBe(
+      getQuorumSignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        hash: wrapKernelMessageHash(applicationHash, accountA.address),
       }),
     )
     const publicOwners = definition.owners.map((owner) => {

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -93,10 +93,27 @@ describe('validator resolution', () => {
       module.initData,
     )
     expect(threshold).toBe(50n)
-    expect(owners).toEqual([
-      { addr: accountA.address, weight: 50n },
-      { addr: accountB.address, weight: 25n },
-    ])
+    expect(owners).toEqual(
+      [
+        { addr: accountA.address, weight: 50n },
+        { addr: accountB.address, weight: 25n },
+      ].sort((left, right) =>
+        BigInt(left.addr) < BigInt(right.addr) ? -1 : 1,
+      ),
+    )
+    expect(
+      resolveValidator(
+        validator({
+          type: 'quorum',
+          module: moduleAddress,
+          thresholdWeight: 50n,
+          owners: [
+            { account: accountB, weight: 25n },
+            { account: accountA, weight: 50n },
+          ],
+        }),
+      ).initData,
+    ).toBe(module.initData)
 
     const signatureA = `0x${'11'.repeat(64)}1b` as const
     const signatureB = `0x${'22'.repeat(64)}1c` as const

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -1,4 +1,4 @@
-import { decodeAbiParameters, maxUint48, size } from 'viem'
+import { decodeAbiParameters, maxUint48, size, slice } from 'viem'
 import { describe, expect, test } from 'vitest'
 import {
   accountA,
@@ -10,6 +10,14 @@ import {
 } from '../../../test/consts'
 import { withoutHostCollation } from '../../../test/utils/locale'
 import { resolveStandaloneAccountConfig } from '../../config/resolve'
+import {
+  buildQuorumSigningTree,
+  encodeQuorumErc1271Signature,
+  encodeQuorumMerkleSignature,
+  encodeQuorumOwnerSignatures,
+  getQuorumErc1271SignableHash,
+  getQuorumSigningTreeHash,
+} from '../../signing/quorum'
 import { getValidatorCapabilities } from './capabilities'
 import { resolveEnsValidator } from './ens'
 import {
@@ -21,6 +29,13 @@ import {
   OWNABLE_V0_VALIDATOR_ADDRESS,
   resolveOwnableValidator,
 } from './ownable'
+import {
+  buildQuorumMerkleTree,
+  encodeQuorumMerkleEnvelope,
+  encodeQuorumValidatorContribution,
+  getQuorumMerkleRootSignableHash,
+  getQuorumSignableHash,
+} from './quorum'
 import { resolveAtomicValidator, resolveValidator } from './resolve'
 import type { AtomicValidatorDefinition } from './types'
 import {
@@ -52,6 +67,228 @@ describe('validator resolution', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000030000000000000000000000006092086a3dc0020cd604a68fcf5d430007d51bb7000000000000000000000000c27b7578151c5ef713c62c65db09763d57ac3596000000000000000000000000f6c02c78ded62973b43bfa523b247da099486936',
     )
     expect(size(encodeOwnableMockSignature(3))).toBe(195)
+  })
+
+  test('encodes weighted quorum installation and sorted signature envelopes', () => {
+    const moduleAddress = '0x0000000000000000000000000000000000000042'
+    const definition = validator({
+      type: 'quorum',
+      module: moduleAddress,
+      thresholdWeight: 50n,
+      owners: [
+        { account: accountA, weight: 50n },
+        { account: accountB, weight: 25n },
+      ],
+    })
+    const module = resolveValidator(definition)
+    expect(module.address).toBe(moduleAddress)
+    const [threshold, owners] = decodeAbiParameters(
+      [
+        { type: 'uint256' },
+        {
+          type: 'tuple[]',
+          components: [
+            { name: 'addr', type: 'address' },
+            { name: 'weight', type: 'uint96' },
+          ],
+        },
+      ],
+      module.initData,
+    )
+    expect(threshold).toBe(50n)
+    expect(owners).toEqual([
+      { addr: accountA.address, weight: 50n },
+      { addr: accountB.address, weight: 25n },
+    ])
+
+    const signatureA = `0x${'11'.repeat(64)}1b` as const
+    const signatureB = `0x${'22'.repeat(64)}1c` as const
+    if (definition.kind !== 'quorum')
+      throw new Error('missing quorum definition')
+    const codec = getValidatorCapabilities(
+      definition,
+      module,
+      'nexus',
+      'user-operation',
+      true,
+    ).contributionCodec
+    if (codec.kind !== 'weighted-quorum')
+      throw new Error('missing quorum codec')
+    const contribution = encodeQuorumValidatorContribution({
+      ...codec,
+      contributions: definition.owners.map((owner) => {
+        if (owner.kind === 'webauthn') throw new Error('unexpected passkey')
+        return {
+          kind: 'ecdsa' as const,
+          ownerId: owner.id,
+          signature:
+            owner.account.address === accountA.address
+              ? signatureA
+              : signatureB,
+          encoding: 'raw-signer' as const,
+        }
+      }),
+    })
+    expect(slice(contribution, 0, 1)).toBe('0x00')
+    expect(
+      getQuorumSignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    ).not.toBe(
+      getQuorumSignableHash({
+        validator: moduleAddress,
+        chainId: 2,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    )
+    const sortedAddresses = [accountA.address, accountB.address].sort()
+    expect(slice(contribution, 1, 21)).toBe(sortedAddresses[0])
+    expect(slice(contribution, 88, 108)).toBe(sortedAddresses[1])
+    const tree = buildQuorumMerkleTree([
+      { account: accountA.address, digest: `0x${'44'.repeat(32)}` },
+      { account: accountB.address, digest: `0x${'55'.repeat(32)}` },
+    ])
+    expect(tree.operations).toHaveLength(2)
+    expect(tree.operations.every(({ root }) => root === tree.root)).toBe(true)
+    expect(
+      getQuorumMerkleRootSignableHash({
+        validator: moduleAddress,
+        root: tree.root,
+      }),
+    ).toMatch(/^0x[0-9a-f]{64}$/u)
+    const merkleEnvelope = encodeQuorumMerkleEnvelope({
+      proof: tree.operations[0],
+      signatures: contribution.slice(4) as `0x${string}`,
+    })
+    expect(slice(merkleEnvelope, 0, 1)).toBe('0x01')
+    expect(slice(merkleEnvelope, 1, 33)).toBe(tree.root)
+
+    const publicTree = buildQuorumSigningTree([
+      { account: accountA.address, digest: `0x${'44'.repeat(32)}` },
+      { account: accountB.address, digest: `0x${'55'.repeat(32)}` },
+    ])
+    const publicRootHash = getQuorumSigningTreeHash({
+      validator: moduleAddress,
+      root: publicTree.root,
+    })
+    expect(publicRootHash).toBe(
+      getQuorumMerkleRootSignableHash({
+        validator: moduleAddress,
+        root: publicTree.root,
+      }),
+    )
+    expect(
+      getQuorumErc1271SignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    ).toBe(
+      getQuorumSignableHash({
+        validator: moduleAddress,
+        chainId: 1,
+        account: accountA.address,
+        hash: `0x${'33'.repeat(32)}`,
+      }),
+    )
+    const publicOwners = definition.owners.map((owner) => {
+      if (owner.kind === 'webauthn' || owner.weight === undefined) {
+        throw new Error('unexpected quorum owner')
+      }
+      return {
+        ownerId: owner.id,
+        signer: owner.account.address,
+        weight: owner.weight,
+      }
+    })
+    const publicWeighted = encodeQuorumOwnerSignatures({
+      owners: publicOwners,
+      thresholdWeight: 50n,
+      signatures: definition.owners.map((owner) => ({
+        ownerId: owner.id,
+        signature:
+          owner.kind !== 'webauthn' &&
+          owner.account.address === accountA.address
+            ? signatureA
+            : signatureB,
+      })),
+    })
+    expect(encodeQuorumErc1271Signature({ signatures: publicWeighted })).toBe(
+      contribution,
+    )
+    expect(
+      encodeQuorumMerkleSignature({
+        operation: publicTree.operations[0],
+        signatures: publicWeighted,
+      }),
+    ).toBe(merkleEnvelope)
+  })
+
+  test('rejects unreachable, duplicate, and underweight quorum policies', () => {
+    const module = '0x0000000000000000000000000000000000000042'
+    expect(() =>
+      resolveValidator(
+        validator({
+          type: 'quorum',
+          module,
+          thresholdWeight: 2n,
+          owners: [{ account: accountA, weight: 1n }],
+        }),
+      ),
+    ).toThrow('total owner weight')
+    expect(() =>
+      resolveValidator(
+        validator({
+          type: 'quorum',
+          module,
+          thresholdWeight: 1n,
+          owners: [
+            { account: accountA, weight: 1n },
+            { account: accountA, weight: 1n },
+          ],
+        }),
+      ),
+    ).toThrow('Duplicate quorum owner')
+
+    const definition = validator({
+      type: 'quorum',
+      module,
+      thresholdWeight: 2n,
+      owners: [
+        { account: accountA, weight: 1n },
+        { account: accountB, weight: 1n },
+      ],
+    })
+    if (definition.kind !== 'quorum')
+      throw new Error('missing quorum definition')
+    expect(() =>
+      encodeQuorumValidatorContribution({
+        owners: definition.owners.map((owner) => {
+          if (owner.kind === 'webauthn' || owner.weight === undefined) {
+            throw new Error('unexpected quorum owner')
+          }
+          return {
+            ownerId: owner.id,
+            signer: owner.account.address,
+            weight: owner.weight,
+          }
+        }),
+        thresholdWeight: 2n,
+        contributions: [
+          {
+            kind: 'ecdsa',
+            ownerId: definition.owners[0].id,
+            signature: `0x${'11'.repeat(64)}1b`,
+            encoding: 'raw-signer',
+          },
+        ],
+      }),
+    ).toThrow('received 1')
   })
 
   test('matches exact WebAuthn module bytes and mock schema', () => {

--- a/src/modules/validators/resolve.ts
+++ b/src/modules/validators/resolve.ts
@@ -2,6 +2,7 @@ import type { ResolvedModule } from '../types'
 import { resolveEnsValidator } from './ens'
 import { resolveMultiFactorValidator } from './multi-factor'
 import { resolveOwnableValidator } from './ownable'
+import { resolveQuorumValidator } from './quorum'
 import type {
   AtomicValidatorDefinition,
   ResolvedValidatorDefinition,
@@ -18,6 +19,8 @@ export function resolveAtomicValidator(
   switch (definition.kind) {
     case 'ecdsa':
       return resolveOwnableValidator(definition)
+    case 'quorum':
+      return resolveQuorumValidator(definition)
     case 'ens':
       return resolveEnsValidator(definition)
     case 'passkey':

--- a/src/modules/validators/types.ts
+++ b/src/modules/validators/types.ts
@@ -5,6 +5,7 @@ import type { SmartSessionEnableContributionData } from './smart-session-signatu
 
 export type ValidatorKind =
   | 'ecdsa'
+  | 'quorum'
   | 'ens'
   | 'passkey'
   | 'multi-factor'
@@ -29,6 +30,20 @@ export interface OwnableValidatorConfig {
   accounts: Account[]
   threshold?: number
   module?: Address
+}
+
+/** One Quorum Signer owner and its non-zero voting weight. */
+export interface QuorumOwner {
+  account: Account
+  weight: bigint
+}
+
+/** Weighted owner configuration for a deployed Quorum Signer validator. */
+export interface QuorumValidatorConfig {
+  type: 'quorum'
+  owners: QuorumOwner[]
+  thresholdWeight: bigint
+  module: Address
 }
 
 export interface ENSValidatorConfig {
@@ -57,6 +72,7 @@ export interface MultiFactorValidatorConfig {
 
 export type OwnerSet =
   | OwnableValidatorConfig
+  | QuorumValidatorConfig
   | ENSValidatorConfig
   | WebauthnValidatorConfig
   | MultiFactorValidatorConfig
@@ -65,9 +81,9 @@ export type OwnerSet =
 // surface (the published types are the named configs above and `OwnerSet`).
 export type AtomicValidatorInput =
   | OwnableValidatorConfig
+  | QuorumValidatorConfig
   | ENSValidatorConfig
   | WebauthnValidatorConfig
-
 export type MultiFactorValidatorInput = MultiFactorValidatorConfig
 
 export type ValidatorInput = OwnerSet
@@ -86,6 +102,7 @@ export type ValidatorOwner =
       readonly signerId: string
       readonly account: Account
       readonly expiration?: Date
+      readonly weight?: bigint
     }
   | {
       readonly kind: 'webauthn'
@@ -101,6 +118,7 @@ export interface AtomicValidatorDefinition {
   readonly module: ValidatorModuleSelection
   readonly owners: readonly ValidatorOwner[]
   readonly threshold: number
+  readonly thresholdWeight?: bigint
 }
 
 export interface MultiFactorValidatorDefinition {
@@ -128,6 +146,16 @@ export type ValidatorContributionCodec =
         readonly usePrecompile: boolean
         readonly format: 'current' | 'v0'
       }
+    }
+  | {
+      readonly kind: 'weighted-quorum'
+      readonly validator: ModuleId
+      readonly owners: readonly {
+        readonly ownerId: string
+        readonly signer: Address
+        readonly weight: bigint
+      }[]
+      readonly thresholdWeight: bigint
     }
   | {
       readonly kind: 'nested-threshold'

--- a/src/package.json
+++ b/src/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/src/signing/passkeys.d.ts",
       "import": "./dist/src/signing/passkeys.js"
     },
+    "./signing/quorum": {
+      "types": "./dist/src/signing/quorum.d.ts",
+      "import": "./dist/src/signing/quorum.js"
+    },
     "./actions/smart-sessions": {
       "types": "./dist/src/actions/smart-sessions.d.ts",
       "import": "./dist/src/actions/smart-sessions.js"

--- a/src/signing/hash.ts
+++ b/src/signing/hash.ts
@@ -1,0 +1,25 @@
+import type { Hex } from 'viem'
+import { wrapKernelMessageHash } from '../accounts/kernel-signing'
+import type { EvmChainReference } from '../chains/types'
+import { getQuorumSignableHash } from '../modules/validators/quorum'
+import type { SigningContext } from './context'
+
+export function resolveAccountValidatorSignableHash(input: {
+  readonly hash: Hex
+  readonly chain: EvmChainReference
+  readonly context: SigningContext
+}): Hex {
+  const accountHash =
+    input.context.account.definition.kind === 'kernel'
+      ? wrapKernelMessageHash(input.hash, input.context.account.address)
+      : input.hash
+  return input.context.validator.kind === 'quorum'
+    ? getQuorumSignableHash({
+        validator:
+          input.context.validatorCapabilities.compatibilityKey.moduleAddress,
+        chainId: input.chain.id,
+        account: input.context.account.address,
+        hash: accountHash,
+      })
+    : accountHash
+}

--- a/src/signing/intent-plans/assemble.ts
+++ b/src/signing/intent-plans/assemble.ts
@@ -1,4 +1,5 @@
 import type { Hex } from 'viem'
+import { encodeQuorumMerkleEnvelope } from '../../modules/validators/quorum'
 import type { SigningContext } from '../context'
 import { encodePlannedValidatorContribution } from '../contribution'
 import { runSigningStep } from '../error'
@@ -60,6 +61,19 @@ export function assembleIntentValidatorArtifact(input: {
         })
       : operation()
   let contribution = input.validatorContribution
+  if (input.artifact.quorumMerkleProof) {
+    if (!contribution.startsWith('0x00')) {
+      throw new Error(
+        'Quorum Merkle contribution has no regular envelope prefix',
+      )
+    }
+    contribution = step('validator-encode', () =>
+      encodeQuorumMerkleEnvelope({
+        proof: input.artifact.quorumMerkleProof!,
+        signatures: `0x${contribution.slice(4)}`,
+      }),
+    )
+  }
   const erc7739 = input.artifact.erc7739
   if (erc7739.kind === 'wrap-typed-data') {
     contribution = step('protocol-operation', () =>

--- a/src/signing/intent-plans/independent.ts
+++ b/src/signing/intent-plans/independent.ts
@@ -74,11 +74,15 @@ export function assembleIndependentIntentArtifact(input: {
     throw new Error('Smart Session state cannot be signed independently')
   }
   const validatorContribution = input.artifact.validatorFactors
-    ? encodeIndependentFactors(
-        codec,
-        input.artifact.validatorFactors,
-        contributions,
-      )
+    ? codec.kind !== 'nested-threshold'
+      ? (() => {
+          throw new Error('Independent factor signing requires a nested codec')
+        })()
+      : encodeIndependentFactors(
+          codec,
+          input.artifact.validatorFactors,
+          contributions,
+        )
     : encodeAtomicContributions(
         codec,
         contributions.map(({ contribution }) => contribution),
@@ -206,9 +210,9 @@ function sameValidatorId(left: number | Hex, right: number | Hex): boolean {
 }
 
 function encodeIndependentFactors(
-  codec: Exclude<
+  codec: Extract<
     ValidatorContributionCodec,
-    { readonly kind: 'smart-session' }
+    { readonly kind: 'nested-threshold' }
   >,
   factors: NonNullable<ArtifactAssemblyPlan['validatorFactors']>,
   contributions: readonly {

--- a/src/signing/intent-plans/intent.test.ts
+++ b/src/signing/intent-plans/intent.test.ts
@@ -1224,6 +1224,29 @@ describe('intent signing plans', () => {
         }),
       ).toThrow('cannot be signed independently')
     }
+
+    expect(() =>
+      assembleIndependentIntentArtifact({
+        intentId,
+        originIndex: 0,
+        originCount: 1,
+        signatures: [valid],
+        owners: [{ ownerId: 'owner/a', identity: owner, kind: 'ecdsa' }],
+        artifact: {
+          ...artifact,
+          validatorFactors: [
+            {
+              id: 'factor',
+              publicId: 1,
+              validator,
+              codec,
+            },
+          ],
+          validatorCodec: codec,
+        },
+        context: signingContext,
+      }),
+    ).toThrow('requires a nested codec')
   })
 
   test('reports insufficient independent atomic and MFA signatures', () => {

--- a/src/signing/pipeline.test.ts
+++ b/src/signing/pipeline.test.ts
@@ -380,6 +380,9 @@ describe('direct rewritten signing pipelines', () => {
       }).payloadKind,
     ).toBe('typed-data')
 
+    if (context.validator.kind === 'multi-factor') {
+      throw new Error('Expected atomic validator')
+    }
     const quorum = resolveAccountTypedDataSigning({
       typedData,
       chain,

--- a/src/signing/pipeline.test.ts
+++ b/src/signing/pipeline.test.ts
@@ -379,6 +379,31 @@ describe('direct rewritten signing pipelines', () => {
         },
       }).payloadKind,
     ).toBe('typed-data')
+
+    const quorum = resolveAccountTypedDataSigning({
+      typedData,
+      chain,
+      context: {
+        ...context,
+        validator: {
+          ...context.validator,
+          kind: 'quorum',
+          thresholdWeight: 1n,
+        },
+        validatorCapabilities: {
+          ...context.validatorCapabilities,
+          compatibilityKey: {
+            ...context.validatorCapabilities.compatibilityKey,
+            validatorKind: 'quorum',
+          },
+        },
+      },
+    })
+    expect(quorum).toMatchObject({
+      material: { kind: 'message' },
+      payloadKind: 'message',
+      ecdsaInvocation: 'ecdsa-sign-message',
+    })
   })
 
   test('supports direct typed-data and deployless typed-data routes', async () => {

--- a/src/signing/pipeline.test.ts
+++ b/src/signing/pipeline.test.ts
@@ -4,10 +4,11 @@ import type {
   AccountAdapter,
   AccountSignatureEnvelopeInput,
 } from '../accounts/adapter'
-import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
 import { K1_DEFAULT_VALIDATOR_ADDRESS } from '../accounts/adapters/startale'
 import { EoaSigningNotSupportedError } from '../accounts/error'
+import { wrapKernelMessageHash } from '../accounts/kernel-signing'
 import type { AccountDefinition } from '../accounts/types'
+import { getQuorumSignableHash } from '../modules/validators/quorum'
 import type { SigningContext } from './context'
 import {
   type AuthorizationListPlanInput,
@@ -406,6 +407,52 @@ describe('direct rewritten signing pipelines', () => {
       material: { kind: 'message' },
       payloadKind: 'message',
       ecdsaInvocation: 'ecdsa-sign-message',
+    })
+
+    const kernelQuorumContext: SigningContext = {
+      ...context,
+      account: { definition: kernelDefinition, address: account },
+      validator: {
+        ...context.validator,
+        kind: 'quorum',
+        thresholdWeight: 1n,
+      },
+      validatorCapabilities: {
+        ...context.validatorCapabilities,
+        compatibilityKey: {
+          ...context.validatorCapabilities.compatibilityKey,
+          validatorKind: 'quorum',
+        },
+      },
+    }
+    const kernelQuorum = resolveAccountTypedDataSigning({
+      typedData,
+      chain,
+      context: kernelQuorumContext,
+    })
+    const expectedKernelQuorumHash = getQuorumSignableHash({
+      validator,
+      chainId: chain.id,
+      account,
+      hash: wrapKernelMessageHash(payload, account),
+    })
+    expect(kernelQuorum.material).toEqual({
+      kind: 'message',
+      message: { raw: expectedKernelQuorumHash },
+    })
+    expect(kernelQuorum.material).not.toEqual({
+      kind: 'message',
+      message: {
+        raw: wrapKernelMessageHash(
+          getQuorumSignableHash({
+            validator,
+            chainId: chain.id,
+            account,
+            hash: payload,
+          }),
+          account,
+        ),
+      },
     })
   })
 

--- a/src/signing/plan.ts
+++ b/src/signing/plan.ts
@@ -370,6 +370,7 @@ export function createValidatorSigningTasks(input: {
       if (!signer)
         throw new Error(`Signer reference ${owner.signerId} is missing`)
       const webauthn = owner.kind === 'webauthn'
+      const quorum = input.validator.kind === 'quorum'
       return [
         {
           id: `${input.taskPrefix}:${owner.id}`,
@@ -377,7 +378,9 @@ export function createValidatorSigningTasks(input: {
           role: input.role ?? (factor.factorId ? 'factor' : 'owner'),
           invocationKind: webauthn
             ? input.webauthnInvocation
-            : input.ecdsaInvocation,
+            : quorum
+              ? ('ecdsa-sign-hash' as const)
+              : input.ecdsaInvocation,
           contribution: webauthn
             ? {
                 kind: 'webauthn' as const,
@@ -475,6 +478,16 @@ function materializeTask(
           kind: 'ecdsa-sign-message',
           ...(chain ? { chain } : {}),
           message: material.message,
+        },
+      }
+    case 'ecdsa-sign-hash':
+      requireMaterial(template, material, 'message')
+      return {
+        ...template,
+        invocation: {
+          kind: 'ecdsa-sign-hash',
+          ...(chain ? { chain } : {}),
+          hash: material.message.raw,
         },
       }
     case 'ecdsa-sign-typed-data':

--- a/src/signing/quorum.ts
+++ b/src/signing/quorum.ts
@@ -1,4 +1,6 @@
 import type { Address, Hex } from 'viem'
+import { wrapKernelMessageHash } from '../accounts/kernel-signing'
+import type { AccountType } from '../accounts/types'
 import {
   buildQuorumMerkleTree,
   encodeQuorumMerkleEnvelope,
@@ -51,8 +53,18 @@ export function getQuorumErc1271SignableHash(input: {
   account: Address
   /** Application hash passed to the smart account's ERC-1271 entry point. */
   hash: Hex
+  /** Smart account implementation, when it transforms ERC-1271 hashes. */
+  accountType?: AccountType
 }): Hex {
-  return getQuorumSignableHash(input)
+  return getQuorumSignableHash({
+    validator: input.validator,
+    chainId: input.chainId,
+    account: input.account,
+    hash:
+      input.accountType === 'kernel'
+        ? wrapKernelMessageHash(input.hash, input.account)
+        : input.hash,
+  })
 }
 
 /** Build account-bound Merkle leaves and proofs for a Quorum signing batch. */

--- a/src/signing/quorum.ts
+++ b/src/signing/quorum.ts
@@ -1,0 +1,122 @@
+import type { Address, Hex } from 'viem'
+import {
+  buildQuorumMerkleTree,
+  encodeQuorumMerkleEnvelope,
+  encodeQuorumWeightedSignatures,
+  getQuorumMerkleRootSignableHash,
+  getQuorumSignableHash,
+  type QuorumMerkleOperation,
+} from '../modules/validators/quorum'
+/** One Quorum Signer owner used to assemble a weighted signature. */
+export interface QuorumSigningOwner {
+  /** Stable owner identifier used to associate an independently collected signature. */
+  ownerId: string
+  /** EOA or EIP-1271 signer address configured in the Quorum validator. */
+  signer: Address
+  /** Weight contributed when this owner's signature validates. */
+  weight: bigint
+}
+
+/** One independently collected signature over a Quorum signing digest. */
+export interface QuorumOwnerSignature {
+  /** Identifier matching one configured {@link QuorumSigningOwner}. */
+  ownerId: string
+  /** Raw ECDSA or EIP-1271 signature bytes. */
+  signature: Hex
+}
+
+/** Account-bound operation included in a Quorum Merkle signing batch. */
+export interface QuorumMerkleSigningOperation {
+  /** Smart account that will validate this operation. */
+  account: Address
+  /** Validator-specific operation digest placed in the account-bound Merkle leaf. */
+  digest: Hex
+}
+
+/** Merkle root and one proof-bearing result for every input operation. */
+export interface QuorumMerkleSigningTree {
+  /** Shared root signed by the owner quorum. */
+  root: Hex
+  /** Proofs in the same order as the input operations. */
+  operations: readonly QuorumMerkleOperation[]
+}
+
+/** Bind an ERC-1271 application hash to one Quorum validator, chain, and account. */
+export function getQuorumErc1271SignableHash(input: {
+  /** Deployed Quorum Signer validator address. */
+  validator: Address
+  /** Chain on which ERC-1271 validation will execute. */
+  chainId: number
+  /** Smart account that will call the validator. */
+  account: Address
+  /** Application hash passed to the smart account's ERC-1271 entry point. */
+  hash: Hex
+}): Hex {
+  return getQuorumSignableHash(input)
+}
+
+/** Build account-bound Merkle leaves and proofs for a Quorum signing batch. */
+export function buildQuorumSigningTree(
+  operations: readonly QuorumMerkleSigningOperation[],
+): QuorumMerkleSigningTree {
+  return buildQuorumMerkleTree(operations)
+}
+
+/** Derive the chain-agnostic EIP-712 digest owners sign for a Quorum Merkle root. */
+export function getQuorumSigningTreeHash(input: {
+  /** Deployed Quorum Signer validator address shared by the target chains. */
+  validator: Address
+  /** Root returned by {@link buildQuorumSigningTree}. */
+  root: Hex
+}): Hex {
+  return getQuorumMerkleRootSignableHash(input)
+}
+
+/** Pack weighted owner signatures without selecting a regular or Merkle envelope. */
+export function encodeQuorumOwnerSignatures(input: {
+  /** Complete configured owner policy, including weights. */
+  owners: readonly QuorumSigningOwner[]
+  /** Minimum aggregate weight required by the validator. */
+  thresholdWeight: bigint
+  /** Independently collected signatures over one common Quorum digest. */
+  signatures: readonly QuorumOwnerSignature[]
+}): Hex {
+  return encodeQuorumWeightedSignatures({
+    owners: input.owners.map(({ ownerId, signer, weight }) => ({
+      ownerId,
+      signer,
+      weight,
+    })),
+    thresholdWeight: input.thresholdWeight,
+    contributions: input.signatures.map(({ ownerId, signature }) => ({
+      kind: 'ecdsa',
+      ownerId,
+      signature,
+      encoding: 'raw-signer',
+    })),
+  })
+}
+
+/** Pack a regular ERC-1271 Quorum signature for one operation digest. */
+export function encodeQuorumErc1271Signature(input: {
+  /** Weighted owner entries returned by {@link encodeQuorumOwnerSignatures}. */
+  signatures: Hex
+}): Hex {
+  if (input.signatures === '0x') {
+    throw new Error('Quorum owner signatures must not be empty')
+  }
+  return `0x00${input.signatures.slice(2)}`
+}
+
+/** Pack one operation's Merkle proof and shared weighted owner signatures. */
+export function encodeQuorumMerkleSignature(input: {
+  /** Operation result returned by {@link buildQuorumSigningTree}. */
+  operation: QuorumMerkleOperation
+  /** Weighted owner entries returned by {@link encodeQuorumOwnerSignatures}. */
+  signatures: Hex
+}): Hex {
+  return encodeQuorumMerkleEnvelope({
+    proof: input.operation,
+    signatures: input.signatures,
+  })
+}

--- a/src/signing/signers/ecdsa.ts
+++ b/src/signing/signers/ecdsa.ts
@@ -14,6 +14,7 @@ export async function invokeEcdsaSigner(input: {
     {
       readonly kind:
         | 'ecdsa-sign-message'
+        | 'ecdsa-sign-hash'
         | 'ecdsa-sign-typed-data'
         | 'sign-authorization'
     }
@@ -37,6 +38,15 @@ export async function invokeEcdsaSigner(input: {
       return {
         kind: 'ecdsa-signature',
         signature: normalizeRecovery(signature),
+      }
+    }
+    case 'ecdsa-sign-hash': {
+      if (!account.sign) throw new Error('Account does not support sign')
+      return {
+        kind: 'ecdsa-signature',
+        signature: normalizeRecovery(
+          await account.sign({ hash: input.invocation.hash }),
+        ),
       }
     }
     case 'ecdsa-sign-typed-data': {

--- a/src/signing/signers/signers.test.ts
+++ b/src/signing/signers/signers.test.ts
@@ -47,6 +47,26 @@ describe('signer adapters', () => {
     expect(port.has?.({ id: 'owner', kind: 'webauthn' })).toBe(false)
   })
 
+  test('signs raw quorum digests without EIP-191 prefixing', async () => {
+    const sign = vi.fn(async () => signature)
+    const signMessage = vi.fn(async () => signature)
+    const account = { address, sign, signMessage } as unknown as Account
+    const port = createSignerInvocationPort({
+      signers: { owner: { kind: 'ecdsa', account } },
+    })
+    await expect(
+      port.invoke(
+        { id: 'owner', kind: 'ecdsa' },
+        { kind: 'ecdsa-sign-hash', hash: '0x1234' },
+      ),
+    ).resolves.toEqual({
+      kind: 'ecdsa-signature',
+      signature: `0x${'22'.repeat(64)}1b`,
+    })
+    expect(sign).toHaveBeenCalledWith({ hash: '0x1234' })
+    expect(signMessage).not.toHaveBeenCalled()
+  })
+
   test('keeps WebAuthn hash and typed-data calls distinct', async () => {
     const result = {
       signature: `0x${'33'.repeat(64)}` as Hex,

--- a/src/signing/typed-data.ts
+++ b/src/signing/typed-data.ts
@@ -1,16 +1,15 @@
 import { type Hex, hashTypedData, type TypedDataDefinition } from 'viem'
-import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
 import {
   K1_DEFAULT_VALIDATOR_ADDRESS,
   startaleEip712Domain,
 } from '../accounts/adapters/startale'
 import { EoaSigningNotSupportedError } from '../accounts/error'
 import type { EvmChainReference } from '../chains/types'
-import { getQuorumSignableHash } from '../modules/validators/quorum'
 import type { SigningContext } from './context'
 import { encodePlannedValidatorContribution } from './contribution'
 import { runSigningStep } from './error'
 import { executeSigningPlan, type SigningStageAssemblyInput } from './execute'
+import { resolveAccountValidatorSignableHash } from './hash'
 import { createSingleStageSigningPlan } from './plan'
 import { wrapErc6492Signature } from './protocols/erc6492'
 import {
@@ -52,17 +51,16 @@ export interface AccountTypedDataSigningRoute {
   readonly webauthnInvocation: 'webauthn-sign-hash' | 'webauthn-sign-typed-data'
   readonly erc7739: ArtifactAssemblyPlan['erc7739']
 }
+
 export function resolveAccountTypedDataSigning(input: {
   readonly typedData: TypedDataDefinition
   readonly chain: EvmChainReference
   readonly context: SigningContext
   /**
-   * Hash presented to the validator before Quorum's module/chain/account
-   * binding. Defaults to the EIP-712 hash of `typedData`.
+   * Hash presented to the smart account's ERC-1271 entry point. Defaults to
+   * the EIP-712 hash of `typedData`.
    */
   readonly validationHash?: Hex
-  /** Use `validationHash` as an already derived Quorum signing digest. */
-  readonly skipQuorumBinding?: boolean
 }): AccountTypedDataSigningRoute {
   const payload = input.validationHash ?? hashTypedData(input.typedData)
   const accountKind = input.context.account.definition.kind
@@ -70,37 +68,25 @@ export function resolveAccountTypedDataSigning(input: {
     accountKind === 'startale' &&
     input.context.validatorCapabilities.compatibilityKey.moduleAddress.toLowerCase() ===
       K1_DEFAULT_VALIDATOR_ADDRESS.toLowerCase()
-  const quorumPayload =
-    input.context.validator.kind === 'quorum'
-      ? input.skipQuorumBinding
-        ? payload
-        : getQuorumSignableHash({
-            validator:
-              input.context.validatorCapabilities.compatibilityKey
-                .moduleAddress,
-            chainId: input.chain.id,
-            account: input.context.account.address,
-            hash: payload,
-          })
-      : undefined
-  const messagePayload =
-    accountKind === 'kernel'
-      ? wrapKernelMessageHash(
-          quorumPayload ?? payload,
-          input.context.account.address,
-        )
-      : (quorumPayload ??
-        (startaleK1
-          ? hashErc7739TypedData({
-              typedData: input.typedData,
-              verifierDomain: startaleEip712Domain(
-                input.context.account.address,
-                input.chain.id,
-              ),
-            })
-          : input.context.validatorCapabilities.supportsEip712
-            ? undefined
-            : payload))
+  const requiresRawHash =
+    accountKind === 'kernel' || input.context.validator.kind === 'quorum'
+  const messagePayload = requiresRawHash
+    ? resolveAccountValidatorSignableHash({
+        hash: payload,
+        chain: input.chain,
+        context: input.context,
+      })
+    : startaleK1
+      ? hashErc7739TypedData({
+          typedData: input.typedData,
+          verifierDomain: startaleEip712Domain(
+            input.context.account.address,
+            input.chain.id,
+          ),
+        })
+      : input.context.validatorCapabilities.supportsEip712
+        ? undefined
+        : payload
   return messagePayload
     ? {
         material: { kind: 'message', message: { raw: messagePayload } },

--- a/src/signing/typed-data.ts
+++ b/src/signing/typed-data.ts
@@ -6,6 +6,7 @@ import {
 } from '../accounts/adapters/startale'
 import { EoaSigningNotSupportedError } from '../accounts/error'
 import type { EvmChainReference } from '../chains/types'
+import { getQuorumSignableHash } from '../modules/validators/quorum'
 import type { SigningContext } from './context'
 import { encodePlannedValidatorContribution } from './contribution'
 import { runSigningStep } from './error'
@@ -44,37 +45,62 @@ export interface TypedDataSigningPlanInput {
   >
 }
 
-export function resolveAccountTypedDataSigning(input: {
-  readonly typedData: TypedDataDefinition
-  readonly chain: EvmChainReference
-  readonly context: SigningContext
-}): {
+export interface AccountTypedDataSigningRoute {
   readonly material: SigningPayloadMaterial
   readonly payloadKind: 'message' | 'typed-data'
   readonly ecdsaInvocation: 'ecdsa-sign-message' | 'ecdsa-sign-typed-data'
   readonly webauthnInvocation: 'webauthn-sign-hash' | 'webauthn-sign-typed-data'
   readonly erc7739: ArtifactAssemblyPlan['erc7739']
-} {
-  const payload = hashTypedData(input.typedData)
+}
+export function resolveAccountTypedDataSigning(input: {
+  readonly typedData: TypedDataDefinition
+  readonly chain: EvmChainReference
+  readonly context: SigningContext
+  /**
+   * Hash presented to the validator before Quorum's module/chain/account
+   * binding. Defaults to the EIP-712 hash of `typedData`.
+   */
+  readonly validationHash?: Hex
+  /** Use `validationHash` as an already derived Quorum signing digest. */
+  readonly skipQuorumBinding?: boolean
+}): AccountTypedDataSigningRoute {
+  const payload = input.validationHash ?? hashTypedData(input.typedData)
   const accountKind = input.context.account.definition.kind
   const startaleK1 =
     accountKind === 'startale' &&
     input.context.validatorCapabilities.compatibilityKey.moduleAddress.toLowerCase() ===
       K1_DEFAULT_VALIDATOR_ADDRESS.toLowerCase()
+  const quorumPayload =
+    input.context.validator.kind === 'quorum'
+      ? input.skipQuorumBinding
+        ? payload
+        : getQuorumSignableHash({
+            validator:
+              input.context.validatorCapabilities.compatibilityKey
+                .moduleAddress,
+            chainId: input.chain.id,
+            account: input.context.account.address,
+            hash: payload,
+          })
+      : undefined
   const messagePayload =
     accountKind === 'kernel'
-      ? wrapKernelMessageHash(payload, input.context.account.address)
-      : startaleK1
-        ? hashErc7739TypedData({
-            typedData: input.typedData,
-            verifierDomain: startaleEip712Domain(
-              input.context.account.address,
-              input.chain.id,
-            ),
-          })
-        : input.context.validatorCapabilities.supportsEip712
-          ? undefined
-          : payload
+      ? wrapKernelMessageHash(
+          quorumPayload ?? payload,
+          input.context.account.address,
+        )
+      : (quorumPayload ??
+        (startaleK1
+          ? hashErc7739TypedData({
+              typedData: input.typedData,
+              verifierDomain: startaleEip712Domain(
+                input.context.account.address,
+                input.chain.id,
+              ),
+            })
+          : input.context.validatorCapabilities.supportsEip712
+            ? undefined
+            : payload))
   return messagePayload
     ? {
         material: { kind: 'message', message: { raw: messagePayload } },

--- a/src/signing/types.ts
+++ b/src/signing/types.ts
@@ -70,6 +70,11 @@ export type SignerInvocation =
       readonly message: { readonly raw: Hex }
     }
   | {
+      readonly kind: 'ecdsa-sign-hash'
+      readonly chain?: EvmChainReference
+      readonly hash: Hex
+    }
+  | {
       readonly kind: 'ecdsa-sign-typed-data'
       readonly chain?: EvmChainReference
       readonly typedData: TypedDataDefinition
@@ -309,6 +314,10 @@ export interface ArtifactAssemblyPlan {
       { readonly kind: 'ordered-threshold' }
     >
   }[]
+  readonly quorumMerkleProof?: {
+    readonly root: Hex
+    readonly proof: readonly Hex[]
+  }
   readonly erc7739:
     | { readonly kind: 'none' }
     | {

--- a/src/transactions/intents/sign-transaction.ts
+++ b/src/transactions/intents/sign-transaction.ts
@@ -6,6 +6,11 @@ import {
 } from '../../errors/execution'
 import { encodeValidatorId } from '../../modules/validators/multi-factor'
 import {
+  buildQuorumMerkleTree,
+  getQuorumMerkleRootSignableHash,
+  getQuorumSignableHash,
+} from '../../modules/validators/quorum'
+import {
   createAccountSigningContext,
   getAccountSignatureEnvelope,
   getSigningValidatorCodec,
@@ -24,11 +29,15 @@ import {
   projectIndependentSigning,
 } from '../../signing/intent-plans/plan'
 import type {
+  IntentSigningPayload,
   IntentSigningPlanCreationInput,
   IntentSigningStageInput,
 } from '../../signing/intent-plans/types'
 import { createValidatorSigningTasks } from '../../signing/plan'
-import { resolveAccountTypedDataSigning } from '../../signing/typed-data'
+import {
+  type AccountTypedDataSigningRoute,
+  resolveAccountTypedDataSigning,
+} from '../../signing/typed-data'
 import type {
   ArtifactAssemblyPlan,
   RawSignerResult,
@@ -374,23 +383,64 @@ function buildIntentPlanInput<CompatibilityConfig>(
 ): IntentSigningPlanCreationInput {
   const payloads: Record<Hex, SigningPayloadRegistry[Hex]> = {}
   const stages: IntentSigningStageInput[] = []
-  for (const [index, origin] of prepared.signing.origins.entries()) {
+  const quorumMerkle =
+    context.validator.kind === 'quorum' && prepared.signing.origins.length > 1
+      ? buildQuorumMerkleTree(
+          prepared.signing.origins.map((origin) => ({
+            account: context.account.address,
+            digest: getQuorumSignableHashForIntent(
+              context,
+              origin.id,
+              origin.chain.id,
+            ),
+          })),
+        )
+      : undefined
+  const quorumRootHash = quorumMerkle
+    ? getQuorumMerkleRootSignableHash({
+        validator: context.validatorCapabilities.compatibilityKey.moduleAddress,
+        root: quorumMerkle.root,
+      })
+    : undefined
+  if (quorumMerkle && quorumRootHash) {
+    const firstOrigin = prepared.signing.origins[0]
     const route = resolveAccountTypedDataSigning({
-      typedData: origin.typedData,
-      chain: origin.chain,
+      typedData: firstOrigin.typedData,
+      chain: firstOrigin.chain,
       context,
+      validationHash: quorumRootHash,
+      skipQuorumBinding: true,
     })
-    payloads[origin.id] = route.material
+    payloads[firstOrigin.id] = route.material
     stages.push(
-      signingStage({
-        id: `origin-${index}`,
-        payloadId: origin.id,
-        chain: origin.chain,
-        usage: 'intent-origin',
+      quorumMerkleSigningStage({
+        origins: prepared.signing.origins,
+        payloadId: firstOrigin.id,
         context,
         route,
+        proofs: quorumMerkle.operations,
       }),
     )
+  } else {
+    for (const [index, origin] of prepared.signing.origins.entries()) {
+      const route = resolveAccountTypedDataSigning({
+        typedData: origin.typedData,
+        chain: origin.chain,
+        context,
+        validationHash: origin.id,
+      })
+      payloads[origin.id] = route.material
+      stages.push(
+        signingStage({
+          id: `origin-${index}`,
+          payloadId: origin.id,
+          chain: origin.chain,
+          usage: 'intent-origin',
+          context,
+          route,
+        }),
+      )
+    }
   }
   const lastOriginIndex = prepared.signing.origins.length - 1
   stages.push({
@@ -398,7 +448,7 @@ function buildIntentPlanInput<CompatibilityConfig>(
     checkpoint: { kind: 'none', id: 'destination:none' },
     priorOutputs: [
       {
-        stageId: `origin-${lastOriginIndex}`,
+        stageId: quorumMerkle ? 'quorum-origins' : `origin-${lastOriginIndex}`,
         outputId: `origin-${lastOriginIndex}`,
         selection: 'whole',
       },
@@ -411,7 +461,9 @@ function buildIntentPlanInput<CompatibilityConfig>(
         usage: 'intent-destination',
         input: {
           kind: 'reuse-artifact',
-          stageId: `origin-${lastOriginIndex}`,
+          stageId: quorumMerkle
+            ? 'quorum-origins'
+            : `origin-${lastOriginIndex}`,
           artifactId: `origin-${lastOriginIndex}`,
           selection: 'whole',
         },
@@ -428,6 +480,7 @@ function buildIntentPlanInput<CompatibilityConfig>(
       typedData: target.typedData,
       chain: target.chain,
       context,
+      validationHash: target.id,
     })
     payloads[target.id] = route.material
     stages.push(
@@ -444,45 +497,131 @@ function buildIntentPlanInput<CompatibilityConfig>(
   return { intent: prepared.signing, stages, payloads }
 }
 
+function quorumMerkleSigningStage(input: {
+  readonly origins: readonly IntentSigningPayload[]
+  readonly payloadId: Hex
+  readonly context: SigningContext
+  readonly route: AccountTypedDataSigningRoute
+  readonly proofs: readonly {
+    readonly root: Hex
+    readonly proof: readonly Hex[]
+  }[]
+}): IntentSigningStageInput {
+  const tasks = createValidatorSigningTasks({
+    validator: input.context.validator,
+    signerReferences: input.context.signerReferences,
+    taskPrefix: 'quorum-root',
+    ecdsaInvocation: input.route.ecdsaInvocation,
+    webauthnInvocation: input.route.webauthnInvocation,
+    selectedSignerIds: input.context.effectiveSigners.signerIds,
+  }).map(
+    (task): SigningTaskTemplate => ({
+      ...task,
+      payload: { source: 'plan-payload', payloadId: input.payloadId },
+    }),
+  )
+  const validatorCodec = getSigningValidatorCodec(
+    input.context,
+    input.route.payloadKind,
+  )
+  return {
+    id: 'quorum-origins',
+    checkpoint: { kind: 'none', id: 'quorum-origins:none' },
+    priorOutputs: [],
+    tasks,
+    schedule: [
+      {
+        id: 'quorum-root:signers',
+        execution: 'parallel',
+        taskIds: tasks.map(({ id }) => id),
+      },
+    ],
+    artifacts: input.origins.map((_, index) => ({
+      id: `origin-${index}`,
+      usage: 'intent-origin',
+      input: { kind: 'task-results', taskIds: tasks.map(({ id }) => id) },
+      validatorCodec,
+      quorumMerkleProof: input.proofs[index],
+      erc7739: { kind: 'none' },
+      accountEnvelope: getAccountSignatureEnvelope(input.context),
+      erc6492: { kind: 'none' },
+    })),
+  }
+}
+
+function getQuorumSignableHashForIntent(
+  context: SigningContext,
+  hash: Hex,
+  chainId: number,
+): Hex {
+  return getQuorumSignableHash({
+    validator: context.validatorCapabilities.compatibilityKey.moduleAddress,
+    chainId,
+    account: context.account.address,
+    hash,
+  })
+}
+
 function signingStage(input: {
   readonly id: string
   readonly payloadId: Hex
   readonly chain: import('../../chains/types').EvmChainReference
   readonly usage: 'intent-origin' | 'intent-target'
   readonly context: SigningContext
-  readonly route: ReturnType<typeof resolveAccountTypedDataSigning>
+  readonly route: AccountTypedDataSigningRoute
+  readonly quorumMerkleProof?: {
+    readonly root: Hex
+    readonly proof: readonly Hex[]
+  }
+  readonly reuseStageId?: string
 }): IntentSigningStageInput {
   const direct = input.context.account.definition.kind === 'eoa'
-  const tasks = direct
-    ? eoaTask(input)
-    : createValidatorSigningTasks({
-        validator: input.context.validator,
-        signerReferences: input.context.signerReferences,
-        taskPrefix: input.id,
-        ecdsaInvocation: input.route.ecdsaInvocation,
-        webauthnInvocation: input.route.webauthnInvocation,
-        selectedSignerIds: input.context.effectiveSigners.signerIds,
-      }).map(
-        (task): SigningTaskTemplate => ({
-          ...task,
-          chain: input.chain,
-          payload: { source: 'plan-payload', payloadId: input.payloadId },
-        }),
-      )
+  const tasks = input.reuseStageId
+    ? []
+    : direct
+      ? eoaTask(input)
+      : createValidatorSigningTasks({
+          validator: input.context.validator,
+          signerReferences: input.context.signerReferences,
+          taskPrefix: input.id,
+          ecdsaInvocation: input.route.ecdsaInvocation,
+          webauthnInvocation: input.route.webauthnInvocation,
+          selectedSignerIds: input.context.effectiveSigners.signerIds,
+        }).map(
+          (task): SigningTaskTemplate => ({
+            ...task,
+            chain: input.chain,
+            payload: { source: 'plan-payload', payloadId: input.payloadId },
+          }),
+        )
   const artifact: Omit<ArtifactAssemblyPlan, 'stageId'> = {
     id: input.id,
     usage: input.usage,
-    input: { kind: 'task-results', taskIds: tasks.map(({ id }) => id) },
-    validatorCodec: direct
+    input: input.reuseStageId
+      ? {
+          kind: 'reuse-artifact',
+          stageId: input.reuseStageId,
+          artifactId: input.reuseStageId,
+          selection: 'whole',
+        }
+      : { kind: 'task-results', taskIds: tasks.map(({ id }) => id) },
+    validatorCodec: input.reuseStageId
       ? { kind: 'none' }
-      : getSigningValidatorCodec(input.context, input.route.payloadKind),
-    ...(!direct && input.context.validator.kind === 'multi-factor'
+      : direct
+        ? { kind: 'none' }
+        : getSigningValidatorCodec(input.context, input.route.payloadKind),
+    ...(!direct &&
+    !input.reuseStageId &&
+    input.context.validator.kind === 'multi-factor'
       ? {
           validatorFactors: getSigningValidatorFactors(
             input.context,
             input.route.payloadKind,
           ),
         }
+      : {}),
+    ...(input.quorumMerkleProof
+      ? { quorumMerkleProof: input.quorumMerkleProof }
       : {}),
     erc7739: input.route.erc7739,
     accountEnvelope: direct
@@ -493,18 +632,29 @@ function signingStage(input: {
   return {
     id: input.id,
     checkpoint: { kind: 'none', id: `${input.id}:none` },
-    priorOutputs: [],
+    priorOutputs: input.reuseStageId
+      ? [
+          {
+            stageId: input.reuseStageId,
+            outputId: input.reuseStageId,
+            selection: 'whole',
+          },
+        ]
+      : [],
     tasks,
-    schedule: [
-      {
-        id: `${input.id}:signers`,
-        execution:
-          input.context.validator.kind === 'multi-factor'
-            ? 'serial'
-            : 'parallel',
-        taskIds: tasks.map(({ id }) => id),
-      },
-    ],
+    schedule:
+      tasks.length === 0
+        ? []
+        : [
+            {
+              id: `${input.id}:signers`,
+              execution:
+                input.context.validator.kind === 'multi-factor'
+                  ? 'serial'
+                  : 'parallel',
+              taskIds: tasks.map(({ id }) => id),
+            },
+          ],
     artifacts: [artifact],
   }
 }

--- a/src/transactions/intents/sign-transaction.ts
+++ b/src/transactions/intents/sign-transaction.ts
@@ -8,7 +8,6 @@ import { encodeValidatorId } from '../../modules/validators/multi-factor'
 import {
   buildQuorumMerkleTree,
   getQuorumMerkleRootSignableHash,
-  getQuorumSignableHash,
 } from '../../modules/validators/quorum'
 import {
   createAccountSigningContext,
@@ -18,6 +17,7 @@ import {
   type SigningContext,
 } from '../../signing/context'
 import { executeSigningPlan } from '../../signing/execute'
+import { resolveAccountValidatorSignableHash } from '../../signing/hash'
 import {
   assembleIndependentIntentArtifact,
   type IndependentOwnerDescriptor,
@@ -405,11 +405,11 @@ function buildIntentPlanInput<CompatibilityConfig>(
       ? buildQuorumMerkleTree(
           prepared.signing.origins.map((origin) => ({
             account: context.account.address,
-            digest: getQuorumSignableHashForIntent(
+            digest: resolveAccountValidatorSignableHash({
+              hash: origin.id,
+              chain: origin.chain,
               context,
-              origin.id,
-              origin.chain.id,
-            ),
+            }),
           })),
         )
       : undefined
@@ -421,13 +421,13 @@ function buildIntentPlanInput<CompatibilityConfig>(
     : undefined
   if (quorumMerkle && quorumRootHash) {
     const firstOrigin = prepared.signing.origins[0]
-    const route = resolveAccountTypedDataSigning({
-      typedData: firstOrigin.typedData,
-      chain: firstOrigin.chain,
-      context,
-      validationHash: quorumRootHash,
-      skipQuorumBinding: true,
-    })
+    const route: AccountTypedDataSigningRoute = {
+      material: { kind: 'message', message: { raw: quorumRootHash } },
+      payloadKind: 'message',
+      ecdsaInvocation: 'ecdsa-sign-message',
+      webauthnInvocation: 'webauthn-sign-hash',
+      erc7739: { kind: 'none' },
+    }
     payloads[firstOrigin.id] = route.material
     stages.push(
       quorumMerkleSigningStage({
@@ -564,19 +564,6 @@ function quorumMerkleSigningStage(input: {
       erc6492: { kind: 'none' },
     })),
   }
-}
-
-function getQuorumSignableHashForIntent(
-  context: SigningContext,
-  hash: Hex,
-  chainId: number,
-): Hex {
-  return getQuorumSignableHash({
-    validator: context.validatorCapabilities.compatibilityKey.moduleAddress,
-    chainId,
-    account: context.account.address,
-    hash,
-  })
 }
 
 function signingStage(input: {

--- a/src/transactions/intents/sign-transaction.ts
+++ b/src/transactions/intents/sign-transaction.ts
@@ -123,15 +123,32 @@ export async function signIntentAsOwner<CompatibilityConfig>(
     signerInvoker: signing.signerInvoker,
     assembleStage: () => ({}),
   })
-  const origin = prepared.signing.origins.map((_payload, index) => {
-    const stage = transcript.stages.find(
-      ({ stage: materialized }) => materialized.stageId === `origin-${index}`,
-    )
-    const result = stage
-      ? Object.entries(stage.results).find(([taskId]) =>
-          taskId.includes(owner.ownerId),
-        )?.[1]
+  const quorumRootStage =
+    signing.validator.kind === 'quorum' && prepared.signing.origins.length > 1
+      ? transcript.stages.find(
+          ({ stage: materialized }) =>
+            materialized.stageId === 'quorum-origins',
+        )
       : undefined
+  const quorumRootResult = quorumRootStage
+    ? Object.entries(quorumRootStage.results).find(([taskId]) =>
+        taskId.includes(owner.ownerId),
+      )?.[1]
+    : undefined
+  const origin = prepared.signing.origins.map((_payload, index) => {
+    const stage = quorumRootStage
+      ? undefined
+      : transcript.stages.find(
+          ({ stage: materialized }) =>
+            materialized.stageId === `origin-${index}`,
+        )
+    const result =
+      quorumRootResult ??
+      (stage
+        ? Object.entries(stage.results).find(([taskId]) =>
+            taskId.includes(owner.ownerId),
+          )?.[1]
+        : undefined)
     return independentOriginResult(owner, result)
   })
   const signature =

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -19,7 +19,7 @@ import { createAccountSigningContext } from '../../signing/context'
 import { buildIntentSigningInput, prepareIntent } from './prepare'
 import { sendIntent } from './send'
 import { buildSessionIntentPlanInput } from './session-signing'
-import { signIntent } from './sign-transaction'
+import { signIntent, signIntentAsOwner } from './sign-transaction'
 import { submitIntent } from './submit'
 import type { IntentWorkflowContext } from './types'
 
@@ -340,6 +340,15 @@ describe('intent workflow', () => {
     expect(firstSignature.slice(4, 68)).toBe(secondSignature.slice(4, 68))
     expect(secondSignature).toMatch(/^0x01/u)
     expect(signed.destinationSignature).toBe(secondSignature)
+
+    const ownerSignature = await signIntentAsOwner(workflow, prepared, {
+      signerId: `ecdsa:${account.address.toLowerCase()}`,
+    })
+    if (ownerSignature.kind !== 'ecdsa') {
+      throw new Error('Expected independent ECDSA signature')
+    }
+    expect(ownerSignature.origin).toHaveLength(2)
+    expect(ownerSignature.origin[0]).toBe(ownerSignature.origin[1])
   })
 
   test('uses an explicit owner selection for preparation and signing', async () => {

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -286,6 +286,62 @@ describe('intent workflow', () => {
     expect(workflow.signerInvoker.invoke).toHaveBeenCalledOnce()
   })
 
+  test('signs a multi-origin quorum once and emits per-origin Merkle proofs', async () => {
+    const quorumValidator = '0x0000000000000000000000000000000000000042'
+    const baseRuntime = runtime()
+    const quorumRuntime: AccountRuntime = {
+      ...baseRuntime,
+      construction: {
+        ...baseRuntime.construction,
+        owner: defineValidator({
+          type: 'quorum',
+          module: quorumValidator,
+          thresholdWeight: 1n,
+          owners: [{ account, weight: 1n }],
+        }),
+      },
+    }
+    const secondOrigin = {
+      ...quote().signData.origin[0],
+      domain: { chainId: 10, verifyingContract: address },
+      message: { value: '2' },
+    }
+    const workflow = context({
+      account: { forChain: vi.fn(async () => quorumRuntime) },
+      quoteClient: {
+        createQuote: vi.fn(async () => ({
+          traceId: 'trace-merkle',
+          routes: [
+            {
+              ...quote(),
+              signData: {
+                ...quote().signData,
+                origin: [quote().signData.origin[0], secondOrigin],
+              },
+            },
+          ],
+        })),
+      },
+    })
+    const prepared = await prepareIntent(workflow, input)
+    const signed = await signIntent(workflow, prepared)
+
+    expect(workflow.signerInvoker.invoke).toHaveBeenCalledOnce()
+    expect(signed.originSignatures).toHaveLength(2)
+    const [firstSignature, secondSignature] = signed.originSignatures
+    if (
+      typeof firstSignature !== 'string' ||
+      typeof secondSignature !== 'string'
+    ) {
+      throw new Error('Expected Quorum Merkle signatures')
+    }
+    expect(firstSignature).not.toBe(secondSignature)
+    expect(firstSignature).toMatch(/^0x01/u)
+    expect(firstSignature.slice(4, 68)).toBe(secondSignature.slice(4, 68))
+    expect(secondSignature).toMatch(/^0x01/u)
+    expect(signed.destinationSignature).toBe(secondSignature)
+  })
+
   test('uses an explicit owner selection for preparation and signing', async () => {
     const workflow = context()
     const validator = defineValidator({

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -10,10 +10,16 @@ import type {
   AccountRuntimePort,
   AccountSignatureEnvelopeInput,
 } from '../../accounts/adapter'
+import { wrapKernelMessageHash } from '../../accounts/kernel-signing'
 import type { AccountConstruction } from '../../accounts/types'
 import { toEvmChainReference } from '../../chains/caip2'
 import type { OrchestratorQuote } from '../../clients/orchestrator/types'
 import { defineValidator } from '../../modules/validators/definition'
+import {
+  buildQuorumMerkleTree,
+  getQuorumMerkleRootSignableHash,
+  getQuorumSignableHash,
+} from '../../modules/validators/quorum'
 import { toSession } from '../../modules/validators/smart-sessions/resolve'
 import { createAccountSigningContext } from '../../signing/context'
 import { buildIntentSigningInput, prepareIntent } from './prepare'
@@ -349,6 +355,82 @@ describe('intent workflow', () => {
     }
     expect(ownerSignature.origin).toHaveLength(2)
     expect(ownerSignature.origin[0]).toBe(ownerSignature.origin[1])
+  })
+
+  test('signs Kernel quorum Merkle leaves with account wrapping before validator binding', async () => {
+    const quorumValidator = '0x0000000000000000000000000000000000000042'
+    const baseRuntime = runtime()
+    const kernelAccount = {
+      kind: 'kernel' as const,
+      version: { source: 'explicit' as const, value: '3.3' as const },
+      salt: { source: 'explicit' as const, value: '0x' as const },
+    }
+    const quorumRuntime: AccountRuntime = {
+      ...baseRuntime,
+      construction: {
+        ...baseRuntime.construction,
+        account: kernelAccount,
+        owner: defineValidator({
+          type: 'quorum',
+          module: quorumValidator,
+          thresholdWeight: 1n,
+          owners: [{ account, weight: 1n }],
+        }),
+      },
+      identity: { definition: kernelAccount, address },
+    }
+    const secondOrigin = {
+      ...quote().signData.origin[0],
+      domain: { chainId: 10, verifyingContract: address },
+      message: { value: '2' },
+    }
+    const workflow = context({
+      account: { forChain: vi.fn(async () => quorumRuntime) },
+      quoteClient: {
+        createQuote: vi.fn(async () => ({
+          traceId: 'trace-kernel-merkle',
+          routes: [
+            {
+              ...quote(),
+              signData: {
+                ...quote().signData,
+                origin: [quote().signData.origin[0], secondOrigin],
+              },
+            },
+          ],
+        })),
+      },
+    })
+    const prepared = await prepareIntent(workflow, input)
+    const tree = buildQuorumMerkleTree(
+      prepared.signing.origins.map((origin) => ({
+        account: address,
+        digest: getQuorumSignableHash({
+          validator: quorumValidator,
+          chainId: origin.chain.id,
+          account: address,
+          hash: wrapKernelMessageHash(origin.id, address),
+        }),
+      })),
+    )
+    const expectedRootHash = getQuorumMerkleRootSignableHash({
+      validator: quorumValidator,
+      root: tree.root,
+    })
+
+    const signed = await signIntent(workflow, prepared)
+
+    expect(signed.originSignatures).toHaveLength(2)
+    expect(workflow.signerInvoker.invoke).toHaveBeenCalledOnce()
+    expect(vi.mocked(workflow.signerInvoker.invoke).mock.calls[0]?.[1]).toEqual(
+      {
+        kind: 'ecdsa-sign-hash',
+        hash: expectedRootHash,
+      },
+    )
+    expect(expectedRootHash).not.toBe(
+      wrapKernelMessageHash(expectedRootHash, address),
+    )
   })
 
   test('uses an explicit owner selection for preparation and signing', async () => {

--- a/src/transactions/user-operations/prepare.ts
+++ b/src/transactions/user-operations/prepare.ts
@@ -151,14 +151,16 @@ export function buildUserOperationSigningPlanInput(
   chain: EvmChainReference,
   hash: Hex,
 ): UserOperationSigningPlanInput {
+  const selectedSignerIds = signingContext.effectiveSigners.signerIds
   const tasks = createValidatorSigningTasks({
     validator: signingContext.validator,
     signerReferences: signingContext.signerReferences,
     taskPrefix: 'user-operation',
     ecdsaInvocation: 'ecdsa-sign-message',
     webauthnInvocation: 'webauthn-sign-hash',
+    selectedSignerIds,
   })
-  const topology = signingTopology(signingContext.validator)
+  const topology = signingTopology(signingContext.validator, selectedSignerIds)
   return {
     hash,
     chain,

--- a/src/transactions/user-operations/validator-account.ts
+++ b/src/transactions/user-operations/validator-account.ts
@@ -2,6 +2,7 @@ import type { Hex } from 'viem'
 import type { AccountRuntime } from '../../accounts/adapter'
 import { encodeMultiFactorContribution } from '../../modules/validators/multi-factor'
 import { encodeOwnableMockSignature } from '../../modules/validators/ownable'
+import { encodeQuorumMockSignature } from '../../modules/validators/quorum'
 import { resolveValidator } from '../../modules/validators/resolve'
 import { WEBAUTHN_MOCK_SIGNATURE } from '../../modules/validators/webauthn'
 import type { SigningContext } from '../../signing/context'
@@ -16,6 +17,9 @@ export function getUserOperationStubSignature(
     )
   }
   if (context.validator.kind === 'passkey') return WEBAUTHN_MOCK_SIGNATURE
+  if (context.validator.kind === 'quorum') {
+    return encodeQuorumMockSignature(context.validator)
+  }
   if (context.validator.kind === 'multi-factor') {
     return encodeMultiFactorContribution({
       factorOrder: context.validator.validators.map(({ id }) => id),

--- a/src/transactions/user-operations/workflow.test.ts
+++ b/src/transactions/user-operations/workflow.test.ts
@@ -6,6 +6,7 @@ import type { AccountConstruction } from '../../accounts/types'
 import { toEvmChainReference } from '../../chains/caip2'
 import type { ContractRead, RpcReadContext } from '../../clients/rpc/types'
 import { defineValidator } from '../../modules/validators/definition'
+import { getQuorumSignableHash } from '../../modules/validators/quorum'
 import { ecdsaSignerId } from '../../modules/validators/signer-id'
 import { prepareUserOperation } from './prepare'
 import {
@@ -204,6 +205,37 @@ describe('UserOperation workflow', () => {
     expect(prepared.signing.effectiveSelection.signerIds).toEqual([
       ecdsaSignerId(selectedOwner),
     ])
+  })
+
+  test('signs quorum UserOperations over the raw EntryPoint hash', async () => {
+    const quorumValidator = '0x0000000000000000000000000000000000000042'
+    const baseRuntime = runtime()
+    const quorumRuntime: AccountRuntime = {
+      ...baseRuntime,
+      construction: {
+        ...baseRuntime.construction,
+        owner: defineValidator({
+          type: 'quorum',
+          module: quorumValidator,
+          thresholdWeight: 1n,
+          owners: [{ account: owner, weight: 1n }],
+        }),
+      },
+    }
+    const workflow = context({
+      account: { forChain: vi.fn(async () => quorumRuntime) },
+    })
+    const prepared = await prepareUserOperation(workflow, input)
+    expect(prepared.signing.hash).toBe(prepared.hash)
+    expect(prepared.signing.tasks[0]?.invocationKind).toBe('ecdsa-sign-hash')
+    expect(prepared.signing.hash).not.toBe(
+      getQuorumSignableHash({
+        validator: quorumValidator,
+        chainId: chain.id,
+        account: sender,
+        hash: prepared.hash,
+      }),
+    )
   })
 
   test('prepares nonce, account call data, deployment, fees, gas, and signing plan', async () => {

--- a/src/transactions/user-operations/workflow.test.ts
+++ b/src/transactions/user-operations/workflow.test.ts
@@ -238,6 +238,53 @@ describe('UserOperation workflow', () => {
     )
   })
 
+  test('signs quorum UserOperations with a threshold-satisfying owner subset', async () => {
+    const quorumValidator = '0x0000000000000000000000000000000000000042'
+    const validator = defineValidator({
+      type: 'quorum',
+      module: quorumValidator,
+      thresholdWeight: 2n,
+      owners: [
+        { account: owner, weight: 1n },
+        { account: selectedOwner, weight: 2n },
+      ],
+    })
+    const baseRuntime = runtime()
+    const quorumRuntime: AccountRuntime = {
+      ...baseRuntime,
+      construction: { ...baseRuntime.construction, owner: validator },
+    }
+    const invoke = vi.fn(async () => ({
+      kind: 'ecdsa-signature' as const,
+      signature,
+    }))
+    const workflow = context({
+      account: { forChain: vi.fn(async () => quorumRuntime) },
+      signerInvoker: { has: () => true, invoke },
+    })
+    const prepared = await prepareUserOperation(workflow, {
+      ...input,
+      signers: {
+        kind: 'owner',
+        validator,
+        signerIds: [ecdsaSignerId(selectedOwner)],
+      },
+    })
+
+    expect(prepared.signing.effectiveSelection.signerIds).toEqual([
+      ecdsaSignerId(selectedOwner),
+    ])
+    expect(prepared.signing.tasks).toHaveLength(1)
+    expect(prepared.signing.tasks[0]?.signer.id).toBe(
+      ecdsaSignerId(selectedOwner),
+    )
+
+    await expect(signUserOperation(workflow, prepared)).resolves.toMatchObject({
+      signature: expect.any(String),
+    })
+    expect(invoke).toHaveBeenCalledTimes(1)
+  })
+
   test('prepares nonce, account call data, deployment, fees, gas, and signing plan', async () => {
     const workflow = context({
       paymaster: {

--- a/test/types/independent-signing.ts
+++ b/test/types/independent-signing.ts
@@ -1,14 +1,60 @@
 import type {
   OwnerSignature,
   PreparedTransactionData,
+  QuorumValidatorConfig,
   RhinestoneAccount,
   SignedTransactionData,
 } from '../../src/index'
+import {
+  buildQuorumSigningTree,
+  encodeQuorumErc1271Signature,
+  encodeQuorumMerkleSignature,
+  encodeQuorumOwnerSignatures,
+  getQuorumErc1271SignableHash,
+  getQuorumSigningTreeHash,
+  type QuorumSigningOwner,
+} from '../../src/signing/quorum'
 import { accountA } from '../consts'
 
 declare const account: RhinestoneAccount
 declare const prepared: PreparedTransactionData
 declare const signatures: OwnerSignature[]
+declare const quorumOwners: QuorumValidatorConfig['owners']
+
+const quorumConfig: QuorumValidatorConfig = {
+  type: 'quorum',
+  module: '0x0000000000000000000000000000000000000042',
+  thresholdWeight: 2n,
+  owners: quorumOwners,
+}
+
+declare const quorumSigningOwners: readonly QuorumSigningOwner[]
+const erc1271Hash = getQuorumErc1271SignableHash({
+  validator: quorumConfig.module,
+  chainId: 1,
+  account: accountA.address,
+  hash: `0x${'11'.repeat(32)}`,
+})
+const tree = buildQuorumSigningTree([
+  { account: accountA.address, digest: erc1271Hash },
+  { account: accountA.address, digest: `0x${'22'.repeat(32)}` },
+])
+const rootHash = getQuorumSigningTreeHash({
+  validator: quorumConfig.module,
+  root: tree.root,
+})
+const packedOwners = encodeQuorumOwnerSignatures({
+  owners: quorumSigningOwners,
+  thresholdWeight: 1n,
+  signatures: [{ ownerId: 'owner-1', signature: `0x${'33'.repeat(65)}` }],
+})
+const regularSignature = encodeQuorumErc1271Signature({
+  signatures: packedOwners,
+})
+const merkleSignature = encodeQuorumMerkleSignature({
+  operation: tree.operations[0],
+  signatures: packedOwners,
+})
 
 const ownerSignature: Promise<OwnerSignature> = account.signTransaction(
   prepared,
@@ -30,6 +76,11 @@ const selectedSignedTransaction: Promise<SignedTransactionData> =
 const assembledTransaction: Promise<SignedTransactionData> =
   account.assembleTransaction(prepared, signatures)
 
+void quorumConfig
+void erc1271Hash
+void rootHash
+void regularSignature
+void merkleSignature
 void ownerSignature
 void selectedOwnerSignature
 void multiFactorOwnerSignature

--- a/test/types/independent-signing.ts
+++ b/test/types/independent-signing.ts
@@ -35,6 +35,13 @@ const erc1271Hash = getQuorumErc1271SignableHash({
   account: accountA.address,
   hash: `0x${'11'.repeat(32)}`,
 })
+const kernelErc1271Hash = getQuorumErc1271SignableHash({
+  validator: quorumConfig.module,
+  chainId: 1,
+  account: accountA.address,
+  accountType: 'kernel',
+  hash: `0x${'11'.repeat(32)}`,
+})
 const tree = buildQuorumSigningTree([
   { account: accountA.address, digest: erc1271Hash },
   { account: accountA.address, digest: `0x${'22'.repeat(32)}` },
@@ -78,6 +85,7 @@ const assembledTransaction: Promise<SignedTransactionData> =
 
 void quorumConfig
 void erc1271Hash
+void kernelErc1271Hash
 void rootHash
 void regularSignature
 void merkleSignature

--- a/test/vectors/accounts/invariants.test.ts
+++ b/test/vectors/accounts/invariants.test.ts
@@ -159,6 +159,8 @@ function reorderOwners(owners: OwnerSet, reorder: Reorder): OwnerSet {
   switch (owners.type) {
     case 'ecdsa':
       return { ...owners, accounts: reorder(owners.accounts) }
+    case 'quorum':
+      return { ...owners, owners: reorder(owners.owners) }
     case 'passkey':
       return { ...owners, accounts: reorder(owners.accounts) }
     case 'ens':
@@ -182,6 +184,8 @@ function ownerCount(owners: OwnerSet): number {
     case 'ecdsa':
     case 'passkey':
       return owners.accounts.length
+    case 'quorum':
+      return owners.owners.length
     case 'ens':
       return owners.owners.length
     case 'multi-factor':
@@ -207,6 +211,14 @@ function recaseOwners(owners: OwnerSet, casing: Casing): OwnerSet {
         accounts: owners.accounts.map((account) =>
           withAddressCasing(account, casing),
         ),
+      }
+    case 'quorum':
+      return {
+        ...owners,
+        owners: owners.owners.map((owner) => ({
+          ...owner,
+          account: withAddressCasing(owner.account, casing),
+        })),
       }
     case 'ens':
       return {
@@ -619,7 +631,10 @@ describe('derivation is invariant under module and default spelling', () => {
         expect(deriveStatic({ ...withoutDefaults, modules: [] })).toEqual(
           baseline,
         )
-        if (withoutDefaults.owners) {
+        if (
+          withoutDefaults.owners &&
+          withoutDefaults.owners.type !== 'quorum'
+        ) {
           const { threshold: _threshold, ...owners } = withoutDefaults.owners
           const implicit = deriveStatic({
             ...withoutDefaults,
@@ -729,6 +744,18 @@ function replaceOwnerAccounts(
     const accounts = replace(owners.accounts)
     return accounts ? { ...owners, accounts } : undefined
   }
+  if (owners.type === 'quorum') {
+    const accounts = replace(owners.owners.map((owner) => owner.account))
+    return accounts
+      ? {
+          ...owners,
+          owners: accounts.map((account, index) => ({
+            account,
+            weight: owners.owners[index]?.weight ?? 1n,
+          })),
+        }
+      : undefined
+  }
   if (owners.type === 'ens') {
     const accounts = replace(owners.owners.map((owner) => owner.account))
     return accounts
@@ -766,7 +793,7 @@ const mutations: readonly Mutation[] = [
   {
     name: 'raises the owner threshold',
     apply: (config) => {
-      if (!config.owners) return undefined
+      if (!config.owners || config.owners.type === 'quorum') return undefined
       if (ownerCount(config.owners) < 2) return undefined
       if (config.owners.threshold === 2) return undefined
       return {


### PR DESCRIPTION
Closes [RHI-6008](https://linear.app/rhinestone/issue/RHI-6008)

## Summary
Add first-class weighted Quorum Signer support across account configuration, validator resolution, signing plans, and public SDK helpers. This lets integrators configure weighted owner policies and collect regular or cross-chain ERC-1271 signatures without reimplementing Quorum-specific hashing, ordering, proof, and envelope rules.

## Changes
### Configuration and validator resolution
- Add `owners: { type: 'quorum', module, thresholdWeight, owners }` account configuration with weighted owner entries.
- Resolve deployed Quorum validator installation data and validate owner count, weights, thresholds, duplicate signers, signature sizes, and canonical signer ordering.
- Add weighted-quorum capabilities, contribution encoding, signer selection, and maximum-cost UserOperation stub signatures.

### Signing flows
- Bind regular ERC-1271 message and typed-data hashes to the validator, chain, and smart account.
- Encode threshold-satisfying weighted owner signatures in deterministic address order.
- Sign multi-origin intents once over a chain-agnostic Merkle root, then emit account-bound proofs and validator envelopes for each origin.
- Preserve raw EntryPoint hash signing for Quorum UserOperations.

### Public API, tests, and release notes
- Export headless helpers from `@rhinestone/sdk/signing/quorum` for regular ERC-1271 digests, Merkle trees, root hashes, weighted signatures, and regular or proof-bearing envelopes.
- Add validator resolution, signer, intent workflow, UserOperation workflow, and public type-usage coverage.
- Document the Quorum signing architecture and add a minor changeset.

## How It Works
A Quorum validator carries an explicit deployed module, weighted owners, and a threshold weight. Regular signing derives an account-bound validator digest and packs the selected owner contributions after verifying that their aggregate weight reaches the threshold. For multi-origin intents, the SDK creates account-bound leaves, builds a sorted-pair Merkle tree, asks the owner quorum to sign one EIP-712 root digest, and assembles a distinct proof-bearing signature for every origin.

## Testing
- Added adversarial validator resolution and encoding coverage for invalid thresholds, weights, owners, ordering, duplicates, and signature bounds.
- Added workflow coverage for single-invocation multi-origin Merkle signing and raw-hash Quorum UserOperations.
- Added compile-time public API coverage for Quorum configuration and headless signing helpers.
- Parent workflow verification was completed before this bounded PR operation.

## Notes
- This is a minor SDK release.
- Quorum configuration requires an explicit deployed validator module address.
- The PR is intentionally opened as a draft.