### PR TITLE
fix(ci): open bump PRs with an app token, and label them

### DIFF
--- a/.github/workflows/update-shared-configs.yaml
+++ b/.github/workflows/update-shared-configs.yaml
@@ -12,11 +12,25 @@ jobs:
   upgrade-shared-configs:
     runs-on: ubuntu-latest
     steps:
+      # GitHub creates no workflow runs for events triggered by GITHUB_TOKEN, so
+      # a PR opened with it never fires `pull_request`, the required checks
+      # never report, and it sits BLOCKED with no error anywhere (RHI-5172).
+      # Events from an app token do trigger workflows.
+      - name: Mint an app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       # v2 (on `main`) no longer bundles `@rhinestone/shared-configs`, so the
       # auto-bump only applies to the legacy v1 line — check out and PR v1.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: v1
+          # Persisted for the `git push` below, so the branch and the PR come
+          # from the same identity.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect package manager
         id: pm
@@ -124,7 +138,7 @@ jobs:
       - name: Create PR
         if: steps.check.outputs.skip != 'true' && steps.commit.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           VERSION="${{ steps.vars.outputs.version }}"
           gh pr create \
@@ -138,4 +152,5 @@ jobs:
           ---
           *Created automatically by [yeet](https://github.com/rhinestonewtf/yeet) publish workflow.*" \
             --base v1 \
-            --head "${{ steps.vars.outputs.branch }}"
+            --head "${{ steps.vars.outputs.branch }}" \
+            --label ship


### PR DESCRIPTION
Phase 3 of RHI-5172. This repo never used yeet's reusable bump workflow — it has its own copy, with the same defect.

## Why the bump PRs here can never merge

GitHub creates no workflow runs for events triggered by `GITHUB_TOKEN`. So every bump PR this workflow opens never fires `pull_request`, none of the required checks report, and it sits `BLOCKED` with no error anywhere explaining why. 95 bot-authored bump PRs are open across the org right now.

The merges are the visible half. The half that matters is that a `@rhinestone/shared-configs` bump currently runs **no typecheck** here, and a bump is a type-level breaking change whenever `ChainEntry` gains a required field.

## Changes

* Mint a GitHub App token and use it for both the branch push (via `actions/checkout`'s persisted credentials) and `gh pr create`. Events from an app token do trigger workflows. `APP_ID`/`APP_PRIVATE_KEY` are org-level secrets — no provisioning needed.
* Add `--label ship`. Rhinestone requires exactly one review label and it drives the `agent-gate` required check; without one the gate reports `Awaiting classification` and waits indefinitely (RHI-5120). So these PRs were stalled twice over — no CI *and* a hung gate.

Self-contained: unlike the reusable-workflow path (`rhinestonewtf/yeet#283` plus a change in each caller), this repo resolves the secrets directly and needs no coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
