### PR TITLE
fix(signing): sign session ERC-1271 typed data in direct mode

### DIFF
--- a/.changeset/fix-session-erc1271-typed-data.md
+++ b/.changeset/fix-session-erc1271-typed-data.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Sign session ERC-1271 typed data in direct (notarized) mode. Signing typed data with a session previously produced an ERC-7739 nested signature that external ERC-1271 verifiers could not resolve, so `isValidSignature` checks against those signatures failed. Session typed-data signing now emits the same direct-mode, account-bound signature that session message signing already produced, so external verifiers resolve the session validator directly. Non-session signing and the account-native ERC-7739 paths are unchanged.

--- a/src/api/direct-signing.ts
+++ b/src/api/direct-signing.ts
@@ -2,10 +2,10 @@ import {
   encodePacked,
   type Hex,
   hashMessage,
+  hashTypedData,
   pad,
   type SignableMessage,
   type TypedDataDefinition,
-  zeroHash,
 } from 'viem'
 import type { AccountRuntime } from '../accounts/adapter'
 import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
@@ -48,34 +48,34 @@ export async function signRuntimeMessage(
   readonly signature: Hex
   readonly transcript: SigningTranscript
 }> {
-  const selection = input.session
-    ? sessionOwnerSelection(input.session)
-    : input.selection
+  if (input.session) {
+    return signSessionErc1271({
+      runtime: input.runtime,
+      signerInvoker: input.signerInvoker,
+      checkpoints: input.checkpoints,
+      chain: input.chain,
+      session: input.session,
+      contentHash: hashMessage(input.message),
+      nominalMessage: input.message,
+    })
+  }
   const context = createAccountSigningContext({
     runtime: input.runtime,
     purpose: 'erc1271',
     signerInvoker: input.signerInvoker,
-    ...(selection ? { selection } : {}),
+    ...(input.selection ? { selection: input.selection } : {}),
   })
-  const topology = signingTopology(context.validator, selection?.signerIds)
+  const topology = signingTopology(
+    context.validator,
+    input.selection?.signerIds,
+  )
   const payload = hashMessage(input.message)
   const accountHash =
     input.runtime.construction.account.kind === 'kernel'
       ? wrapKernelMessageHash(payload, context.account.address)
       : payload
-  const signingMaterial = input.session
-    ? {
-        kind: 'message' as const,
-        message: {
-          raw: hashMessage({
-            raw: encodePacked(
-              ['bytes32', 'bytes32'],
-              [pad(context.account.address, { size: 32 }), accountHash],
-            ),
-          }),
-        },
-      }
-    : input.runtime.construction.account.kind === 'kernel'
+  const signingMaterial =
+    input.runtime.construction.account.kind === 'kernel'
       ? {
           kind: 'message' as const,
           message: { raw: accountHash },
@@ -96,31 +96,11 @@ export async function signRuntimeMessage(
         taskPrefix: 'message',
         ecdsaInvocation: 'ecdsa-sign-message',
         webauthnInvocation: 'webauthn-sign-hash',
-        ...(selection ? { selectedSignerIds: selection.signerIds } : {}),
+        ...(input.selection
+          ? { selectedSignerIds: input.selection.signerIds }
+          : {}),
       }),
-      route: input.session
-        ? {
-            ...route,
-            validatorCodec: {
-              kind: 'smart-session',
-              validator: {
-                kind: 'validator',
-                address: getSmartSessionEmissaryAddress(
-                  input.runtime.construction.sessions.environment,
-                ),
-              },
-              mode: 'notarized',
-              permissionId: getPermissionId(input.session.session),
-              signerCodec: requireSessionOwnerCodec(
-                getSigningValidatorCodec(context),
-              ),
-            },
-            accountEnvelope: smartSessionEnvelope(
-              route.accountEnvelope,
-              input.runtime.construction.sessions.environment,
-            ),
-          }
-        : route,
+      route,
     },
   })
 }
@@ -131,21 +111,33 @@ export async function signRuntimeTypedData(
   readonly signature: Hex
   readonly transcript: SigningTranscript
 }> {
-  const selection = input.session
-    ? sessionOwnerSelection(input.session)
-    : input.selection
+  if (input.session) {
+    // Sessions sign an account-bound digest in direct (notarized) mode, the
+    // same shape signRuntimeMessage produces, so external ERC-1271 verifiers
+    // resolve the session validator directly.
+    const contentHash = hashTypedData(input.typedData)
+    return signSessionErc1271({
+      runtime: input.runtime,
+      signerInvoker: input.signerInvoker,
+      checkpoints: input.checkpoints,
+      chain: input.chain,
+      session: input.session,
+      contentHash,
+      nominalMessage: { raw: contentHash },
+    })
+  }
   const context = createAccountSigningContext({
     runtime: input.runtime,
     purpose: 'erc1271',
     signerInvoker: input.signerInvoker,
-    ...(selection ? { selection } : {}),
+    ...(input.selection ? { selection: input.selection } : {}),
   })
-  const topology = signingTopology(context.validator, selection?.signerIds)
-  const typedData = input.session
-    ? sessionTypedData(input.typedData, input.runtime, input.chain)
-    : input.typedData
+  const topology = signingTopology(
+    context.validator,
+    input.selection?.signerIds,
+  )
   const route = resolveAccountTypedDataSigning({
-    typedData,
+    typedData: input.typedData,
     chain: input.chain,
     context,
   })
@@ -159,7 +151,7 @@ export async function signRuntimeTypedData(
     context,
     checkpoints: input.checkpoints,
     planInput: {
-      typedData,
+      typedData: input.typedData,
       signingMaterial: route.material,
       chain: input.chain,
       ...topology,
@@ -169,22 +161,91 @@ export async function signRuntimeTypedData(
         taskPrefix: 'typed-data',
         ecdsaInvocation: route.ecdsaInvocation,
         webauthnInvocation: route.webauthnInvocation,
-        ...(selection ? { selectedSignerIds: selection.signerIds } : {}),
+        ...(input.selection
+          ? { selectedSignerIds: input.selection.signerIds }
+          : {}),
       }),
-      route: input.session
-        ? {
-            ...accountRoute,
-            erc7739: {
-              kind: 'wrap-session-typed-data',
-              typedData: input.typedData,
-              permissionId: getPermissionId(input.session.session),
-            },
-            accountEnvelope: smartSessionEnvelope(
-              accountRoute.accountEnvelope,
+      route: accountRoute,
+    },
+  })
+}
+
+// Shared ERC-1271 signing for a session: the session owner signs an
+// account-bound digest (keccak of account ‖ contentHash) in the smart-session
+// "notarized" (direct) mode. Used by both message and typed-data signing so
+// they produce the identical on-chain-verifiable shape.
+async function signSessionErc1271(input: {
+  readonly runtime: AccountRuntime
+  readonly signerInvoker: SignerInvocationPort
+  readonly checkpoints: SigningCheckpointPort
+  readonly chain: EvmChainReference
+  readonly session: ResolvedSessionSignerSet
+  readonly contentHash: Hex
+  readonly nominalMessage: SignableMessage
+}): Promise<{
+  readonly signature: Hex
+  readonly transcript: SigningTranscript
+}> {
+  const selection = sessionOwnerSelection(input.session)
+  const context = createAccountSigningContext({
+    runtime: input.runtime,
+    purpose: 'erc1271',
+    signerInvoker: input.signerInvoker,
+    selection,
+  })
+  const topology = signingTopology(context.validator, selection.signerIds)
+  const accountHash =
+    input.runtime.construction.account.kind === 'kernel'
+      ? wrapKernelMessageHash(input.contentHash, context.account.address)
+      : input.contentHash
+  const route = getAccountSignatureRoute(input.runtime, context)
+  return signAccountMessage({
+    context,
+    checkpoints: input.checkpoints,
+    planInput: {
+      message: input.nominalMessage,
+      signingMaterial: {
+        kind: 'message' as const,
+        message: {
+          raw: hashMessage({
+            raw: encodePacked(
+              ['bytes32', 'bytes32'],
+              [pad(context.account.address, { size: 32 }), accountHash],
+            ),
+          }),
+        },
+      },
+      chain: input.chain,
+      ...topology,
+      tasks: createValidatorSigningTasks({
+        validator: context.validator,
+        signerReferences: context.signerReferences,
+        taskPrefix: 'message',
+        ecdsaInvocation: 'ecdsa-sign-message',
+        webauthnInvocation: 'webauthn-sign-hash',
+        selectedSignerIds: selection.signerIds,
+      }),
+      route: {
+        ...route,
+        validatorCodec: {
+          kind: 'smart-session',
+          validator: {
+            kind: 'validator',
+            address: getSmartSessionEmissaryAddress(
               input.runtime.construction.sessions.environment,
             ),
-          }
-        : accountRoute,
+          },
+          mode: 'notarized',
+          permissionId: getPermissionId(input.session.session),
+          signerCodec: requireSessionOwnerCodec(
+            getSigningValidatorCodec(context),
+          ),
+        },
+        accountEnvelope: smartSessionEnvelope(
+          route.accountEnvelope,
+          input.runtime.construction.sessions.environment,
+        ),
+      },
     },
   })
 }
@@ -226,55 +287,4 @@ function smartSessionEnvelope(
   return envelope.kind === 'kernel'
     ? { ...envelope, validator, isRoot: false }
     : { ...envelope, validator }
-}
-
-function sessionTypedData(
-  typedData: TypedDataDefinition,
-  runtime: AccountRuntime,
-  chain: EvmChainReference,
-): TypedDataDefinition {
-  const verifier = sessionVerifierDomain(runtime, chain)
-  return {
-    domain: typedData.domain,
-    primaryType: 'TypedDataSign',
-    types: {
-      ...typedData.types,
-      TypedDataSign: [
-        { name: 'contents', type: typedData.primaryType as string },
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-        { name: 'salt', type: 'bytes32' },
-      ],
-    },
-    message: {
-      contents: typedData.message,
-      ...verifier,
-    },
-  } as unknown as TypedDataDefinition
-}
-
-function sessionVerifierDomain(
-  runtime: AccountRuntime,
-  chain: EvmChainReference,
-) {
-  const common = {
-    chainId: chain.id,
-    verifyingContract: runtime.identity.address,
-    salt: zeroHash,
-  }
-  switch (runtime.construction.account.kind) {
-    case 'safe':
-      return { ...common, name: 'rhinestone safe7579', version: 'v1.0.0' }
-    case 'nexus':
-    case 'hca':
-      return { ...common, name: 'Nexus', version: '1.2.0' }
-    case 'kernel':
-      return { ...common, name: 'Kernel', version: '0.3.3' }
-    case 'startale':
-      return { ...common, name: 'Startale', version: '1.0.0' }
-    case 'eoa':
-      throw new Error('EOA accounts do not have an EIP-712 domain')
-  }
 }

--- a/src/signing/execute.test.ts
+++ b/src/signing/execute.test.ts
@@ -1053,4 +1053,59 @@ describe('signing plan materialization and execution', () => {
       }).endsWith('1f'),
     ).toBe(true)
   })
+
+  test('encodes a session ERC-1271 contribution in direct (notarized) mode', () => {
+    const sessionSignature = `0x${'22'.repeat(64)}1b` as Hex
+    const validator = {
+      kind: 'validator' as const,
+      address: '0x3333333333333333333333333333333333333333' as const,
+    }
+    const artifact = {
+      id: 'signature',
+      stageId: 'stage',
+      usage: 'erc1271' as const,
+      input: { kind: 'task-results' as const, taskIds: ['owner'] },
+      validatorCodec: {
+        kind: 'smart-session' as const,
+        validator,
+        mode: 'notarized' as const,
+        permissionId: payloadId,
+      },
+      erc7739: { kind: 'none' as const },
+      accountEnvelope: { kind: 'none' as const },
+      erc6492: { kind: 'none' as const },
+    }
+    const stage = {
+      stageId: 'stage',
+      facts: [],
+      schedule: [],
+      tasks: [
+        {
+          ...task('owner'),
+          payload: { source: 'plan-payload' as const, payloadId },
+          contribution: {
+            kind: 'session' as const,
+            recoveryEncoding: 'validator-offset-4' as const,
+          },
+          invocation: {
+            kind: 'ecdsa-sign-message' as const,
+            message: { raw: payloadId },
+          },
+        },
+      ],
+    }
+
+    const result = encodePlannedValidatorContribution({
+      artifact,
+      stage,
+      results: {
+        owner: { kind: 'ecdsa-signature', signature: sessionSignature },
+      },
+    })
+    // Direct-mode ERC-1271: a leading smart-session mode byte 0x00, followed
+    // immediately by the permissionId — never mode 0x01 and never a mode-less
+    // blob, so external ERC-1271 verifiers resolve the session on the first try.
+    expect(result.slice(0, 4)).toBe('0x00')
+    expect(result.slice(4, 68)).toBe(payloadId.slice(2))
+  })
 })

--- a/src/signing/typed-data.ts
+++ b/src/signing/typed-data.ts
@@ -1,4 +1,4 @@
-import { concat, type Hex, hashTypedData, type TypedDataDefinition } from 'viem'
+import { type Hex, hashTypedData, type TypedDataDefinition } from 'viem'
 import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
 import {
   K1_DEFAULT_VALIDATOR_ADDRESS,
@@ -171,15 +171,12 @@ export function assembleTypedDataStage(
   )
   const erc7739 = artifact.erc7739
   if (erc7739.kind !== 'none') {
-    contribution = step('protocol-operation', () => {
-      const wrapped = wrapErc7739TypedDataSignature({
+    contribution = step('protocol-operation', () =>
+      wrapErc7739TypedDataSignature({
         typedData: erc7739.typedData,
         signature: contribution,
-      })
-      return erc7739.kind === 'wrap-session-typed-data'
-        ? concat([erc7739.permissionId, wrapped])
-        : wrapped
-    })
+      }),
+    )
   }
   const accountSignature =
     artifact.accountEnvelope.kind === 'none'

--- a/src/signing/types.ts
+++ b/src/signing/types.ts
@@ -315,11 +315,6 @@ export interface ArtifactAssemblyPlan {
         readonly kind: 'wrap-typed-data'
         readonly typedData: TypedDataDefinition
       }
-    | {
-        readonly kind: 'wrap-session-typed-data'
-        readonly typedData: TypedDataDefinition
-        readonly permissionId: Hex
-      }
   readonly accountEnvelope: AccountSignatureEnvelope
   readonly erc6492:
     | { readonly kind: 'none' }


### PR DESCRIPTION
## What

Routes the session case of `signRuntimeTypedData` through the same direct-mode (notarized, mode `0x00`) account-bound signing path that `signRuntimeMessage` already uses for sessions, via a new shared `signSessionErc1271` helper.

Previously, signing typed data with a session produced an ERC-7739 nested signature packed as `permissionId ‖ erc7739Sig` with no smart-session mode byte. External ERC-1271 verifiers (a third-party protocol calling `account.isValidSignature`) can't resolve the session validator from that shape, so verification fails. Message signing already emitted the correct direct-mode shape for sessions — this brings typed-data signing in line.

## Changes

- **`signSessionErc1271` helper** — signs the account-bound digest `hashMessage(pad(account,32) ‖ contentHash)` in smart-session `notarized` mode. Both `signRuntimeMessage` (`contentHash = hashMessage(message)`) and `signRuntimeTypedData` (`contentHash = hashTypedData(typedData)`) use it for the session case, so the two produce identical, verifiable output.
- Removed the now-unused `wrap-session-typed-data` artifact kind (`typed-data.ts`, `types.ts`).
- Account-native (Startale/Nexus-K1) and intent-plan ERC-7739 paths are unchanged.
- Added a test asserting a notarized session contribution begins with mode byte `0x00` followed by the permissionId.

## Testing

- `tsc --noEmit` clean; `biome check` clean.
- `vitest run src/signing/execute.test.ts` — 14/14 pass (incl. the new case).
- Non-session message + typed-data output is byte-identical to before (helper reproduces the prior inline session logic).

Closes [RHI-6074](https://linear.app/rhinestone/issue/RHI-6074)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmP5wzhhzCja1useM2u6oZ
