### PR TITLE
feat: add configurable smart session signing

### DIFF
--- a/.changeset/scoped-session-signing.md
+++ b/.changeset/scoped-session-signing.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add disabled, unrestricted, and EIP-712 domain-and-schema-scoped Smart Session signing capabilities, with optional session-wide validity windows. Existing sessions remain unrestricted when signing configuration is omitted; scoped direct signing is rejected until safe ERC-7739 emission is available.

--- a/src/README.md
+++ b/src/README.md
@@ -199,6 +199,41 @@ const session = toSession({
 })
 ```
 
+Smart Session ERC-1271 signing is unrestricted when `signing` is omitted. It
+can be disabled, time-boxed, or scoped to exact EIP-712 domains and schemas:
+
+```ts
+const disabled = { mode: 'disabled' } as const
+const timeboxed = {
+  mode: 'unrestricted',
+  validAfter: new Date(),
+  validUntil: new Date(Date.now() + 60 * 60 * 1000),
+} as const
+const scoped = {
+  mode: 'scoped',
+  allowedContents: [
+    {
+      domain: {
+        name: 'Permit2',
+        chainId: base.id,
+        verifyingContract: permit2,
+      },
+      types: {
+        Permit: [
+          { name: 'spender', type: 'address' },
+          { name: 'amount', type: 'uint256' },
+        ],
+      },
+      primaryType: 'Permit',
+    },
+  ],
+} as const
+```
+
+A scoped entry constrains its domain and schema, not message values. Scoped
+configuration can be enabled on-chain, but this SDK intentionally rejects
+scoped direct signing until safe ERC-7739 signature emission is available.
+
 For a complete walkthrough, see the [Quickstart guide](https://docs.rhinestone.dev/smart-wallet/quickstart).
 
 ## Migrating from Orchestrator SDK

--- a/src/api/compose.test.ts
+++ b/src/api/compose.test.ts
@@ -385,6 +385,67 @@ describe('internal core composition', () => {
     )
   })
 
+  test.each([
+    {
+      signing: { mode: 'disabled' as const },
+      error: 'signing disabled',
+    },
+    {
+      signing: {
+        mode: 'scoped' as const,
+        allowedContents: [
+          {
+            domain: { chainId: 1, verifyingContract: target },
+            types: { Test: [{ name: 'value', type: 'uint256' }] },
+            primaryType: 'Test',
+          },
+        ],
+      },
+      error: 'safe ERC-7739 emission',
+    },
+  ])(
+    'rejects $signing.mode Smart Session direct signing before invoking a signer',
+    async ({ signing, error }) => {
+      const base = fixture()
+      const invoke = vi.fn()
+      const workflows = createCoreComposition(base.context.sdk, {
+        ...base.dependencies,
+        signerInvoker: { invoke },
+      }).createAccount(base.context).workflows
+      const session = toSession({
+        chain: { id: 1 } as never,
+        owners: { type: 'ecdsa', accounts: [owner] },
+        signing,
+      })
+      const signers = {
+        kind: 'smart-session' as const,
+        byChain: { 1: { session } },
+      }
+      const typedData = {
+        domain: { chainId: 1, verifyingContract: target },
+        types: { Test: [{ name: 'value', type: 'uint256' }] },
+        primaryType: 'Test',
+        message: { value: 1n },
+      } as const
+
+      await expect(
+        workflows.signMessage(base.context, {
+          message: 'hello',
+          chain,
+          signers,
+        }),
+      ).rejects.toThrow(error)
+      await expect(
+        workflows.signTypedData(base.context, {
+          typedData,
+          chain,
+          signers,
+        }),
+      ).rejects.toThrow(error)
+      expect(invoke).not.toHaveBeenCalled()
+    },
+  )
+
   test('waits for intent and custom-bundler deployment execution', async () => {
     const first = fixture()
     const intentWorkflows = first.composition.createAccount(

--- a/src/api/direct-signing.ts
+++ b/src/api/direct-signing.ts
@@ -6,6 +6,7 @@ import {
   pad,
   type SignableMessage,
   type TypedDataDefinition,
+  zeroHash,
 } from 'viem'
 import type { AccountRuntime } from '../accounts/adapter'
 import { wrapKernelMessageHash } from '../accounts/adapters/kernel'
@@ -186,6 +187,7 @@ async function signSessionErc1271(input: {
   readonly signature: Hex
   readonly transcript: SigningTranscript
 }> {
+  assertDirectSessionSigning(input.session)
   const selection = sessionOwnerSelection(input.session)
   const context = createAccountSigningContext({
     runtime: input.runtime,
@@ -248,6 +250,22 @@ async function signSessionErc1271(input: {
       },
     },
   })
+}
+
+function assertDirectSessionSigning(session: ResolvedSessionSignerSet): void {
+  const allowedContents = session.session.erc7739Policies.allowedERC7739Content
+  const allowsDirectSigning = allowedContents.some(
+    (content) =>
+      content.appDomainSeparator === zeroHash &&
+      content.contentNames.includes(''),
+  )
+  if (allowsDirectSigning) return
+  if (allowedContents.length === 0) {
+    throw new Error('This Smart Session has signing disabled')
+  }
+  throw new Error(
+    'Scoped Smart Session signing requires safe ERC-7739 emission, which is not available in this SDK',
+  )
 }
 
 function sessionOwnerSelection(

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -2,7 +2,16 @@
 // from the legacy `src/types.ts` so the published surface no longer depends on
 // the legacy tree. Internal resolved config shapes live in `./resolved`.
 
-import type { Abi, AbiFunction, Account, Address, Chain, Hex } from 'viem'
+import type {
+  Abi,
+  AbiFunction,
+  Account,
+  Address,
+  Chain,
+  Hex,
+  TypedData,
+  TypedDataDomain,
+} from 'viem'
 import type { WebAuthnAccount } from 'viem/account-abstraction'
 import type { AccountType } from '../accounts/types'
 import type { NonEvmAddress, NonEvmChain } from '../chains/non-evm'
@@ -531,6 +540,38 @@ interface SessionPolicyAddresses {
   valueLimit?: Address
 }
 
+/** An EIP-712 domain and canonical schema that a scoped session may sign. */
+interface SessionSigningContent {
+  /** The exact application domain. Omitted fields are not inferred. */
+  domain: TypedDataDomain
+  /** The primary type and every custom type reachable from it. */
+  types: TypedData
+  primaryType: string
+}
+
+/**
+ * ERC-1271 signing capability for a Smart Session.
+ *
+ * Omitting this field preserves the legacy unrestricted behavior. Scoped
+ * signing matches the domain and schema only, not message field values, and
+ * uses one validity window for every allowed schema. The production SDK does
+ * not yet emit scoped ERC-7739 signatures, so scoped direct signing fails
+ * locally until the deployed nested-signing path is remediated.
+ */
+type SessionSigning =
+  | { mode: 'disabled' }
+  | {
+      mode: 'unrestricted'
+      validAfter?: Date
+      validUntil?: Date
+    }
+  | {
+      mode: 'scoped'
+      allowedContents: readonly SessionSigningContent[]
+      validAfter?: Date
+      validUntil?: Date
+    }
+
 interface SessionDefinition<TAbis extends readonly Abi[] = readonly Abi[]> {
   chain: Chain
   owners: OwnerSet
@@ -543,6 +584,11 @@ interface SessionDefinition<TAbis extends readonly Abi[] = readonly Abi[]> {
    * See {@link CrossChainPermissionInput}.
    */
   crossChainPermits?: readonly CrossChainPermissionInput[]
+  /**
+   * Configure ERC-1271 signing. Omission is unrestricted for backwards
+   * compatibility; use `disabled` to remove signing capability explicitly.
+   */
+  signing?: SessionSigning
   /**
    * Override one or more SmartSession policy addresses. Defaults to the latest
    * V2 deployments. Use to pin to V1 deployments for an account that already
@@ -988,6 +1034,8 @@ export type {
   PerChainSessionSignerSet,
   SessionSignerSet,
   SessionDefinition,
+  SessionSigning,
+  SessionSigningContent,
   SessionInput,
   SessionEnableData,
   Session,

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ export type {
   RhinestoneAccountConfig,
   Session,
   SessionDefinition,
+  SessionSigning,
+  SessionSigningContent,
   SignerSet,
   SourceCallInput,
   SourceCallProvidedFunds,

--- a/src/modules/validators/smart-sessions/erc7739.ts
+++ b/src/modules/validators/smart-sessions/erc7739.ts
@@ -1,0 +1,23 @@
+export function encodeErc7739ContentType(input: {
+  readonly primaryType: string
+  readonly types: Readonly<
+    Record<string, readonly { readonly name: string; readonly type: string }[]>
+  >
+}): string {
+  const { primaryType, types } = input
+  const dependencies = new Set<string>()
+  const collect = (type: string): void => {
+    const typeName = type.match(/^\w*/)?.[0]
+    if (!typeName || dependencies.has(typeName) || !types[typeName]) return
+    dependencies.add(typeName)
+    for (const field of types[typeName]) collect(field.type)
+  }
+  collect(primaryType)
+  dependencies.delete(primaryType)
+  return [primaryType, ...[...dependencies].sort()]
+    .map(
+      (type) =>
+        `${type}(${types[type].map((field) => `${field.type} ${field.name}`).join(',')})`,
+    )
+    .join('')
+}

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -17,6 +17,7 @@ import {
   resolvePermit2ClaimPolicy,
 } from './policies/claim'
 import { encodeSessionPolicy } from './policies/encode'
+import { resolveSessionSigning } from './signing'
 import type {
   ResolvedAction,
   Session,
@@ -129,16 +130,16 @@ export function resolveSessionData(
       resolvePermit2ClaimPolicy(policy),
     ),
   }))
+  const erc7739Policies = resolveSessionSigning({
+    signing: definition.signing,
+    environment,
+    addresses,
+  })
   return {
     sessionValidator: validator.address,
     sessionValidatorInitData: validator.initData,
     salt: zeroHash,
-    erc7739Policies: {
-      allowedERC7739Content: [
-        { contentNames: [''], appDomainSeparator: zeroHash },
-      ],
-      erc1271Policies: [{ policy: addresses.sudo, initData: '0x' }],
-    },
+    erc7739Policies,
     actions,
     claimPolicies,
   }

--- a/src/modules/validators/smart-sessions/signing.test.ts
+++ b/src/modules/validators/smart-sessions/signing.test.ts
@@ -1,0 +1,306 @@
+import { domainSeparator, encodePacked, zeroHash } from 'viem'
+import { base } from 'viem/chains'
+import { describe, expect, test } from 'vitest'
+import { accountA } from '../../../../test/consts'
+import {
+  SUDO_POLICY_ADDRESS,
+  TIME_FRAME_POLICY_ADDRESS,
+} from './policies/addresses'
+import { toSession } from './resolve'
+
+const domain = {
+  name: 'Permit2',
+  chainId: base.id,
+  verifyingContract: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+} as const
+const permitDetails = [
+  { name: 'token', type: 'address' },
+  { name: 'amount', type: 'uint160' },
+  { name: 'expiration', type: 'uint48' },
+  { name: 'nonce', type: 'uint48' },
+] as const
+const permitSingle = [
+  { name: 'details', type: 'PermitDetails' },
+  { name: 'spender', type: 'address' },
+  { name: 'sigDeadline', type: 'uint256' },
+] as const
+const permitBatch = [
+  { name: 'details', type: 'PermitDetails[]' },
+  { name: 'spender', type: 'address' },
+  { name: 'sigDeadline', type: 'uint256' },
+] as const
+
+function definition() {
+  return {
+    chain: base,
+    owners: { type: 'ecdsa' as const, accounts: [accountA] },
+  }
+}
+
+describe('Smart Session signing capability', () => {
+  test('keeps omission and explicit unrestricted signing identical', () => {
+    const omitted = toSession(definition())
+    const explicit = toSession({
+      ...definition(),
+      signing: { mode: 'unrestricted' },
+    })
+
+    expect(explicit.permissionId).toBe(omitted.permissionId)
+    expect(explicit.erc7739Policies).toEqual({
+      allowedERC7739Content: [
+        { appDomainSeparator: zeroHash, contentNames: [''] },
+      ],
+      erc1271Policies: [{ policy: SUDO_POLICY_ADDRESS, initData: '0x' }],
+    })
+  })
+
+  test('resolves disabled signing to empty contract configuration', () => {
+    const session = toSession({
+      ...definition(),
+      signing: { mode: 'disabled' },
+    })
+    expect(session.erc7739Policies).toEqual({
+      allowedERC7739Content: [],
+      erc1271Policies: [],
+    })
+  })
+
+  test('groups canonical schemas under their exact application domain', () => {
+    const session = toSession({
+      ...definition(),
+      signing: {
+        mode: 'scoped',
+        allowedContents: [
+          {
+            domain,
+            primaryType: 'PermitSingle',
+            types: { PermitSingle: permitSingle, PermitDetails: permitDetails },
+          },
+          {
+            domain,
+            primaryType: 'PermitBatch',
+            types: { PermitDetails: permitDetails, PermitBatch: permitBatch },
+          },
+        ],
+      },
+    })
+
+    expect(session.erc7739Policies.allowedERC7739Content).toEqual([
+      {
+        appDomainSeparator: domainSeparator({ domain }),
+        contentNames: [
+          'PermitSingle(PermitDetails details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)',
+          'PermitBatch(PermitDetails[] details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)',
+        ],
+      },
+    ])
+  })
+
+  test('selects one time-frame policy and honors address overrides', () => {
+    const timeFrame = '0xdeadbeef00000000000000000000000000000001' as const
+    const session = toSession({
+      ...definition(),
+      policyAddresses: { timeFrame },
+      signing: {
+        mode: 'unrestricted',
+        validAfter: new Date(1_000),
+        validUntil: new Date(5_999),
+      },
+    })
+
+    expect(session.erc7739Policies.erc1271Policies).toEqual([
+      {
+        policy: timeFrame,
+        initData: encodePacked(['uint48', 'uint48'], [5, 1]),
+      },
+    ])
+  })
+
+  test('uses the established one-sided time-frame defaults', () => {
+    const afterOnly = toSession({
+      ...definition(),
+      signing: { mode: 'unrestricted', validAfter: new Date(1_000) },
+    })
+    const untilOnly = toSession({
+      ...definition(),
+      signing: { mode: 'unrestricted', validUntil: new Date(5_000) },
+    })
+
+    expect(afterOnly.erc7739Policies.erc1271Policies).toEqual([
+      {
+        policy: TIME_FRAME_POLICY_ADDRESS,
+        initData: encodePacked(['uint48', 'uint48'], [4_102_444_800, 1]),
+      },
+    ])
+    expect(untilOnly.erc7739Policies.erc1271Policies).toEqual([
+      {
+        policy: TIME_FRAME_POLICY_ADDRESS,
+        initData: encodePacked(['uint48', 'uint48'], [5, 0]),
+      },
+    ])
+  })
+
+  test('rejects invalid scoped content', () => {
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'scoped',
+          allowedContents: [
+            {
+              domain: {
+                ...domain,
+                verifyingContracts: domain.verifyingContract,
+              },
+              primaryType: 'Permit',
+              types: { Permit: [{ name: 'value', type: 'uint256' }] },
+            },
+          ],
+        } as never,
+      }),
+    ).toThrow('Unsupported EIP-712 domain field "verifyingContracts"')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'scoped',
+          allowedContents: [
+            {
+              domain,
+              primaryType: 'Permit',
+              types: { Permit: [{ name: 'values', type: 'uint256[0]' }] },
+            },
+          ],
+        },
+      }),
+    ).toThrow('not a valid EIP-712 type')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'scoped',
+          allowedContents: [
+            {
+              domain,
+              primaryType: 'Permit',
+              types: {
+                Permit: [
+                  { name: 'value', type: 'uint256' },
+                  { name: 'value', type: 'address' },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow('duplicate field "value"')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'scoped',
+          allowedContents: [
+            {
+              domain,
+              primaryType: 'EIP712Domain',
+              types: { EIP712Domain: [] },
+            },
+          ],
+        },
+      }),
+    ).toThrow('cannot be a scoped signing primary type')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: { mode: 'scoped', allowedContents: [] },
+      }),
+    ).toThrow('at least one')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'scoped',
+          allowedContents: [{ domain, primaryType: 'Missing', types: {} }],
+        },
+      }),
+    ).toThrow('primary type "Missing" is missing')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'scoped',
+          allowedContents: [
+            {
+              domain,
+              primaryType: 'PermitSingle',
+              types: { PermitSingle: permitSingle },
+            },
+          ],
+        },
+      }),
+    ).toThrow('type "PermitDetails" is missing')
+  })
+
+  test('rejects duplicate resolved domain and schema pairs', () => {
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'scoped',
+          allowedContents: [
+            {
+              domain,
+              primaryType: 'PermitSingle',
+              types: {
+                PermitSingle: permitSingle,
+                PermitDetails: permitDetails,
+              },
+            },
+            {
+              domain: { ...domain },
+              primaryType: 'PermitSingle',
+              types: {
+                PermitDetails: permitDetails,
+                PermitSingle: permitSingle,
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow('Duplicate scoped signing content')
+  })
+
+  test('rejects invalid and inverted validity windows after second normalization', () => {
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'disabled',
+          validUntil: new Date(),
+        } as never,
+      }),
+    ).toThrow('Disabled session signing cannot have a validity window')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: { mode: 'unrestricted', validAfter: new Date(Number.NaN) },
+      }),
+    ).toThrow('valid Date')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: { mode: 'unrestricted', validAfter: new Date(-1) },
+      }),
+    ).toThrow('uint48 range')
+    expect(() =>
+      toSession({
+        ...definition(),
+        signing: {
+          mode: 'unrestricted',
+          validAfter: new Date(2_000),
+          validUntil: new Date(1_999),
+        },
+      }),
+    ).toThrow('validUntil is before validAfter')
+  })
+})

--- a/src/modules/validators/smart-sessions/signing.test.ts
+++ b/src/modules/validators/smart-sessions/signing.test.ts
@@ -174,6 +174,26 @@ describe('Smart Session signing capability', () => {
         },
       }),
     ).toThrow('not a valid EIP-712 type')
+    for (const type of ['uint', 'int']) {
+      expect(() =>
+        toSession({
+          ...definition(),
+          signing: {
+            mode: 'scoped',
+            allowedContents: [
+              {
+                domain,
+                primaryType: 'Permit',
+                types: {
+                  Permit: [{ name: 'value', type }],
+                  [type]: [],
+                },
+              },
+            ],
+          } as never,
+        }),
+      ).toThrow(`type "${type}" is not a valid EIP-712 type`)
+    }
     expect(() =>
       toSession({
         ...definition(),

--- a/src/modules/validators/smart-sessions/signing.ts
+++ b/src/modules/validators/smart-sessions/signing.ts
@@ -120,6 +120,11 @@ function validateTypeDependencies(primaryType: string, types: TypedData): void {
       )
     }
     const typeName = match[1]
+    if (typeName === 'uint' || typeName === 'int') {
+      throw new Error(
+        `Scoped signing type "${typeName}" is not a valid EIP-712 type`,
+      )
+    }
     if (isPrimitiveType(typeName) || visited.has(typeName)) return
     const fields = types[typeName]
     if (!fields) {
@@ -152,7 +157,7 @@ function isPrimitiveType(type: string): boolean {
     type === 'string' ||
     type === 'bytes' ||
     /^bytes([1-9]|[12][0-9]|3[0-2])$/u.test(type) ||
-    /^(u?int)(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)?$/u.test(
+    /^(u?int)(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)$/u.test(
       type,
     )
   )

--- a/src/modules/validators/smart-sessions/signing.ts
+++ b/src/modules/validators/smart-sessions/signing.ts
@@ -1,0 +1,204 @@
+import { domainSeparator, type TypedData, zeroHash } from 'viem'
+import { FAR_FUTURE_MS } from '../permissions'
+import { encodeErc7739ContentType } from './erc7739'
+import type { ResolvedPolicyAddresses } from './policies/addresses'
+import { encodeSessionPolicy } from './policies/encode'
+import type {
+  ResolvedERC7739Policies,
+  SessionSigning,
+  SessionSigningContent,
+} from './types'
+
+const UINT48_MAX = 2 ** 48 - 1
+const DOMAIN_FIELDS = new Set([
+  'name',
+  'version',
+  'chainId',
+  'verifyingContract',
+  'salt',
+])
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/u
+
+export function resolveSessionSigning(input: {
+  readonly signing?: SessionSigning
+  readonly environment: 'production' | 'development'
+  readonly addresses: ResolvedPolicyAddresses
+}): ResolvedERC7739Policies {
+  const signing = input.signing ?? { mode: 'unrestricted' }
+  if (signing.mode === 'disabled') {
+    if ('validAfter' in signing || 'validUntil' in signing) {
+      throw new Error('Disabled session signing cannot have a validity window')
+    }
+    return { allowedERC7739Content: [], erc1271Policies: [] }
+  }
+
+  const allowedERC7739Content =
+    signing.mode === 'unrestricted'
+      ? [{ appDomainSeparator: zeroHash, contentNames: [''] }]
+      : resolveAllowedContents(signing.allowedContents)
+
+  return {
+    allowedERC7739Content,
+    erc1271Policies: [
+      resolveSigningPolicy({
+        validAfter: signing.validAfter,
+        validUntil: signing.validUntil,
+        environment: input.environment,
+        addresses: input.addresses,
+      }),
+    ],
+  }
+}
+
+function resolveAllowedContents(
+  contents: readonly SessionSigningContent[],
+): ResolvedERC7739Policies['allowedERC7739Content'] {
+  if (contents.length === 0) {
+    throw new Error(
+      'Scoped session signing requires at least one allowed content',
+    )
+  }
+
+  const byDomain = new Map<
+    string,
+    { appDomainSeparator: `0x${string}`; contentNames: string[] }
+  >()
+  const seen = new Set<string>()
+  for (const content of contents) {
+    validateContent(content)
+    const appDomainSeparator = domainSeparator({ domain: content.domain })
+    const contentName = encodeErc7739ContentType({
+      primaryType: content.primaryType,
+      types: content.types,
+    })
+    const duplicateKey = `${appDomainSeparator}:${contentName}`
+    if (seen.has(duplicateKey)) {
+      throw new Error(
+        `Duplicate scoped signing content for ${content.primaryType} under domain ${appDomainSeparator}`,
+      )
+    }
+    seen.add(duplicateKey)
+
+    const group = byDomain.get(appDomainSeparator)
+    if (group) group.contentNames.push(contentName)
+    else {
+      byDomain.set(appDomainSeparator, {
+        appDomainSeparator,
+        contentNames: [contentName],
+      })
+    }
+  }
+  return [...byDomain.values()]
+}
+
+function validateContent(content: SessionSigningContent): void {
+  for (const field of Object.keys(content.domain)) {
+    if (!DOMAIN_FIELDS.has(field)) {
+      throw new Error(`Unsupported EIP-712 domain field "${field}"`)
+    }
+  }
+  if (content.primaryType === 'EIP712Domain') {
+    throw new Error('EIP712Domain cannot be a scoped signing primary type')
+  }
+  if (!content.types[content.primaryType]) {
+    throw new Error(
+      `Scoped signing primary type "${content.primaryType}" is missing from types`,
+    )
+  }
+  validateTypeDependencies(content.primaryType, content.types)
+}
+
+function validateTypeDependencies(primaryType: string, types: TypedData): void {
+  const visited = new Set<string>()
+  const visit = (type: string): void => {
+    const match = type.match(
+      /^([A-Za-z_][A-Za-z0-9_]*)(\[(?:[1-9][0-9]*)?\])*$/u,
+    )
+    if (!match) {
+      throw new Error(
+        `Scoped signing type "${type}" is not a valid EIP-712 type`,
+      )
+    }
+    const typeName = match[1]
+    if (isPrimitiveType(typeName) || visited.has(typeName)) return
+    const fields = types[typeName]
+    if (!fields) {
+      throw new Error(`Scoped signing type "${typeName}" is missing from types`)
+    }
+    visited.add(typeName)
+    const fieldNames = new Set<string>()
+    for (const field of fields) {
+      if (!IDENTIFIER.test(field.name)) {
+        throw new Error(
+          `Scoped signing field name "${field.name}" in ${typeName} is invalid`,
+        )
+      }
+      if (fieldNames.has(field.name)) {
+        throw new Error(
+          `Scoped signing type "${typeName}" has duplicate field "${field.name}"`,
+        )
+      }
+      fieldNames.add(field.name)
+      visit(field.type)
+    }
+  }
+  visit(primaryType)
+}
+
+function isPrimitiveType(type: string): boolean {
+  return (
+    type === 'address' ||
+    type === 'bool' ||
+    type === 'string' ||
+    type === 'bytes' ||
+    /^bytes([1-9]|[12][0-9]|3[0-2])$/u.test(type) ||
+    /^(u?int)(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)?$/u.test(
+      type,
+    )
+  )
+}
+
+function resolveSigningPolicy(input: {
+  readonly validAfter?: Date
+  readonly validUntil?: Date
+  readonly environment: 'production' | 'development'
+  readonly addresses: ResolvedPolicyAddresses
+}) {
+  if (input.validAfter === undefined && input.validUntil === undefined) {
+    return encodeSessionPolicy(
+      { type: 'sudo' },
+      input.environment,
+      input.addresses,
+    )
+  }
+
+  const validAfter = dateSeconds(input.validAfter ?? new Date(0), 'validAfter')
+  const validUntil = dateSeconds(
+    input.validUntil ?? new Date(FAR_FUTURE_MS),
+    'validUntil',
+  )
+  if (validUntil < validAfter) {
+    throw new Error('Session signing validUntil is before validAfter')
+  }
+  return encodeSessionPolicy(
+    {
+      type: 'time-frame',
+      validAfter: validAfter * 1000,
+      validUntil: validUntil * 1000,
+    },
+    input.environment,
+    input.addresses,
+  )
+}
+
+function dateSeconds(date: Date, field: string): number {
+  const milliseconds = date.getTime()
+  if (!Number.isFinite(milliseconds)) {
+    throw new Error(`Session signing ${field} must be a valid Date`)
+  }
+  const seconds = Math.floor(milliseconds / 1000)
+  if (seconds < 0 || seconds > UINT48_MAX) {
+    throw new Error(`Session signing ${field} is outside the uint48 range`)
+  }
+  return seconds
+}

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -4,7 +4,9 @@ import type {
   Address,
   Chain,
   Hex,
+  TypedData,
   TypedDataDefinition,
+  TypedDataDomain,
 } from 'viem'
 import type { OwnerSet } from '../types'
 
@@ -154,12 +156,33 @@ export interface Permit2ClaimPolicy {
   fillDeadline?: { chain: Chain; min?: bigint; max?: bigint }[]
 }
 
+export interface SessionSigningContent {
+  readonly domain: TypedDataDomain
+  readonly types: TypedData
+  readonly primaryType: string
+}
+
+export type SessionSigning =
+  | { readonly mode: 'disabled' }
+  | {
+      readonly mode: 'unrestricted'
+      readonly validAfter?: Date
+      readonly validUntil?: Date
+    }
+  | {
+      readonly mode: 'scoped'
+      readonly allowedContents: readonly SessionSigningContent[]
+      readonly validAfter?: Date
+      readonly validUntil?: Date
+    }
+
 export interface SessionDefinition {
   chain: Chain
   owners: OwnerSet
   permissions?: Permission[]
   claimPolicies?: Permit2ClaimPolicy[]
   crossChainPermits?: CrossChainPermissionInput[]
+  signing?: SessionSigning
   policyAddresses?: SessionPolicyAddresses
 }
 

--- a/src/signing/protocols/erc7739.ts
+++ b/src/signing/protocols/erc7739.ts
@@ -12,6 +12,9 @@ import {
   toHex,
 } from 'viem'
 import { wrapTypedDataSignature } from 'viem/experimental/erc7739'
+import { encodeErc7739ContentType } from '../../modules/validators/smart-sessions/erc7739'
+
+export { encodeErc7739ContentType }
 
 export interface Erc7739VerifierDomain {
   readonly name: string
@@ -33,7 +36,10 @@ export function hashErc7739TypedData(input: {
     string,
     readonly { readonly name: string; readonly type: string }[]
   >
-  const contentsType = encodeType(primaryType, typeFields)
+  const contentsType = encodeErc7739ContentType({
+    primaryType,
+    types: typeFields,
+  })
   const typedDataSignTypeHash = keccak256(
     toHex(
       `TypedDataSign(${primaryType} contents,string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)${contentsType}`,
@@ -94,27 +100,4 @@ export function wrapErc7739TypedDataSignature(input: {
     message: typedData.message as Record<string, unknown>,
     signature: input.signature,
   })
-}
-
-function encodeType(
-  primaryType: string,
-  types: Readonly<
-    Record<string, readonly { readonly name: string; readonly type: string }[]>
-  >,
-): string {
-  const dependencies = new Set<string>()
-  const collect = (type: string): void => {
-    const typeName = type.match(/^\w*/)?.[0]
-    if (!typeName || dependencies.has(typeName) || !types[typeName]) return
-    dependencies.add(typeName)
-    for (const field of types[typeName]) collect(field.type)
-  }
-  collect(primaryType)
-  dependencies.delete(primaryType)
-  return [primaryType, ...[...dependencies].sort()]
-    .map(
-      (type) =>
-        `${type}(${types[type].map((field) => `${field.type} ${field.name}`).join(',')})`,
-    )
-    .join('')
 }

--- a/src/signing/protocols/protocols.test.ts
+++ b/src/signing/protocols/protocols.test.ts
@@ -8,6 +8,7 @@ import {
 } from './erc6492'
 import {
   type Erc7739VerifierDomain,
+  encodeErc7739ContentType,
   hashErc7739TypedData,
   wrapErc7739TypedDataSignature,
 } from './erc7739'
@@ -120,8 +121,16 @@ describe('signing protocol operations', () => {
         verifierDomain,
       })
 
+    expect(
+      encodeErc7739ContentType({
+        primaryType: 'Mail',
+        types: { Mail: mail, Person: person, Attachment: attachment },
+      }),
+    ).toBe(
+      'Mail(Person from,Person to,string contents,Attachment attachment)Attachment(string uri,Person uploader)Person(string name,address wallet)',
+    )
     // The dependency set is discovery-ordered, so the digest is only stable
-    // because `encodeType` sorts it; declaration order must not matter.
+    // because the shared content encoder sorts it; declaration order must not matter.
     expect(hash({ Mail: mail, Person: person, Attachment: attachment })).toBe(
       hash({ Attachment: attachment, Person: person, Mail: mail }),
     )

--- a/test/types/public-boundary.ts
+++ b/test/types/public-boundary.ts
@@ -17,6 +17,8 @@ import {
   type RhinestoneAccountConfig,
   RhinestoneSDK,
   type SerializedIntentInput,
+  type SessionSigning,
+  type SessionSigningContent,
   type SignData,
   type SignedIntentData,
   type SignedTransactionData,
@@ -62,6 +64,17 @@ declare const quote: Quote
 declare const signData: SignData
 declare const typedData: HashTypedDataParameters
 declare const sessionSigners: Extract<SignerSet, { type: 'session' }>
+
+const signingContent: SessionSigningContent = {
+  domain: { name: 'Example', chainId: mainnet.id },
+  types: { Example: [{ name: 'value', type: 'uint256' }] },
+  primaryType: 'Example',
+}
+const sessionSigning: SessionSigning = {
+  mode: 'scoped',
+  allowedContents: [signingContent],
+}
+void sessionSigning
 
 const ownerSigners = {
   type: 'owner',

--- a/test/types/session-permissions.ts
+++ b/test/types/session-permissions.ts
@@ -1,6 +1,11 @@
 import { type Address, erc20Abi } from 'viem'
 import { base } from 'viem/chains'
-import type { Permission, Permit2ClaimPolicy } from '../../src/index'
+import type {
+  Permission,
+  Permit2ClaimPolicy,
+  SessionSigning,
+  SessionSigningContent,
+} from '../../src/index'
 import { toSession } from '../../src/smart-sessions/index'
 import { accountA } from '../consts'
 
@@ -189,4 +194,48 @@ toSession({
       type: 'permit2-claim',
     },
   ],
+})
+
+const signingContent = {
+  domain: { name: 'Permit2', chainId: base.id, verifyingContract: USDC },
+  types: {
+    Permit: [
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+  },
+  primaryType: 'Permit',
+} as const satisfies SessionSigningContent
+
+const scopedSigning = {
+  mode: 'scoped',
+  allowedContents: [signingContent],
+  validUntil: new Date('2030-01-01'),
+} as const satisfies SessionSigning
+
+for (const signing of [
+  { mode: 'disabled' } as const,
+  { mode: 'unrestricted', validAfter: new Date(0) } as const,
+  scopedSigning,
+]) {
+  toSession({
+    chain: base,
+    owners: { type: 'ecdsa', accounts: [accountA] },
+    permissions: [permission],
+    signing,
+  })
+}
+
+toSession({
+  chain: base,
+  owners: { type: 'ecdsa', accounts: [accountA] },
+  // @ts-expect-error disabled signing cannot define a validity window.
+  signing: { mode: 'disabled', validUntil: new Date() },
+})
+
+toSession({
+  chain: base,
+  owners: { type: 'ecdsa', accounts: [accountA] },
+  // @ts-expect-error unsupported signing mode.
+  signing: { mode: 'all' },
 })


### PR DESCRIPTION
- Add disabled, unrestricted, and EIP-712 domain/schema-scoped session signing modes.
- Support optional signing validity windows while preserving existing omitted-session behavior.
- Fail fast for disabled and scoped direct signing until safe ERC-7739 emission is restored.

Closes [RHI-6178](https://linear.app/rhinestone/issue/RHI-6178/configurable-erc-1271-signing-capability-for-smart-sessions)