### PR TITLE
feat: support registry-free MFA module

### DIFF
--- a/.changeset/registry-free-mfa.md
+++ b/.changeset/registry-free-mfa.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add an opt-in registry-free multi-factor validator address and allow MFA account actions to target a selected multi-factor module. Existing MFA configurations and actions continue to use the legacy module by default.

--- a/src/actions/mfa.test.ts
+++ b/src/actions/mfa.test.ts
@@ -1,0 +1,159 @@
+import { type Address, decodeFunctionData, parseAbi } from 'viem'
+import { base } from 'viem/chains'
+import { describe, expect, test, vi } from 'vitest'
+import { accountA } from '../../test/consts'
+import { RhinestoneSDK } from '..'
+import { resolveCalls } from '../calls/resolve'
+import { toEvmChainReference } from '../chains/caip2'
+import type { CallInput, OwnableValidatorConfig } from '../config/account'
+import {
+  MULTI_FACTOR_VALIDATOR_ADDRESS,
+  MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+} from '../modules/validators/multi-factor'
+import {
+  changeThreshold,
+  disable,
+  enable,
+  removeSubValidator,
+  setSubValidator,
+} from './mfa'
+
+const accountAddress = '0xc02C600Bd93e6C86aE2Ed1D418B87Fe225171E74'
+
+const rpcReadContract = vi.hoisted(() =>
+  vi
+    .fn()
+    .mockResolvedValue([
+      [
+        '0x0000007261E4E2F1a892A58fd0708c9321e76020',
+        '0xf6bdf42c9be18ceca5c06c42a43daf7fbbe7896b',
+      ],
+      '0x0000000000000000000000000000000000000001',
+    ]),
+)
+
+vi.mock('../clients/rpc/compatibility', () => ({
+  materializeRpcReader: () => ({
+    chain: { kind: 'evm', id: base.id, caip2: `eip155:${base.id}` },
+    rpc: {
+      getCode: vi.fn(),
+      getTransactionCount: vi.fn(),
+      readContract: rpcReadContract,
+      multicall: vi.fn(),
+    },
+  }),
+}))
+
+const moduleActionAbi = parseAbi([
+  'function installModule(uint256 moduleTypeId, address module, bytes initData)',
+  'function uninstallModule(uint256 moduleTypeId, address module, bytes deInitData)',
+])
+const managementActionAbi = parseAbi([
+  'function setThreshold(uint8 threshold)',
+  'function setValidator(address validatorAddress, bytes12 validatorId, bytes newValidatorData)',
+  'function removeValidator(address validatorAddress, bytes12 validatorId)',
+])
+
+async function resolveCallInputs(calls: readonly CallInput[], config: unknown) {
+  return resolveCalls(calls as never, {
+    account: accountAddress,
+    chain: toEvmChainReference(base.id),
+    config: config as never,
+  })
+}
+
+async function accountConfig() {
+  const sdk = new RhinestoneSDK({ apiKey: 'test' })
+  return (
+    await sdk.createAccount({
+      owners: { type: 'ecdsa', accounts: [accountA] },
+    })
+  ).config
+}
+
+const factor: OwnableValidatorConfig = {
+  type: 'ecdsa',
+  accounts: [accountA],
+}
+
+const moduleCases = [
+  {
+    name: 'legacy default',
+    argument: undefined,
+    expected: MULTI_FACTOR_VALIDATOR_ADDRESS,
+  },
+  {
+    name: 'registry-free override',
+    argument: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+    expected: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+  },
+] as const
+
+function expectModuleArgument(data: `0x${string}`, expected: Address) {
+  const decoded = decodeFunctionData({ abi: moduleActionAbi, data })
+  expect(decoded.args[1].toLowerCase()).toBe(expected.toLowerCase())
+}
+
+function expectSingleEvmCall(
+  calls: Awaited<ReturnType<typeof resolveCallInputs>>,
+) {
+  expect(calls).toHaveLength(1)
+  const call = calls[0]
+  if (!call || !('to' in call) || !call.data) {
+    throw new Error('Expected one EVM calldata call')
+  }
+  return call
+}
+
+function managementFunctionName(data?: `0x${string}`) {
+  if (!data) throw new Error('Expected management calldata')
+  return decodeFunctionData({ abi: managementActionAbi, data }).functionName
+}
+
+describe('MFA actions', () => {
+  test.each(moduleCases)(
+    'installs the $name module',
+    async ({ argument, expected }) => {
+      const calls = await resolveCallInputs(
+        [enable([factor], 1, argument)],
+        await accountConfig(),
+      )
+
+      const call = expectSingleEvmCall(calls)
+      expect(call.to).toBe(accountAddress)
+      expectModuleArgument(call.data, expected)
+    },
+  )
+
+  test.each(moduleCases)(
+    'uninstalls the $name module',
+    async ({ argument, expected }) => {
+      const calls = await resolveCallInputs(
+        [disable(argument)],
+        await accountConfig(),
+      )
+
+      const call = expectSingleEvmCall(calls)
+      expect(call.to).toBe(accountAddress)
+      expectModuleArgument(call.data, expected)
+    },
+  )
+
+  test.each(moduleCases)(
+    'targets the $name module for management calls',
+    ({ argument, expected }) => {
+      const calls = [
+        changeThreshold(2, argument),
+        setSubValidator(1, factor, argument),
+        removeSubValidator(1, factor, argument),
+      ]
+
+      expect(calls.map(({ to }) => to)).toEqual([expected, expected, expected])
+      expect(calls.map(({ data }) => managementFunctionName(data))).toEqual([
+        'setThreshold',
+        'setValidator',
+        'removeValidator',
+      ])
+    },
+  )
+})

--- a/src/actions/mfa.ts
+++ b/src/actions/mfa.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, type Hex, padHex, toHex } from 'viem'
+import { type Address, encodeFunctionData, type Hex, padHex, toHex } from 'viem'
 import type {
   CalldataInput,
   LazyCallInput,
@@ -27,12 +27,15 @@ function factorModule(validator: MfaFactor) {
 function multiFactorModule(
   validators: readonly (MfaFactor | null)[],
   threshold: number,
+  moduleAddress?: Address,
 ) {
   const definition: MultiFactorValidatorDefinition = {
     kind: 'multi-factor',
     id: 'action/multi-factor',
     publicId: 0,
-    module: { source: 'default', profile: 'multi-factor' },
+    module: moduleAddress
+      ? { source: 'explicit', address: moduleAddress }
+      : { source: 'default', profile: 'multi-factor' },
     validators: validators.flatMap((validator, index) =>
       validator
         ? [
@@ -53,13 +56,15 @@ function multiFactorModule(
  * Enable multi-factor authentication
  * @param validators List of validators to use
  * @param threshold Threshold for the validators
+ * @param moduleAddress Multi-factor module to install. Defaults to the legacy module.
  * @returns Calls to enable multi-factor authentication
  */
 function enable(
   validators: (OwnableValidatorConfig | WebauthnValidatorConfig | null)[],
   threshold = 1,
+  moduleAddress?: Address,
 ): LazyCallInput {
-  const module = multiFactorModule(validators, threshold)
+  const module = multiFactorModule(validators, threshold, moduleAddress)
   return {
     async resolve(context) {
       return resolveModuleInstallation(context, module)
@@ -70,11 +75,15 @@ function enable(
 /**
  * Change the multi-factor threshold
  * @param newThreshold New threshold
+ * @param moduleAddress Multi-factor module to update. Defaults to the legacy module.
  * @returns Call to change the threshold
  */
-function changeThreshold(newThreshold: number): CalldataInput {
+function changeThreshold(
+  newThreshold: number,
+  moduleAddress: Address = MULTI_FACTOR_VALIDATOR_ADDRESS,
+): CalldataInput {
   return {
-    to: MULTI_FACTOR_VALIDATOR_ADDRESS,
+    to: moduleAddress,
     value: 0n,
     data: encodeFunctionData({
       abi: [
@@ -94,10 +103,11 @@ function changeThreshold(newThreshold: number): CalldataInput {
 
 /**
  * Disable multi-factor authentication
+ * @param moduleAddress Multi-factor module to uninstall. Defaults to the legacy module.
  * @returns Calls to disable multi-factor authentication
  */
-function disable(): LazyCallInput {
-  const module = multiFactorModule([], 1)
+function disable(moduleAddress?: Address): LazyCallInput {
+  const module = multiFactorModule([], 1, moduleAddress)
   return {
     async resolve(context) {
       return resolveModuleUninstallation(context, module)
@@ -109,16 +119,18 @@ function disable(): LazyCallInput {
  * Set a sub-validator (multi-factor)
  * @param id Validator ID
  * @param validator Validator module
+ * @param moduleAddress Multi-factor module to update. Defaults to the legacy module.
  * @returns Call to set the sub-validator
  */
 function setSubValidator(
   id: Hex | number,
   validator: OwnableValidatorConfig | WebauthnValidatorConfig,
+  moduleAddress: Address = MULTI_FACTOR_VALIDATOR_ADDRESS,
 ): CalldataInput {
   const validatorId = padHex(toHex(id), { size: 12 })
   const validatorModule = factorModule(validator)
   return {
-    to: MULTI_FACTOR_VALIDATOR_ADDRESS,
+    to: moduleAddress,
     value: 0n,
     data: encodeFunctionData({
       abi: [
@@ -151,16 +163,18 @@ function setSubValidator(
  * Remove a sub-validator (multi-factor)
  * @param id Validator ID
  * @param validator Validator module
+ * @param moduleAddress Multi-factor module to update. Defaults to the legacy module.
  * @returns Call to remove the sub-validator
  */
 function removeSubValidator(
   id: Hex | number,
   validator: OwnableValidatorConfig | WebauthnValidatorConfig,
+  moduleAddress: Address = MULTI_FACTOR_VALIDATOR_ADDRESS,
 ): CalldataInput {
   const validatorId = padHex(toHex(id), { size: 12 })
   const validatorModule = factorModule(validator)
   return {
-    to: MULTI_FACTOR_VALIDATOR_ADDRESS,
+    to: moduleAddress,
     value: 0n,
     data: encodeFunctionData({
       abi: [

--- a/src/config/resolve.test.ts
+++ b/src/config/resolve.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test, vi } from 'vitest'
 import { passkeyAccount } from '../../test/consts'
 import { propertyParameters } from '../../test/utils/property'
 import type { AccountInput } from '../accounts/types'
+import { MULTI_FACTOR_VALIDATOR_V2_ADDRESS } from '../modules/validators/multi-factor'
 import { SOCIAL_RECOVERY_VALIDATOR_ADDRESS } from '../modules/validators/social-recovery'
 import { currentV2Defaults } from './defaults'
 import type { AccountConstructionInput, SdkConstructionInput } from './input'
@@ -521,14 +522,14 @@ describe('SDK config resolution', () => {
     })
   })
 
-  test('retains init data and resolves default multi-factor threshold', () => {
+  test('retains init data and registry-free multi-factor selection', () => {
     const sdk = resolveSdkConfig({ apiKey: 'test' })
     const initData = { address: addressA }
     const account = resolveAccountConfig(sdk, {
       initData,
       owners: {
         type: 'multi-factor',
-        module: addressB,
+        module: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
         validators: [{ type: 'ecdsa', accounts: [accountA] }],
       },
     })
@@ -537,7 +538,10 @@ describe('SDK config resolution', () => {
     expect(account.owners).toMatchObject({
       kind: 'multi-factor',
       threshold: 1,
-      module: { source: 'explicit', address: addressB },
+      module: {
+        source: 'explicit',
+        address: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+      },
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,10 @@ import {
   solanaMainnet,
   tronMainnet,
 } from './chains/non-evm'
-import { MULTI_FACTOR_VALIDATOR_ADDRESS } from './modules/validators/multi-factor'
+import {
+  MULTI_FACTOR_VALIDATOR_ADDRESS,
+  MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+} from './modules/validators/multi-factor'
 import { OWNABLE_VALIDATOR_ADDRESS } from './modules/validators/ownable'
 import { SMART_SESSION_EMISSARY_ADDRESS } from './modules/validators/smart-sessions/module'
 import { WEBAUTHN_VALIDATOR_ADDRESS } from './modules/validators/webauthn'
@@ -21,6 +24,7 @@ export {
   OWNABLE_VALIDATOR_ADDRESS,
   WEBAUTHN_VALIDATOR_ADDRESS,
   MULTI_FACTOR_VALIDATOR_ADDRESS,
+  MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
   SMART_SESSION_EMISSARY_ADDRESS,
 }
 

--- a/src/modules/validators/multi-factor.ts
+++ b/src/modules/validators/multi-factor.ts
@@ -13,6 +13,9 @@ import type { MultiFactorValidatorDefinition } from './types'
 export const MULTI_FACTOR_VALIDATOR_ADDRESS: Address =
   '0xf6bdf42c9be18ceca5c06c42a43daf7fbbe7896b'
 
+export const MULTI_FACTOR_VALIDATOR_V2_ADDRESS: Address =
+  '0x0000007261E4E2F1a892A58fd0708c9321e76020'
+
 export type AtomicValidatorResolver = (
   definition: MultiFactorValidatorDefinition['validators'][number],
 ) => ResolvedModule

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -12,7 +12,10 @@ import { withoutHostCollation } from '../../../test/utils/locale'
 import { resolveStandaloneAccountConfig } from '../../config/resolve'
 import { getValidatorCapabilities } from './capabilities'
 import { resolveEnsValidator } from './ens'
-import { MULTI_FACTOR_VALIDATOR_ADDRESS } from './multi-factor'
+import {
+  MULTI_FACTOR_VALIDATOR_ADDRESS,
+  MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+} from './multi-factor'
 import {
   encodeOwnableMockSignature,
   OWNABLE_V0_VALIDATOR_ADDRESS,
@@ -74,19 +77,19 @@ describe('validator resolution', () => {
     ).not.toThrow()
   })
 
-  test('materializes nested MFA with stable ids and module overrides', () => {
+  test('materializes nested MFA with stable ids and the registry-free module', () => {
     const module = resolveValidator(
       validator({
         type: 'multi-factor',
         threshold: 1,
-        module: '0x00000000000000000000000000000000deadbeef',
+        module: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
         validators: [
           { type: 'ecdsa', accounts: [accountA] },
           { type: 'passkey', accounts: [passkeyAccount] },
         ],
       }),
     )
-    expect(module.address).toBe('0x00000000000000000000000000000000deadbeef')
+    expect(module.address).toBe(MULTI_FACTOR_VALIDATOR_V2_ADDRESS)
     expect(module.initData.startsWith('0x01')).toBe(true)
   })
 

--- a/src/signing/context.test.ts
+++ b/src/signing/context.test.ts
@@ -8,6 +8,7 @@ import {
 import { toEvmChainReference } from '../chains/caip2'
 import { createStaticAccountRuntime } from '../config/account-runtime'
 import { resolveAccountConfig, resolveSdkConfig } from '../config/resolve'
+import { MULTI_FACTOR_VALIDATOR_V2_ADDRESS } from '../modules/validators/multi-factor'
 import { resolveValidator } from '../modules/validators/resolve'
 import { SOCIAL_RECOVERY_VALIDATOR_ADDRESS } from '../modules/validators/social-recovery'
 import { buildUserOperationSigningPlanInput } from '../transactions/user-operations/prepare'
@@ -69,6 +70,40 @@ describe('account signature routing', () => {
       }
     },
   )
+
+  test('routes registry-free MFA through the Nexus signing context', () => {
+    const sdk = resolveSdkConfig({ apiKey: 'test' })
+    const account = resolveAccountConfig(sdk, {
+      account: { type: 'nexus' },
+      owners: { type: 'ecdsa', accounts: [owner] },
+    })
+    const runtime = createStaticAccountRuntime(account, chain, true)
+    const selection = adaptSignerSelection(account, {
+      type: 'owner',
+      kind: 'multi-factor',
+      module: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+      validators: [
+        { type: 'ecdsa', id: 1, accounts: [owner] },
+        { type: 'passkey', id: 2, accounts: [passkeyAccount] },
+      ],
+    })
+    if (selection.kind !== 'owner') throw new Error('Expected owner selection')
+
+    const context = createAccountSigningContext({
+      runtime,
+      purpose: 'user-operation',
+      signerInvoker: { invoke: vi.fn() },
+      selection,
+    })
+
+    expect(context.validatorCapabilities.compatibilityKey.moduleAddress).toBe(
+      MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+    )
+    expect(getAccountSignatureRoute(runtime, context).accountEnvelope).toEqual({
+      kind: 'nexus',
+      validator: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+    })
+  })
 
   test.each(['safe', 'nexus', 'kernel', 'startale'] as const)(
     'routes guardian UserOperations to the social recovery validator on %s',

--- a/test/contract/fixtures/consumer.ts
+++ b/test/contract/fixtures/consumer.ts
@@ -44,6 +44,14 @@ const accountConfig: RhinestoneAccountConfig = {
   owners: { type: 'ecdsa', accounts: [owner] },
 }
 
+const registryFreeMfaConfig: RhinestoneAccountConfig = {
+  owners: {
+    type: 'multi-factor',
+    module: '0x0000007261E4E2F1a892A58fd0708c9321e76020',
+    validators: [{ type: 'ecdsa', accounts: [owner] }],
+  },
+}
+
 const lazyCall: CallInput = {
   async resolve({ accountAddress, chain, config }) {
     void accountAddress
@@ -63,6 +71,7 @@ void legacySdk.createAccount(accountConfig)
 void apiKeySdk.createAccount(accountConfig)
 void jwtSdk.createAccount(accountConfig)
 void transaction
+void registryFreeMfaConfig
 void actions
 void ecdsaActions
 void mfaActions

--- a/test/integration/scenarios/smoke.itest.ts
+++ b/test/integration/scenarios/smoke.itest.ts
@@ -1,5 +1,6 @@
 import { describe, test } from 'vitest'
 import { SimulationFailedError } from '../../../src/errors/index'
+import { MULTI_FACTOR_VALIDATOR_V2_ADDRESS } from '../../../src/index'
 import { sourceChain, targetChain } from '../config/chains'
 import { createIntegrationSDK } from '../config/environment'
 import {
@@ -48,6 +49,43 @@ describe.sequential('SDK integration smoke', () => {
     expectNoFailedOperations(execution.status)
     expectCompletedOperation(execution.status, sourceChain.id)
     expectNoOperationOnChain(execution.status, targetChain.id)
+    await expectDeployed(account, sourceChain)
+  })
+
+  test('runs a sponsored same-chain intent with registry-free MFA', async () => {
+    const sdk = createIntegrationSDK()
+    const firstOwner = createOwner()
+    const secondOwner = createOwner()
+    const account = await sdk.createAccount({
+      account: { type: 'nexus' },
+      owners: {
+        type: 'multi-factor',
+        module: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+        threshold: 2,
+        validators: [
+          { type: 'ecdsa', accounts: [firstOwner] },
+          { type: 'ecdsa', accounts: [secondOwner] },
+        ],
+      },
+    })
+
+    await expectNotDeployed(account, sourceChain)
+
+    const execution = await executeIntent({
+      account,
+      label: 'smoke/same-chain/fresh/registry-free-mfa',
+      transaction: {
+        chain: sourceChain,
+        sponsored: true,
+        calls: [createNoopCall()],
+      },
+    })
+
+    expectOutcome(execution, { kind: 'success' })
+    if (execution.phase !== 'success') return
+
+    expectNoFailedOperations(execution.status)
+    expectCompletedOperation(execution.status, sourceChain.id)
     await expectDeployed(account, sourceChain)
   })
 

--- a/test/types/public-boundary.ts
+++ b/test/types/public-boundary.ts
@@ -11,6 +11,7 @@ import * as errors from '../../src/errors/index'
 import {
   hyperCorePerp,
   hyperCoreSpot,
+  MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
   type PreparedTransactionData,
   type Quote,
   type RhinestoneAccount,
@@ -37,6 +38,14 @@ const recipient = '0x0000000000000000000000000000000000000001'
 const accountConfig = {
   account: { type: 'safe', version: '1.4.1', adapter: '2.0.0' },
   owners: { type: 'ecdsa', accounts: [owner], threshold: 1 },
+} satisfies RhinestoneAccountConfig
+
+const registryFreeMfaConfig = {
+  owners: {
+    type: 'multi-factor',
+    module: MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
+    validators: [{ type: 'ecdsa', accounts: [owner] }],
+  },
 } satisfies RhinestoneAccountConfig
 
 new RhinestoneSDK({ apiKey: 'legacy-api-key' })
@@ -187,6 +196,7 @@ void typedDataSignature
 void intentSignature
 void userOperation
 void sameChainTransaction
+void registryFreeMfaConfig
 void crossChainWithDeadline
 void crossChainNonEvmWithDeadline
 void hyperCoreSpotDelivery


### PR DESCRIPTION
- Export the registry-free MFA validator address while preserving the legacy default.
- Allow MFA lifecycle and management actions to target an explicit parent module.
- Cover config, signing, package compatibility, and fresh Nexus sponsored execution.

Closes [RHI-6190](https://linear.app/rhinestone/issue/RHI-6190/sdk-v2-support-registry-free-mfa-module-end-to-end)