### PR TITLE
feat: support ECO solver network tracking

### DIFF
--- a/.changeset/eco-solver-network.md
+++ b/.changeset/eco-solver-network.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Expose Eco solver-network delivery metadata through the public `BridgeFill` type. Built-in Smart Session settlement-layer permissions remain limited to legacy Standard ECO until route-aware solver-network authorization is available.

--- a/scripts/contract/run.ts
+++ b/scripts/contract/run.ts
@@ -25,6 +25,10 @@ const consumerFixturePath = join(
   repositoryRoot,
   'test/contract/fixtures/consumer.ts',
 )
+const currentConsumerFixturePath = join(
+  repositoryRoot,
+  'test/contract/fixtures/current-consumer.ts',
+)
 const assignabilityFixturePath = join(
   repositoryRoot,
   'test/contract/fixtures/assignability.ts',
@@ -277,6 +281,7 @@ async function main(): Promise<void> {
     })
     compileConsumer(baseConsumers.full)
     compileConsumer(currentConsumers.full)
+    compileConsumer(currentConsumers.full, currentConsumerFixturePath)
 
     const compatibilityConsumer = join(
       temporaryDirectory,

--- a/src/clients/orchestrator/client.test.ts
+++ b/src/clients/orchestrator/client.test.ts
@@ -83,6 +83,43 @@ describe('orchestrator client', () => {
                   fillStatusTimeout: 30,
                 },
               },
+              {
+                intentId: 'intent-2',
+                expiresAt: 1,
+                estimatedFillTime: { seconds: 2 },
+                settlementLayer: 'ECO',
+                signData: {
+                  origin: [],
+                  destination: {
+                    domain: {},
+                    types: {},
+                    primaryType: 'Test',
+                    message: {},
+                  },
+                },
+                cost: {
+                  input: [],
+                  output: [],
+                  fees: {
+                    total: { usd: 0 },
+                    breakdown: {
+                      gas: { usd: 0, sponsored: false },
+                      bridge: { usd: 0, sponsored: false },
+                      swap: { usd: 0, sponsored: false },
+                      app: { usd: 0, sponsored: false },
+                      protocol: { usd: 0, sponsored: false },
+                      sponsorSurcharge: { usd: 0, sponsored: false },
+                    },
+                  },
+                },
+                bridgeFill: {
+                  type: 'ECO',
+                  destinationChainId: 42161,
+                  intentHash: `0x${'22'.repeat(32)}`,
+                  fillExpirationPeriod: 60,
+                  fillStatusTimeout: 30,
+                },
+              },
             ],
           }),
           { headers: { 'x-trace-id': 'trace-1' } },
@@ -134,6 +171,11 @@ describe('orchestrator client', () => {
       type: 'RELAY',
       destinationChainId: 10,
       requestId: 'request-1',
+    })
+    expect(result.routes[1]?.bridgeFill).toEqual({
+      type: 'ECO',
+      destinationChainId: 42161,
+      intentHash: `0x${'22'.repeat(32)}`,
     })
     expect(fetch).toHaveBeenCalledWith(
       'https://orchestrator.example/quotes',

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -1,4 +1,4 @@
-import type { Address, SignedAuthorization } from 'viem'
+import type { Address, Hex, SignedAuthorization } from 'viem'
 import {
   chainIdFromReference,
   formatCaip2,
@@ -252,8 +252,48 @@ function mapTokenRequirementsFromWire(
 function mapBridgeFillFromWire(
   value: NonNullable<WireQuote['bridgeFill']>,
 ): BridgeFill {
-  const { fillStatusTimeout: _ignored, ...bridgeFill } = value
-  return bridgeFill as BridgeFill
+  switch (value.type) {
+    case 'OFT':
+      return {
+        type: 'OFT',
+        destinationChainId: value.destinationChainId,
+      }
+    case 'ECO':
+      return {
+        type: 'ECO',
+        destinationChainId: value.destinationChainId,
+        intentHash: value.intentHash as Hex,
+      }
+    case 'RELAY':
+      return {
+        type: 'RELAY',
+        destinationChainId: value.destinationChainId,
+        requestId: value.requestId,
+      }
+    case 'NEAR':
+      return {
+        type: 'NEAR',
+        destinationChainId: value.destinationChainId,
+        depositAddress: value.depositAddress as Address,
+      }
+    case 'RHINO':
+      return {
+        type: 'RHINO',
+        destinationChainId: value.destinationChainId,
+        commitmentId: value.commitmentId,
+      }
+    case 'CCTP':
+      return {
+        type: 'CCTP',
+        destinationChainId: value.destinationChainId,
+        sourceDomainId: value.sourceDomainId,
+        destinationDomainId: value.destinationDomainId,
+      }
+    default:
+      throw new Error(
+        `Unsupported bridge fill type from orchestrator: ${String((value as { readonly type?: unknown }).type)}`,
+      )
+  }
 }
 
 type WireAuthorization = NonNullable<

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -285,9 +285,13 @@ interface SignData {
   targetExecution?: TypedDataDefinition
 }
 
-// Per-intent tracking handle for layers that hand off to a third-party bridge
+/**
+ * Per-intent tracking handle for settlement layers that hand delivery off to
+ * a third-party bridge or solver network.
+ */
 type BridgeFill =
   | { type: 'OFT'; destinationChainId: number }
+  | { type: 'ECO'; destinationChainId: number; intentHash: Hex }
   | { type: 'RELAY'; destinationChainId: number; requestId: string }
   | { type: 'NEAR'; destinationChainId: number; depositAddress: Address }
   | { type: 'RHINO'; destinationChainId: number; commitmentId: string }

--- a/src/clients/orchestrator/wire.ts
+++ b/src/clients/orchestrator/wire.ts
@@ -30,8 +30,28 @@ export type WireIntentRequestInternal = WireIntentRequest & {
   readonly options?: { readonly dryRun?: boolean }
 }
 export type WireSplitRequest = JsonRequest<'getSplit'>
-export type WireQuoteResponse = Folded<JsonResponse<'createQuote'>>
-export type WireQuote = WireQuoteResponse['routes'][number]
+type GeneratedWireQuoteResponse = Folded<JsonResponse<'createQuote'>>
+type GeneratedWireQuote = GeneratedWireQuoteResponse['routes'][number]
+type EcoBridgeFill = {
+  readonly destinationChainId: number
+  readonly fillExpirationPeriod?: number
+  readonly fillStatusTimeout: number
+  readonly type: 'ECO'
+  readonly intentHash: string
+}
+
+// The ECO solver-network variant is already part of the orchestrator feature
+// branch but not yet in the pinned, published OpenAPI document. Keep the HTTP
+// boundary truthful during that rollout; the next generated-wire sync will add
+// the structurally identical variant to GeneratedWireQuote.
+export type WireQuote = Omit<GeneratedWireQuote, 'bridgeFill'> & {
+  readonly bridgeFill?:
+    | NonNullable<GeneratedWireQuote['bridgeFill']>
+    | EcoBridgeFill
+}
+export type WireQuoteResponse = Omit<GeneratedWireQuoteResponse, 'routes'> & {
+  readonly routes: readonly WireQuote[]
+}
 export type WirePortfolioResponse = Folded<JsonResponse<'getPortfolio'>>
 export type WireIntentStatusResponse = Folded<JsonResponse<'getIntent'>>
 export type WireSplitResponse = Folded<JsonResponse<'getSplit'>>

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -300,6 +300,11 @@ interface CrossChainPermit {
    * Settlement layers this session is permitted to use. Omit (or pass
    * `[]`) for any supported layer — the SDK resolves to the union of
    * every arbiter in its bundled allow-set.
+   *
+   * **Smart Session limitation:** the built-in `ECO` permission currently
+   * authorizes only the legacy Standard ECO arbiter. Eco solver-network routes
+   * remain blocked by this allow-set until a route-aware claim policy can
+   * safely inspect their encoded delivery terms.
    */
   settlementLayers?: CrossChainSettlementLayer[]
 }
@@ -358,6 +363,11 @@ interface CrossChainPermissionInput {
    * `[]`) to allow **any of the supported settlement layers** — the SDK
    * resolves to the union of every arbiter in its bundled allow-set. Pass
    * a subset (e.g. `['ECO']`) to narrow.
+   *
+   * **Smart Session limitation:** the built-in `ECO` permission currently
+   * authorizes only the legacy Standard ECO arbiter. Eco solver-network routes
+   * remain blocked by this allow-set until a route-aware claim policy can
+   * safely inspect their encoded delivery terms.
    */
   settlementLayers?: CrossChainSettlementLayer[]
 }

--- a/src/modules/validators/policies/claim/arbiters.test.ts
+++ b/src/modules/validators/policies/claim/arbiters.test.ts
@@ -25,10 +25,12 @@ describe('getArbitersForSettlementLayers', () => {
     expect(ecoOnly.length).toBeLessThan(any.length)
   })
 
-  test('single ECO layer resolves to at least one ecoArbiter address', () => {
-    const addrs = getArbitersForSettlementLayers(['ECO'])
-    expect(addrs).toBeDefined()
-    expect(addrs!.length).toBeGreaterThan(0)
+  test('ECO preserves production Standard ECO arbiters and excludes the generic IntentExecutor adapter', () => {
+    // source: shared-configs generated production address book
+    expect(getArbitersForSettlementLayers(['ECO'])).toEqual([
+      '0x2e7627CCfAe4eDb336eEb5a70f08415B0F1a2b8C',
+      '0xA212A6ACCC8db0e4cdf4394D0A851c70Fc27A8F0',
+    ])
   })
 
   test('ACROSS layer resolves to BOTH the 7579 and multicall arbiter impls', () => {
@@ -58,11 +60,12 @@ describe('getArbitersForSettlementLayers', () => {
     expect(new Set(lower).size).toBe(lower.length)
   })
 
-  test('dev contracts produce a different (or equal) set vs mainnet', () => {
-    const mainnet = getArbitersForSettlementLayers(['ECO'], false)
-    const dev = getArbitersForSettlementLayers(['ECO'], true)
-    expect(mainnet).toBeDefined()
-    expect(dev).toBeDefined()
+  test('ECO preserves development Standard ECO arbiters and excludes the generic IntentExecutor adapter', () => {
+    // source: shared-configs generated development address book
+    expect(getArbitersForSettlementLayers(['ECO'], true)).toEqual([
+      '0x1BeBAfb3D05d84A5Bfd94800c88d1342f755d8AB',
+      '0x8A061029AE4c5Cf69b5368119B3b0C80B31F55fE',
+    ])
   })
 
   test('duplicate layers do not produce duplicate addresses', () => {

--- a/src/modules/validators/policies/claim/arbiters.ts
+++ b/src/modules/validators/policies/claim/arbiters.ts
@@ -5,6 +5,14 @@ import type { CrossChainSettlementLayer } from '../../smart-sessions/types'
  * The arbiter contract keys that each settlement layer expands to. `ACROSS`
  * whitelists both arbiter impls so a session is permissioned for the 7579 and
  * multicall paths regardless of which one the orchestrator picks at intent time.
+ *
+ * `ECO` intentionally remains mapped to the legacy Standard ECO arbiters. The
+ * solver-network ECO route uses `intentExecutorAdapter`, but the current claim
+ * policy only inspects the outer origin mandate. Authorizing that generic
+ * adapter would also authorize unrelated IntentExecutor-backed routes without
+ * enforcing the encoded Eco destination, token, recipient, or deadline. Keep
+ * solver-network ECO blocked by this built-in permission until a route-aware
+ * policy is available.
  */
 const SETTLEMENT_LAYER_CONTRACT_KEYS: Record<
   CrossChainSettlementLayer,

--- a/src/modules/validators/smart-sessions/policies/claim.test.ts
+++ b/src/modules/validators/smart-sessions/policies/claim.test.ts
@@ -45,6 +45,11 @@ describe('Smart Sessions claim policies', () => {
       'development',
     )
     expect(afterOnly.claim).toMatchObject({
+      // source: shared-configs generated development address book
+      spenders: [
+        '0x1BeBAfb3D05d84A5Bfd94800c88d1342f755d8AB',
+        '0x8A061029AE4c5Cf69b5368119B3b0C80B31F55fE',
+      ],
       sourceTokens: [{ chain: base, address: source }],
       destinationTokens: [{ chain: arbitrum, address: destination }],
       recipients: [{ chain: arbitrum, address: recipient }],
@@ -59,6 +64,24 @@ describe('Smart Sessions claim policies', () => {
     expect(expandCrossChainPermit({}, 'production').fallbackPolicies).toEqual(
       [],
     )
+  })
+
+  test('keeps solver-network ECO blocked instead of authorizing the generic IntentExecutor adapter', () => {
+    const { claim } = expandCrossChainPermit(
+      { settlementLayers: ['ECO'] },
+      'production',
+    )
+    // source: shared-configs generated production address book
+    const intentExecutorAdapter =
+      '0xa5DAC04a6cCF0eb19cE091b6B400Fc4FCD13Da1e' as const
+
+    expect(claim.spenders).not.toContain(intentExecutorAdapter)
+    expect(
+      permit2ClaimPolicyMatchesMessage(claim, {
+        ...message,
+        spender: intentExecutorAdapter,
+      }),
+    ).toBe(false)
   })
 
   test('checks every message restriction independently', () => {

--- a/test/contract/fixtures/current-consumer.ts
+++ b/test/contract/fixtures/current-consumer.ts
@@ -1,0 +1,17 @@
+import type { BridgeFill } from '@rhinestone/sdk'
+import type { Hex } from 'viem'
+import { mainnet } from 'viem/chains'
+
+function readEcoIntentHash(bridgeFill: BridgeFill): Hex | undefined {
+  if (bridgeFill.type !== 'ECO') return undefined
+  return bridgeFill.intentHash
+}
+
+const ecoBridgeFill = {
+  type: 'ECO',
+  destinationChainId: mainnet.id,
+  intentHash: `0x${'11'.repeat(32)}`,
+} as const satisfies BridgeFill
+const ecoIntentHash: Hex | undefined = readEcoIntentHash(ecoBridgeFill)
+
+void ecoIntentHash

--- a/test/types/public-boundary.ts
+++ b/test/types/public-boundary.ts
@@ -9,6 +9,7 @@ import * as sessionActions from '../../src/actions/smart-sessions'
 import type { SponsorLimitKey } from '../../src/errors/index'
 import * as errors from '../../src/errors/index'
 import {
+  type BridgeFill,
   hyperCorePerp,
   hyperCoreSpot,
   MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
@@ -74,6 +75,19 @@ declare const signData: SignData
 declare const typedData: HashTypedDataParameters
 declare const sessionSigners: Extract<SignerSet, { type: 'session' }>
 
+const ecoBridgeFill = {
+  type: 'ECO',
+  destinationChainId: mainnet.id,
+  intentHash: `0x${'11'.repeat(32)}`,
+} as const satisfies BridgeFill
+const ecoIntentHash: Hex = ecoBridgeFill.intentHash
+
+function readEcoIntentHash(bridgeFill: BridgeFill): Hex | undefined {
+  if (bridgeFill.type !== 'ECO') return undefined
+  return bridgeFill.intentHash
+}
+const narrowedEcoIntentHash: Hex | undefined = readEcoIntentHash(ecoBridgeFill)
+
 const signingContent: SessionSigningContent = {
   domain: { name: 'Example', chainId: mainnet.id },
   types: { Example: [{ name: 'value', type: 'uint256' }] },
@@ -84,6 +98,8 @@ const sessionSigning: SessionSigning = {
   allowedContents: [signingContent],
 }
 void sessionSigning
+void ecoIntentHash
+void narrowedEcoIntentHash
 
 const ownerSigners = {
   type: 'owner',


### PR DESCRIPTION
## Summary

- Add public ECO `BridgeFill` tracking, including the solver-network intent hash.
- Deliberately do **not** authorize the generic `IntentExecutor` for built-in ECO Smart Sessions: current policies cannot validate the nested route constraints.
- Keep the legacy ECO arbiter mapping for compatibility.
- Temporarily augment the OpenAPI wire type pending orchestrator publication.

Linear: RHI-6174

## Verification

- `bunx biome check --write`
- `bun run check`
- `bun run check:architecture`
- `bun run typecheck`
- `bun run test:types`
- `bun run build`
- `bun run test:unit -- --run`
- `SDK_CONTRACT_BASE_SHA=596a470e00eb0156ee28445b68a9addd7edfebd7 bun run test:contract` (`@rhinestone/sdk@2.3.0`, latest ancestor release)