### PR TITLE
feat(smart-sessions): experimental spend-session abstraction + settlement-layer policy encoding (RHI-6242)

### DIFF
--- a/.changeset/one-time-use-sessions.md
+++ b/.changeset/one-time-use-sessions.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add one-time-use session support. A session may pin an id via `oneTimeUse: { id }` (requires `policyAddresses.oneTimeUseId`) so it settles at most once per chain across both settlement routes: the OneTimeUseIdPolicy is installed on every action (executor route) and co-located with the Permit2 claim policy on the ERC-1271 list (permit2 route). Exposes `buildOneTimeUseBurnOp`, `oneTimeUseIdErc1271Policy`, `encodeOneTimeUseIdInitData`, and the `OneTimeUseSettlementRoute` / `OneTimeUseBurnOp` types from `@rhinestone/sdk/smart-sessions`.

--- a/.changeset/rhi-6242-spend-session.md
+++ b/.changeset/rhi-6242-spend-session.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Add an experimental spend-session abstraction (`experimental_defineSpendSession`) that formulates the session-policy combination from a business-level spend (tokens, amounts, recipients, target chains, settlement layers), covering same-chain and Across/Eco cross-chain routes with optional one-time-use. Adds a byte-exact encoder for the IntentExecutor settlement-layer policy family (CCTP/Relay/Rhino adapters) and an `erc1271Policies` install path on the session definition. The IntentExecutor-backed layers are refused until that policy is deployed.

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -561,6 +561,13 @@ interface SessionDefinition<TAbis extends readonly Abi[] = readonly Abi[]> {
    * partner).
    */
   oneTimeUse?: { id: bigint }
+  /**
+   * Pre-encoded ERC-1271 policy entries to install on the session's 1271 surface
+   * (e.g. an IntentExecutor settlement-layer policy — see
+   * `intentExecutorPolicyEntry`). Enforcing entries replace the default sudo
+   * entry so the 1271 list stays a strict AND. Experimental.
+   */
+  erc1271Policies?: readonly { policy: Address; initData: Hex }[]
 }
 
 type SessionInput<TAbis extends readonly Abi[] = readonly Abi[]> = Omit<

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -529,6 +529,9 @@ interface SessionPolicyAddresses {
   timeFrame?: Address
   usageLimit?: Address
   valueLimit?: Address
+  // Required when a session sets `oneTimeUse`; no default until the policy has a
+  // canonical deployment.
+  oneTimeUseId?: Address
 }
 
 interface SessionDefinition<TAbis extends readonly Abi[] = readonly Abi[]> {
@@ -549,6 +552,15 @@ interface SessionDefinition<TAbis extends readonly Abi[] = readonly Abi[]> {
    * has sessions enabled against them.
    */
   policyAddresses?: SessionPolicyAddresses
+  /**
+   * Pins a one-time-use id on the session (RHI-5798): the session settles at most
+   * once per chain. Requires `policyAddresses.oneTimeUseId`. Each settlement must
+   * carry the matching burn op ({@link buildOneTimeUseBurnOp}) in its
+   * `preClaimExecutions`; a Permit2-route session must also supply a
+   * `claimPolicies` entry (moved onto the 1271 surface as the digest-binding
+   * partner).
+   */
+  oneTimeUse?: { id: bigint }
 }
 
 type SessionInput<TAbis extends readonly Abi[] = readonly Abi[]> = Omit<

--- a/src/modules/validators/smart-sessions/digest.ts
+++ b/src/modules/validators/smart-sessions/digest.ts
@@ -30,12 +30,17 @@ export function getSessionData(session: Session): SessionData {
     salt: session.salt,
     erc7739Policies: session.erc7739Policies,
     actions: session.actions,
-    claimPolicies: session.claimPolicies.map((policy) => ({
-      policy: PERMIT2_CLAIM_POLICY_ADDRESS,
-      initData: encodePermit2ClaimPolicyInitData(
-        resolvePermit2ClaimPolicy(policy),
-      ),
-    })),
+    // When the claim policies are enforced via the erc1271 surface they're
+    // already in erc7739Policies; encoding them here too would settle them on
+    // the on-chain claim (lockTag) surface as well.
+    claimPolicies: session.claimPoliciesEnforcedVia1271
+      ? []
+      : session.claimPolicies.map((policy) => ({
+          policy: PERMIT2_CLAIM_POLICY_ADDRESS,
+          initData: encodePermit2ClaimPolicyInitData(
+            resolvePermit2ClaimPolicy(policy),
+          ),
+        })),
   }
 }
 

--- a/src/modules/validators/smart-sessions/one-time-use.test.ts
+++ b/src/modules/validators/smart-sessions/one-time-use.test.ts
@@ -1,0 +1,63 @@
+import { decodeFunctionData, pad, toHex } from 'viem'
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildOneTimeUseBurnOp,
+  encodeOneTimeUseIdInitData,
+  oneTimeUseIdErc1271Policy,
+  oneTimeUseIdPolicyAbi,
+} from './one-time-use'
+
+const POLICY = '0x00000000000000000000000000000000000000aa' as const
+
+describe('encodeOneTimeUseIdInitData', () => {
+  test('encodes the id as a bytes32', () => {
+    expect(encodeOneTimeUseIdInitData(42n)).toBe(pad(toHex(42n), { size: 32 }))
+  })
+  test('rejects a zero id (policy treats 0 as "not configured")', () => {
+    expect(() => encodeOneTimeUseIdInitData(0n)).toThrow()
+  })
+})
+
+describe('oneTimeUseIdErc1271Policy', () => {
+  test('produces a {policy, initData} entry pinning the id', () => {
+    expect(oneTimeUseIdErc1271Policy({ policy: POLICY, id: 7n })).toEqual({
+      policy: POLICY,
+      initData: pad(toHex(7n), { size: 32 }),
+    })
+  })
+})
+
+describe('buildOneTimeUseBurnOp', () => {
+  test('executor route → consume(id), no witness', () => {
+    const op = buildOneTimeUseBurnOp({
+      policy: POLICY,
+      id: 42n,
+      route: 'executor',
+    })
+    expect(op.to).toBe(POLICY)
+    expect(op.value).toBe(0n)
+    const { functionName, args } = decodeFunctionData({
+      abi: oneTimeUseIdPolicyAbi,
+      data: op.data,
+    })
+    expect(functionName).toBe('consume')
+    expect(args).toEqual([42n])
+  })
+
+  test('permit2 route → consumeFor(id, 0) placeholder for the orchestrator to stamp', () => {
+    const op = buildOneTimeUseBurnOp({
+      policy: POLICY,
+      id: 42n,
+      route: 'permit2',
+    })
+    const { functionName, args } = decodeFunctionData({
+      abi: oneTimeUseIdPolicyAbi,
+      data: op.data,
+    })
+    expect(functionName).toBe('consumeFor')
+    // Placeholder witness 0 — the real Permit2 order nonce is stamped in by the
+    // orchestrator before the mandate is signed.
+    expect(args).toEqual([42n, 0n])
+  })
+})

--- a/src/modules/validators/smart-sessions/one-time-use.test.ts
+++ b/src/modules/validators/smart-sessions/one-time-use.test.ts
@@ -60,4 +60,13 @@ describe('buildOneTimeUseBurnOp', () => {
     // orchestrator before the mandate is signed.
     expect(args).toEqual([42n, 0n])
   })
+
+  test('rejects id=0 (cannot emit a burn op for an unpinnable id)', () => {
+    expect(() =>
+      buildOneTimeUseBurnOp({ policy: POLICY, id: 0n, route: 'executor' }),
+    ).toThrow(/non-zero uint256/)
+    expect(() =>
+      buildOneTimeUseBurnOp({ policy: POLICY, id: 0n, route: 'permit2' }),
+    ).toThrow(/non-zero uint256/)
+  })
 })

--- a/src/modules/validators/smart-sessions/one-time-use.ts
+++ b/src/modules/validators/smart-sessions/one-time-use.ts
@@ -1,0 +1,82 @@
+import { type Address, encodeFunctionData, type Hex, pad, toHex } from 'viem'
+
+// OneTimeUseIdPolicy (RHI-5798): a session pins an id it invents, and each
+// settlement burns that id through an injected pre-claim execution, so a session
+// settles at most once per chain regardless of route. This module produces the
+// two SDK-side artifacts: the session's erc1271 policy entry, and the burn op the
+// caller places in the intent's `preClaimExecutions`.
+export const oneTimeUseIdPolicyAbi = [
+  {
+    type: 'function',
+    name: 'consume',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'id', type: 'uint256' }],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'consumeFor',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'id', type: 'uint256' },
+      { name: 'witness', type: 'uint256' },
+    ],
+    outputs: [],
+  },
+] as const
+
+// Which burn call a settlement route needs. `permit2` (Across/Eco via the arbiter)
+// proves the burn with a witness; `executor` (IntentExecutor) needs none.
+export type OneTimeUseSettlementRoute = 'permit2' | 'executor'
+
+export interface OneTimeUseBurnOp {
+  readonly to: Address
+  readonly value: bigint
+  readonly data: Hex
+}
+
+// Encodes the pinned id as the policy's initData (a bytes32). The id must be a
+// non-zero uint256 — the policy rejects zero ("not configured").
+export function encodeOneTimeUseIdInitData(id: bigint): Hex {
+  if (id <= 0n || id > (1n << 256n) - 1n) {
+    throw new Error('OneTimeUseId id must be a non-zero uint256')
+  }
+  return pad(toHex(id), { size: 32 })
+}
+
+// The erc1271 policy entry to add to a session's erc7739Policies.erc1271Policies.
+export function oneTimeUseIdErc1271Policy(params: {
+  policy: Address
+  id: bigint
+}): { readonly policy: Address; readonly initData: Hex } {
+  return {
+    policy: params.policy,
+    initData: encodeOneTimeUseIdInitData(params.id),
+  }
+}
+
+// The burn op to inject into the intent's `preClaimExecutions`.
+//   - executor route: `consume(id)` — no witness.
+//   - permit2 route:  `consumeFor(id, 0)` — a PLACEHOLDER witness. The witness
+//     must equal the settlement's Permit2 order nonce, which only the orchestrator
+//     knows, so it stamps the real nonce into this op before the mandate is signed.
+export function buildOneTimeUseBurnOp(params: {
+  policy: Address
+  id: bigint
+  route: OneTimeUseSettlementRoute
+}): OneTimeUseBurnOp {
+  const { policy, id, route } = params
+  const data =
+    route === 'permit2'
+      ? encodeFunctionData({
+          abi: oneTimeUseIdPolicyAbi,
+          functionName: 'consumeFor',
+          args: [id, 0n],
+        })
+      : encodeFunctionData({
+          abi: oneTimeUseIdPolicyAbi,
+          functionName: 'consume',
+          args: [id],
+        })
+  return { to: policy, value: 0n, data }
+}

--- a/src/modules/validators/smart-sessions/one-time-use.ts
+++ b/src/modules/validators/smart-sessions/one-time-use.ts
@@ -35,12 +35,16 @@ export interface OneTimeUseBurnOp {
   readonly data: Hex
 }
 
-// Encodes the pinned id as the policy's initData (a bytes32). The id must be a
-// non-zero uint256 — the policy rejects zero ("not configured").
-export function encodeOneTimeUseIdInitData(id: bigint): Hex {
+// The id must be a non-zero uint256 — the policy rejects zero ("not configured").
+function assertValidOneTimeUseId(id: bigint): void {
   if (id <= 0n || id > (1n << 256n) - 1n) {
     throw new Error('OneTimeUseId id must be a non-zero uint256')
   }
+}
+
+// Encodes the pinned id as the policy's initData (a bytes32).
+export function encodeOneTimeUseIdInitData(id: bigint): Hex {
+  assertValidOneTimeUseId(id)
   return pad(toHex(id), { size: 32 })
 }
 
@@ -66,6 +70,9 @@ export function buildOneTimeUseBurnOp(params: {
   route: OneTimeUseSettlementRoute
 }): OneTimeUseBurnOp {
   const { policy, id, route } = params
+  // Reject id=0 here too (not just at initData encoding) so a caller can't emit a
+  // burn op whose id doesn't match a validly-pinned session.
+  assertValidOneTimeUseId(id)
   const data =
     route === 'permit2'
       ? encodeFunctionData({

--- a/src/modules/validators/smart-sessions/policies/addresses.ts
+++ b/src/modules/validators/smart-sessions/policies/addresses.ts
@@ -28,6 +28,8 @@ export interface ResolvedPolicyAddresses {
   readonly timeFrame: Address
   readonly usageLimit: Address
   readonly valueLimit: Address
+  // No canonical deployment yet, so no default — only present when overridden.
+  readonly oneTimeUseId?: Address
 }
 
 export const DEFAULT_POLICY_ADDRESSES: ResolvedPolicyAddresses = Object.freeze({
@@ -53,5 +55,8 @@ export function resolvePolicyAddresses(
     timeFrame: overrides?.timeFrame ?? DEFAULT_POLICY_ADDRESSES.timeFrame,
     usageLimit: overrides?.usageLimit ?? DEFAULT_POLICY_ADDRESSES.usageLimit,
     valueLimit: overrides?.valueLimit ?? DEFAULT_POLICY_ADDRESSES.valueLimit,
+    ...(overrides?.oneTimeUseId
+      ? { oneTimeUseId: overrides.oneTimeUseId }
+      : {}),
   }
 }

--- a/src/modules/validators/smart-sessions/policies/addresses.ts
+++ b/src/modules/validators/smart-sessions/policies/addresses.ts
@@ -30,6 +30,8 @@ export interface ResolvedPolicyAddresses {
   readonly valueLimit: Address
   // No canonical deployment yet, so no default — only present when overridden.
   readonly oneTimeUseId?: Address
+  // The IntentExecutor settlement-layer policy — no canonical deployment yet.
+  readonly intentExecutorPolicy?: Address
 }
 
 export const DEFAULT_POLICY_ADDRESSES: ResolvedPolicyAddresses = Object.freeze({
@@ -57,6 +59,9 @@ export function resolvePolicyAddresses(
     valueLimit: overrides?.valueLimit ?? DEFAULT_POLICY_ADDRESSES.valueLimit,
     ...(overrides?.oneTimeUseId
       ? { oneTimeUseId: overrides.oneTimeUseId }
+      : {}),
+    ...(overrides?.intentExecutorPolicy
+      ? { intentExecutorPolicy: overrides.intentExecutorPolicy }
       : {}),
   }
 }

--- a/src/modules/validators/smart-sessions/policies/addresses.ts
+++ b/src/modules/validators/smart-sessions/policies/addresses.ts
@@ -30,8 +30,6 @@ export interface ResolvedPolicyAddresses {
   readonly valueLimit: Address
   // No canonical deployment yet, so no default — only present when overridden.
   readonly oneTimeUseId?: Address
-  // The IntentExecutor settlement-layer policy — no canonical deployment yet.
-  readonly intentExecutorPolicy?: Address
 }
 
 export const DEFAULT_POLICY_ADDRESSES: ResolvedPolicyAddresses = Object.freeze({
@@ -59,9 +57,6 @@ export function resolvePolicyAddresses(
     valueLimit: overrides?.valueLimit ?? DEFAULT_POLICY_ADDRESSES.valueLimit,
     ...(overrides?.oneTimeUseId
       ? { oneTimeUseId: overrides.oneTimeUseId }
-      : {}),
-    ...(overrides?.intentExecutorPolicy
-      ? { intentExecutorPolicy: overrides.intentExecutorPolicy }
       : {}),
   }
 }

--- a/src/modules/validators/smart-sessions/policies/settlement-layer.test.ts
+++ b/src/modules/validators/smart-sessions/policies/settlement-layer.test.ts
@@ -1,12 +1,4 @@
-import {
-  type Address,
-  type Hex,
-  keccak256,
-  size,
-  slice,
-  toBytes,
-  toHex,
-} from 'viem'
+import { type Address, type Hex, size, slice } from 'viem'
 import { describe, expect, test } from 'vitest'
 import {
   addressToBytes32,
@@ -35,10 +27,19 @@ const RECIPIENT: Address = '0x1111111111111111111111111111111111111111'
 const GAS_TOKEN: Address = '0x4200000000000000000000000000000000000006'
 
 describe('settlement-layer encoders — layer ids', () => {
-  test('layer ids are keccak256 of the adapter names', () => {
-    expect(CCTP_LAYER_ID).toBe(keccak256(toBytes('CCTP')))
-    expect(RELAY_LAYER_ID).toBe(keccak256(toBytes('RELAY')))
-    expect(RHINO_LAYER_ID).toBe(keccak256(toBytes('RHINO')))
+  // Pinned to fixed hashes (not keccak256(toBytes(name)), which would be a
+  // tautology) so an accidental rename of the id source is caught. These must
+  // equal each adapter's on-chain LAYER_ID = keccak256("<NAME>").
+  test('layer ids match the on-chain adapter LAYER_ID hashes', () => {
+    expect(CCTP_LAYER_ID).toBe(
+      '0xb15c6f4cb2704b59886404596581f035599143a4de893556943a4865c51863a5',
+    )
+    expect(RELAY_LAYER_ID).toBe(
+      '0x7f7b7e37c1c73a7fe521e350bfc44f06aa9ebbc4658ac6261b21c1e6f7b97f58',
+    )
+    expect(RHINO_LAYER_ID).toBe(
+      '0x5c01ead7ebf445ae993202284f0d6b2304b4adfcf34ea7abdee7f15587009db9',
+    )
   })
 })
 
@@ -155,8 +156,7 @@ describe('settlement-layer encoders — policy initData', () => {
     })
     const header = 54
     // header · count(1) · [32 + 2 + len]·2
-    const expected =
-      header + 1 + (32 + 2 + size(cctp)) + (32 + 2 + size(rhino))
+    const expected = header + 1 + (32 + 2 + size(cctp)) + (32 + 2 + size(rhino))
     expect(size(initData)).toBe(expected)
     // layer count byte right after the header
     expect(slice(initData, header, header + 1)).toBe('0x02')

--- a/src/modules/validators/smart-sessions/policies/settlement-layer.test.ts
+++ b/src/modules/validators/smart-sessions/policies/settlement-layer.test.ts
@@ -1,0 +1,207 @@
+import {
+  type Address,
+  type Hex,
+  keccak256,
+  size,
+  slice,
+  toBytes,
+  toHex,
+} from 'viem'
+import { describe, expect, test } from 'vitest'
+import {
+  addressToBytes32,
+  CCTP_LAYER_ID,
+  type CctpLayerConfig,
+  encodeCctpAdapterConfig,
+  encodeIntentExecutorBaseHeader,
+  encodeIntentExecutorPolicyInitData,
+  encodeRelayAdapterConfig,
+  encodeRhinoAdapterConfig,
+  encodeStaticIntentExecutorPolicyInitData,
+  FLAG_LOCK_ACCOUNT,
+  FLAG_REQUIRE_GAS_REFUND,
+  type IntentExecutorBaseConfig,
+  intentExecutorPolicyEntry,
+  RELAY_LAYER_ID,
+  RHINO_LAYER_ID,
+} from './settlement-layer'
+
+const IE: Address = '0x00000000005aD9ce1f5035FD62CA96CEf16AdAAF'
+const TOKEN_MESSENGER: Address = '0xBd3fa81B58Ba92a82136038B25aDec7066af3155'
+const USDC: Address = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const RELAY_ROUTER: Address = '0xb92fe925DC43a0EcDe6C8B1A2709c170eC4ffF4f'
+const RHINO_BRIDGE: Address = '0x4cd00E387622C35BdDB9b4c962c136462338bc31'
+const RECIPIENT: Address = '0x1111111111111111111111111111111111111111'
+const GAS_TOKEN: Address = '0x4200000000000000000000000000000000000006'
+
+describe('settlement-layer encoders — layer ids', () => {
+  test('layer ids are keccak256 of the adapter names', () => {
+    expect(CCTP_LAYER_ID).toBe(keccak256(toBytes('CCTP')))
+    expect(RELAY_LAYER_ID).toBe(keccak256(toBytes('RELAY')))
+    expect(RHINO_LAYER_ID).toBe(keccak256(toBytes('RHINO')))
+  })
+})
+
+describe('settlement-layer encoders — base header', () => {
+  test('layout is intentExecutor(20)·flags(1)·maxExchangeRate(32)·count(1)·tokens', () => {
+    const base: IntentExecutorBaseConfig = {
+      intentExecutor: IE,
+      flags: FLAG_REQUIRE_GAS_REFUND | FLAG_LOCK_ACCOUNT,
+      maxExchangeRate: 123n,
+      gasTokens: [GAS_TOKEN],
+    }
+    const header = encodeIntentExecutorBaseHeader(base)
+    // 54 + 20*gasTokens.length
+    expect(size(header)).toBe(54 + 20)
+    expect(slice(header, 0, 20).toLowerCase()).toBe(IE.toLowerCase())
+    expect(slice(header, 20, 21)).toBe('0x03') // 0x01 | 0x02
+    expect(BigInt(slice(header, 21, 53))).toBe(123n)
+    expect(slice(header, 53, 54)).toBe('0x01') // one gas token
+    expect(slice(header, 54, 74).toLowerCase()).toBe(GAS_TOKEN.toLowerCase())
+  })
+
+  test('empty gas tokens → 54 bytes, count 0', () => {
+    const header = encodeIntentExecutorBaseHeader({ intentExecutor: IE })
+    expect(size(header)).toBe(54)
+    expect(slice(header, 53, 54)).toBe('0x00')
+    expect(slice(header, 20, 21)).toBe('0x00') // default flags 0
+  })
+})
+
+describe('settlement-layer encoders — CCTP adapter config', () => {
+  const cfg: CctpLayerConfig = {
+    tokenMessenger: TOKEN_MESSENGER,
+    maxFeeCap: 500n,
+    minFinalityFloor: 1000,
+    mintRecipients: [addressToBytes32(RECIPIENT)],
+    burnTokens: [USDC],
+    destDomains: [3, 6],
+  }
+
+  test('byte-count matches 56 + 1 + 32*mint + 1 + 20*burn + 1 + 4*dom', () => {
+    const blob = encodeCctpAdapterConfig(cfg)
+    expect(size(blob)).toBe(56 + 1 + 32 * 1 + 1 + 20 * 1 + 1 + 4 * 2)
+  })
+
+  test('field placement', () => {
+    const blob = encodeCctpAdapterConfig(cfg)
+    expect(slice(blob, 0, 20).toLowerCase()).toBe(TOKEN_MESSENGER.toLowerCase())
+    expect(BigInt(slice(blob, 20, 52))).toBe(500n)
+    expect(Number(BigInt(slice(blob, 52, 56)))).toBe(1000)
+    expect(slice(blob, 56, 57)).toBe('0x01') // mint count
+    expect(slice(blob, 57, 89).toLowerCase()).toBe(
+      addressToBytes32(RECIPIENT).toLowerCase(),
+    )
+    // burn count then token
+    expect(slice(blob, 89, 90)).toBe('0x01')
+    expect(slice(blob, 90, 110).toLowerCase()).toBe(USDC.toLowerCase())
+    // dest domain count then two uint32s
+    expect(slice(blob, 110, 111)).toBe('0x02')
+    expect(Number(BigInt(slice(blob, 111, 115)))).toBe(3)
+    expect(Number(BigInt(slice(blob, 115, 119)))).toBe(6)
+  })
+
+  test('empty destDomains → count 0, no domain bytes', () => {
+    const blob = encodeCctpAdapterConfig({ ...cfg, destDomains: [] })
+    expect(size(blob)).toBe(56 + 1 + 32 + 1 + 20 + 1)
+  })
+})
+
+describe('settlement-layer encoders — Relay adapter config', () => {
+  test('byte-count 40 + 1 + 20*recip + 1 + 20*tok, zero ieAdapter default', () => {
+    const blob = encodeRelayAdapterConfig({
+      relayRouter: RELAY_ROUTER,
+      recipients: [RECIPIENT],
+      tokens: [USDC],
+    })
+    expect(size(blob)).toBe(40 + 1 + 20 + 1 + 20)
+    expect(slice(blob, 0, 20).toLowerCase()).toBe(RELAY_ROUTER.toLowerCase())
+    expect(slice(blob, 20, 40)).toBe(
+      '0x0000000000000000000000000000000000000000',
+    )
+  })
+})
+
+describe('settlement-layer encoders — Rhino adapter config', () => {
+  test('byte-count 20 + 1 + 20*tok', () => {
+    const blob = encodeRhinoAdapterConfig({
+      bridgeContract: RHINO_BRIDGE,
+      tokens: [USDC, GAS_TOKEN],
+    })
+    expect(size(blob)).toBe(20 + 1 + 20 * 2)
+    expect(slice(blob, 20, 21)).toBe('0x02')
+  })
+})
+
+describe('settlement-layer encoders — policy initData', () => {
+  const base: IntentExecutorBaseConfig = { intentExecutor: IE }
+  const cctp = encodeCctpAdapterConfig({
+    tokenMessenger: TOKEN_MESSENGER,
+    mintRecipients: [addressToBytes32(RECIPIENT)],
+    burnTokens: [USDC],
+  })
+  const rhino = encodeRhinoAdapterConfig({
+    bridgeContract: RHINO_BRIDGE,
+    tokens: [USDC],
+  })
+
+  test('ownable initData = header · layerCount · [layerId·len·config]…', () => {
+    const initData = encodeIntentExecutorPolicyInitData({
+      base,
+      layers: [
+        { layerId: CCTP_LAYER_ID, config: cctp },
+        { layerId: RHINO_LAYER_ID, config: rhino },
+      ],
+    })
+    const header = 54
+    // header · count(1) · [32 + 2 + len]·2
+    const expected =
+      header + 1 + (32 + 2 + size(cctp)) + (32 + 2 + size(rhino))
+    expect(size(initData)).toBe(expected)
+    // layer count byte right after the header
+    expect(slice(initData, header, header + 1)).toBe('0x02')
+    // first layerId
+    expect(slice(initData, header + 1, header + 33)).toBe(CCTP_LAYER_ID)
+    // first configLen (uint16)
+    expect(Number(BigInt(slice(initData, header + 33, header + 35)))).toBe(
+      size(cctp),
+    )
+  })
+
+  test('static initData = header · config (no wrapper)', () => {
+    const initData = encodeStaticIntentExecutorPolicyInitData({
+      base,
+      config: cctp,
+    })
+    expect(size(initData)).toBe(54 + size(cctp))
+    expect(slice(initData, 54)).toBe(cctp)
+  })
+
+  test('intentExecutorPolicyEntry wraps into a {policy, initData} entry', () => {
+    const POLICY: Address = '0x00000000000000000000000000000000000000AA'
+    const entry = intentExecutorPolicyEntry({
+      policy: POLICY,
+      base,
+      layers: [{ layerId: CCTP_LAYER_ID, config: cctp }],
+    })
+    expect(entry.policy).toBe(POLICY)
+    expect(size(entry.initData as Hex)).toBeGreaterThan(54)
+  })
+
+  test('intentExecutorPolicyEntry throws with no layers', () => {
+    expect(() =>
+      intentExecutorPolicyEntry({
+        policy: '0x00000000000000000000000000000000000000AA',
+        base: { intentExecutor: IE },
+        layers: [],
+      }),
+    ).toThrow(/at least one layer/)
+  })
+})
+
+test('addressToBytes32 left-pads to 32 bytes', () => {
+  const b32 = addressToBytes32(RECIPIENT)
+  expect(size(b32)).toBe(32)
+  expect(slice(b32, 12, 32).toLowerCase()).toBe(RECIPIENT.toLowerCase())
+  expect(slice(b32, 0, 12)).toBe('0x000000000000000000000000')
+})

--- a/src/modules/validators/smart-sessions/policies/settlement-layer.test.ts
+++ b/src/modules/validators/smart-sessions/policies/settlement-layer.test.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, size, slice } from 'viem'
+import { type Address, type Hex, size, slice, zeroAddress } from 'viem'
 import { describe, expect, test } from 'vitest'
 import {
   addressToBytes32,
@@ -59,6 +59,18 @@ describe('settlement-layer encoders — base header', () => {
     expect(BigInt(slice(header, 21, 53))).toBe(123n)
     expect(slice(header, 53, 54)).toBe('0x01') // one gas token
     expect(slice(header, 54, 74).toLowerCase()).toBe(GAS_TOKEN.toLowerCase())
+  })
+
+  // `IntentExecutorConfigLib.initializeBase` reverts `InvalidConfigData` on a
+  // zero gas token, so encoding one produces initData that can only fail at
+  // install — refuse it at the call instead.
+  test('refuses a zero gas token', () => {
+    expect(() =>
+      encodeIntentExecutorBaseHeader({
+        intentExecutor: IE,
+        gasTokens: [GAS_TOKEN, zeroAddress],
+      }),
+    ).toThrow('gasToken must not be the zero address')
   })
 
   test('empty gas tokens → 54 bytes, count 0', () => {
@@ -166,6 +178,18 @@ describe('settlement-layer encoders — policy initData', () => {
     expect(Number(BigInt(slice(initData, header + 33, header + 35)))).toBe(
       size(cctp),
     )
+  })
+
+  // The tail is read by cursor, so a short layerId shifts the configLen and
+  // every later layer with it — the blob stays well-formed and installs as
+  // something else entirely.
+  test('refuses a layerId that is not 32 bytes', () => {
+    expect(() =>
+      encodeIntentExecutorPolicyInitData({
+        base,
+        layers: [{ layerId: slice(CCTP_LAYER_ID, 0, 31), config: cctp }],
+      }),
+    ).toThrow('layerId must be 32 bytes, got 31')
   })
 
   test('static initData = header · config (no wrapper)', () => {

--- a/src/modules/validators/smart-sessions/policies/settlement-layer.ts
+++ b/src/modules/validators/smart-sessions/policies/settlement-layer.ts
@@ -1,0 +1,182 @@
+import {
+  type Address,
+  concat,
+  type Hex,
+  keccak256,
+  pad,
+  size,
+  toBytes,
+  toHex,
+} from 'viem'
+
+// IntentExecutor settlement-layer policy (smart-sessions-v2 #46 / PR #54): an
+// EIP-1271 policy that gates the settlement signature the StandaloneIntentExecutor
+// requests, dispatching each inner call to a stateless per-layer adapter ACL
+// (CCTP / Relay / Rhino). This module reproduces the on-chain config/initData
+// byte layout so a session can install the policy with the right restrictions.
+//
+// Every blob here is MANUALLY BYTE-PACKED (the contract slices bytes with explicit
+// cursors — there is no abi.decode in the config path). All scalars are
+// big-endian, unpadded to their exact field width; addresses are raw 20 bytes;
+// CCTP mint recipients are raw 32 bytes. Use concat, never the ABI coder.
+
+// Adapter layer ids are the adapters' self-declared keccak256(name).
+export const CCTP_LAYER_ID: Hex = keccak256(toBytes('CCTP'))
+export const RELAY_LAYER_ID: Hex = keccak256(toBytes('RELAY'))
+export const RHINO_LAYER_ID: Hex = keccak256(toBytes('RHINO'))
+
+// Base-header flags.
+export const FLAG_REQUIRE_GAS_REFUND = 0x01
+export const FLAG_LOCK_ACCOUNT = 0x02
+
+// Left-pads an address into the 32-byte form CCTP uses for `mintRecipient`.
+export function addressToBytes32(address: Address): Hex {
+  return pad(address, { size: 32 })
+}
+
+// The shared header every IntentExecutor policy initData starts with:
+//   [0:20] intentExecutor · [20] flags · [21:53] maxExchangeRate ·
+//   [53] gasTokenCount · [54:] gasTokens (20 bytes each)
+export interface IntentExecutorBaseConfig {
+  readonly intentExecutor: Address
+  // Bitfield of FLAG_* (require-gas-refund, lock-account).
+  readonly flags?: number
+  // Cap on the gas-refund exchange rate; 0 = uncapped.
+  readonly maxExchangeRate?: bigint
+  // Gas tokens permitted for the refund; each must be non-zero.
+  readonly gasTokens?: Address[]
+}
+
+export function encodeIntentExecutorBaseHeader(
+  config: IntentExecutorBaseConfig,
+): Hex {
+  const gasTokens = config.gasTokens ?? []
+  return concat([
+    config.intentExecutor,
+    toHex(config.flags ?? 0, { size: 1 }),
+    toHex(config.maxExchangeRate ?? 0n, { size: 32 }),
+    toHex(gasTokens.length, { size: 1 }),
+    ...gasTokens,
+  ])
+}
+
+// CCTP adapter config (LAYER_ID = keccak256("CCTP")):
+//   tokenMessenger(20) · maxFeeCap(32) · minFinalityFloor(4) ·
+//   mintRecipientCount(1) · mintRecipients(32 each) ·
+//   burnTokenCount(1) · burnTokens(20 each) ·
+//   destDomainCount(1) · destDomains(4 each; empty = any)
+export interface CctpLayerConfig {
+  readonly tokenMessenger: Address
+  readonly maxFeeCap?: bigint
+  readonly minFinalityFloor?: number
+  // 32-byte mint recipients (use addressToBytes32 for EVM addresses).
+  readonly mintRecipients: Hex[]
+  readonly burnTokens: Address[]
+  // CCTP destination domain ids; empty = any domain.
+  readonly destDomains?: number[]
+}
+
+export function encodeCctpAdapterConfig(config: CctpLayerConfig): Hex {
+  const destDomains = config.destDomains ?? []
+  return concat([
+    config.tokenMessenger,
+    toHex(config.maxFeeCap ?? 0n, { size: 32 }),
+    toHex(config.minFinalityFloor ?? 0, { size: 4 }),
+    toHex(config.mintRecipients.length, { size: 1 }),
+    ...config.mintRecipients,
+    toHex(config.burnTokens.length, { size: 1 }),
+    ...config.burnTokens,
+    toHex(destDomains.length, { size: 1 }),
+    ...destDomains.map((d) => toHex(d, { size: 4 })),
+  ])
+}
+
+// Relay adapter config (LAYER_ID = keccak256("RELAY")):
+//   relayRouter(20) · intentExecutorAdapter(20; zero = adapter calls denied) ·
+//   recipientCount(1) · recipients(20 each) · tokenCount(1) · tokens(20 each)
+export interface RelayLayerConfig {
+  readonly relayRouter: Address
+  readonly intentExecutorAdapter?: Address
+  readonly recipients: Address[]
+  readonly tokens: Address[]
+}
+
+const ZERO_ADDRESS: Address = '0x0000000000000000000000000000000000000000'
+
+export function encodeRelayAdapterConfig(config: RelayLayerConfig): Hex {
+  return concat([
+    config.relayRouter,
+    config.intentExecutorAdapter ?? ZERO_ADDRESS,
+    toHex(config.recipients.length, { size: 1 }),
+    ...config.recipients,
+    toHex(config.tokens.length, { size: 1 }),
+    ...config.tokens,
+  ])
+}
+
+// Rhino adapter config (LAYER_ID = keccak256("RHINO")):
+//   bridgeContract(20) · tokenCount(1) · tokens(20 each)
+export interface RhinoLayerConfig {
+  readonly bridgeContract: Address
+  readonly tokens: Address[]
+}
+
+export function encodeRhinoAdapterConfig(config: RhinoLayerConfig): Hex {
+  return concat([
+    config.bridgeContract,
+    toHex(config.tokens.length, { size: 1 }),
+    ...config.tokens,
+  ])
+}
+
+// One layer to install: its id plus the adapter config blob (from the encoders
+// above). The contract derives the adapter + configHash on-chain.
+export interface LayerInstall {
+  readonly layerId: Hex
+  readonly config: Hex
+}
+
+// Ownable IntentExecutorPolicy initData = base header || tail, where the tail is:
+//   layerCount(1) · per layer [ layerId(32) · configLen(uint16) · config ]
+export function encodeIntentExecutorPolicyInitData(input: {
+  readonly base: IntentExecutorBaseConfig
+  readonly layers: readonly LayerInstall[]
+}): Hex {
+  const tail = concat([
+    toHex(input.layers.length, { size: 1 }),
+    ...input.layers.flatMap((l) => [
+      l.layerId,
+      toHex(size(l.config), { size: 2 }),
+      l.config,
+    ]),
+  ])
+  return concat([encodeIntentExecutorBaseHeader(input.base), tail])
+}
+
+// Static (single-layer) policy initData = base header || the adapter config blob
+// verbatim (no layer wrapper).
+export function encodeStaticIntentExecutorPolicyInitData(input: {
+  readonly base: IntentExecutorBaseConfig
+  readonly config: Hex
+}): Hex {
+  return concat([encodeIntentExecutorBaseHeader(input.base), input.config])
+}
+
+// The ERC-1271 policy entry to add to a session's erc7739Policies.erc1271Policies
+// for the ownable multi-layer IntentExecutor policy.
+export function intentExecutorPolicyEntry(params: {
+  readonly policy: Address
+  readonly base: IntentExecutorBaseConfig
+  readonly layers: readonly LayerInstall[]
+}): { readonly policy: Address; readonly initData: Hex } {
+  if (params.layers.length === 0) {
+    throw new Error('intentExecutorPolicyEntry requires at least one layer')
+  }
+  return {
+    policy: params.policy,
+    initData: encodeIntentExecutorPolicyInitData({
+      base: params.base,
+      layers: params.layers,
+    }),
+  }
+}

--- a/src/modules/validators/smart-sessions/policies/settlement-layer.ts
+++ b/src/modules/validators/smart-sessions/policies/settlement-layer.ts
@@ -7,7 +7,18 @@ import {
   size,
   toBytes,
   toHex,
+  zeroAddress,
 } from 'viem'
+
+// Guards a packed field width so a truncated address/bytes32 fails with a clear
+// SDK error instead of silently misaligning the blob (the on-chain adapter would
+// then revert on install with an opaque length error).
+function assertWidth(value: Hex, bytes: number, label: string): Hex {
+  if (size(value) !== bytes) {
+    throw new Error(`${label} must be ${bytes} bytes, got ${size(value)}`)
+  }
+  return value
+}
 
 // IntentExecutor settlement-layer policy (smart-sessions-v2 #46 / PR #54): an
 // EIP-1271 policy that gates the settlement signature the StandaloneIntentExecutor
@@ -52,11 +63,11 @@ export function encodeIntentExecutorBaseHeader(
 ): Hex {
   const gasTokens = config.gasTokens ?? []
   return concat([
-    config.intentExecutor,
+    assertWidth(config.intentExecutor, 20, 'intentExecutor'),
     toHex(config.flags ?? 0, { size: 1 }),
     toHex(config.maxExchangeRate ?? 0n, { size: 32 }),
     toHex(gasTokens.length, { size: 1 }),
-    ...gasTokens,
+    ...gasTokens.map((t) => assertWidth(t, 20, 'gasToken')),
   ])
 }
 
@@ -79,13 +90,13 @@ export interface CctpLayerConfig {
 export function encodeCctpAdapterConfig(config: CctpLayerConfig): Hex {
   const destDomains = config.destDomains ?? []
   return concat([
-    config.tokenMessenger,
+    assertWidth(config.tokenMessenger, 20, 'tokenMessenger'),
     toHex(config.maxFeeCap ?? 0n, { size: 32 }),
     toHex(config.minFinalityFloor ?? 0, { size: 4 }),
     toHex(config.mintRecipients.length, { size: 1 }),
-    ...config.mintRecipients,
+    ...config.mintRecipients.map((r) => assertWidth(r, 32, 'mintRecipient')),
     toHex(config.burnTokens.length, { size: 1 }),
-    ...config.burnTokens,
+    ...config.burnTokens.map((t) => assertWidth(t, 20, 'burnToken')),
     toHex(destDomains.length, { size: 1 }),
     ...destDomains.map((d) => toHex(d, { size: 4 })),
   ])
@@ -101,16 +112,18 @@ export interface RelayLayerConfig {
   readonly tokens: Address[]
 }
 
-const ZERO_ADDRESS: Address = '0x0000000000000000000000000000000000000000'
-
 export function encodeRelayAdapterConfig(config: RelayLayerConfig): Hex {
   return concat([
-    config.relayRouter,
-    config.intentExecutorAdapter ?? ZERO_ADDRESS,
+    assertWidth(config.relayRouter, 20, 'relayRouter'),
+    assertWidth(
+      config.intentExecutorAdapter ?? zeroAddress,
+      20,
+      'intentExecutorAdapter',
+    ),
     toHex(config.recipients.length, { size: 1 }),
-    ...config.recipients,
+    ...config.recipients.map((r) => assertWidth(r, 20, 'relay recipient')),
     toHex(config.tokens.length, { size: 1 }),
-    ...config.tokens,
+    ...config.tokens.map((t) => assertWidth(t, 20, 'relay token')),
   ])
 }
 
@@ -123,9 +136,9 @@ export interface RhinoLayerConfig {
 
 export function encodeRhinoAdapterConfig(config: RhinoLayerConfig): Hex {
   return concat([
-    config.bridgeContract,
+    assertWidth(config.bridgeContract, 20, 'bridgeContract'),
     toHex(config.tokens.length, { size: 1 }),
-    ...config.tokens,
+    ...config.tokens.map((t) => assertWidth(t, 20, 'rhino token')),
   ])
 }
 

--- a/src/modules/validators/smart-sessions/policies/settlement-layer.ts
+++ b/src/modules/validators/smart-sessions/policies/settlement-layer.ts
@@ -20,6 +20,15 @@ function assertWidth(value: Hex, bytes: number, label: string): Hex {
   return value
 }
 
+// The gas-token whitelist rejects the zero address on-chain (it is the sentinel
+// for "no entry"), so an initData carrying one reverts at install.
+function assertNonZero(token: Address): Address {
+  if (token === zeroAddress) {
+    throw new Error('gasToken must not be the zero address')
+  }
+  return token
+}
+
 // IntentExecutor settlement-layer policy (smart-sessions-v2 #46 / PR #54): an
 // EIP-1271 policy that gates the settlement signature the StandaloneIntentExecutor
 // requests, dispatching each inner call to a stateless per-layer adapter ACL
@@ -54,7 +63,8 @@ export interface IntentExecutorBaseConfig {
   readonly flags?: number
   // Cap on the gas-refund exchange rate; 0 = uncapped.
   readonly maxExchangeRate?: bigint
-  // Gas tokens permitted for the refund; each must be non-zero.
+  // Gas tokens permitted for the refund; each must be non-zero (the contract
+  // reverts on a zero entry, so this encoder does too).
   readonly gasTokens?: Address[]
 }
 
@@ -67,7 +77,7 @@ export function encodeIntentExecutorBaseHeader(
     toHex(config.flags ?? 0, { size: 1 }),
     toHex(config.maxExchangeRate ?? 0n, { size: 32 }),
     toHex(gasTokens.length, { size: 1 }),
-    ...gasTokens.map((t) => assertWidth(t, 20, 'gasToken')),
+    ...gasTokens.map((t) => assertNonZero(assertWidth(t, 20, 'gasToken'))),
   ])
 }
 
@@ -158,7 +168,7 @@ export function encodeIntentExecutorPolicyInitData(input: {
   const tail = concat([
     toHex(input.layers.length, { size: 1 }),
     ...input.layers.flatMap((l) => [
-      l.layerId,
+      assertWidth(l.layerId, 32, 'layerId'),
       toHex(size(l.config), { size: 2 }),
       l.config,
     ]),

--- a/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
@@ -52,6 +52,42 @@ describe('resolveSessionData — one-time-use session', () => {
     }
   })
 
+  test('executor-only one-time-use drops sudo from the 1271 list, leaving only the once-policy', () => {
+    const data = resolveSessionData({
+      chain: base,
+      owners,
+      oneTimeUse: { id: 42n },
+      policyAddresses: { oneTimeUseId: POLICY },
+    })
+    // No claim policy → the 1271 list is exactly [once]; the permissive sudo
+    // entry is intentionally replaced so the arbiter route can't fall through it.
+    expect(data.erc7739Policies.erc1271Policies).toEqual([onceEntry])
+    expect(data.claimPolicies).toHaveLength(0)
+    // ...and the burn still bounds the executor route: once-policy on every action.
+    expect(data.actions.length).toBeGreaterThan(0)
+    for (const action of data.actions) {
+      expect(action.actionPolicies).toContainEqual(onceEntry)
+    }
+  })
+
+  test('permissionId is derived from validator+salt, not the pinned id (id is bound via the enable-signed config)', () => {
+    const session = (id: bigint) =>
+      toSession({
+        chain: base,
+        owners,
+        claimPolicies: [{ type: 'permit2' }],
+        oneTimeUse: { id },
+        policyAddresses: { oneTimeUseId: POLICY },
+      })
+    // Smart-sessions derives the permissionId from (sessionValidator, initData,
+    // salt) only — the pinned id lives in the once-policy initData, which the
+    // enable signature authorizes over the full session config, not the
+    // permissionId. So two one-time-use sessions differing ONLY by id share a
+    // permissionId (as any two same-owner sessions do, since salt is fixed to
+    // zeroHash) and can't be installed concurrently on the same account.
+    expect(session(42n).permissionId).toBe(session(43n).permissionId)
+  })
+
   test('throws when oneTimeUse is set without policyAddresses.oneTimeUseId', () => {
     expect(() =>
       resolveSessionData({ chain: base, owners, oneTimeUse: { id: 42n } }),

--- a/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
@@ -106,6 +106,8 @@ describe('resolveSessionData — one-time-use session', () => {
     // that the erc1271-resident Permit2ClaimPolicy reads (RHI-5798).
     expect(session.claimPolicies).toHaveLength(1)
     expect(session.claimPoliciesEnforcedVia1271).toBe(true)
+    // Drives prepareIntentSessions to keep the session in verify-execution mode.
+    expect(session.oneTimeUse).toBe(true)
     // ...but the on-chain claim (lockTag) surface stays empty — the policy is
     // enforced via the erc1271 list, so getSessionData must not re-encode it.
     expect(getSessionData(session).claimPolicies).toHaveLength(0)

--- a/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest'
 
 import { accountA } from '../../../../test/consts'
 import { PERMIT2_CLAIM_POLICY_ADDRESS } from '../policies/claim/permit2'
+import { getSessionData } from './digest'
 import { resolveSessionData, toSession } from './resolve'
 
 // Kept out of resolve.test.ts because that file imports fast-check (declared in
@@ -57,7 +58,7 @@ describe('resolveSessionData — one-time-use session', () => {
     ).toThrow(/oneTimeUseId/)
   })
 
-  test('toSession also empties claimPolicies (no leak onto the claim surface via getSessionData)', () => {
+  test('toSession keeps claim policies on the high-level session (permit2 signature calldata) but off the on-chain claim surface', () => {
     const session = toSession({
       chain: base,
       owners,
@@ -65,6 +66,15 @@ describe('resolveSessionData — one-time-use session', () => {
       oneTimeUse: { id: 42n },
       policyAddresses: { oneTimeUseId: POLICY },
     })
-    expect(session.claimPolicies).toHaveLength(0)
+    // Populated so claimPolicyData() can build the permit2 settlement calldata
+    // that the erc1271-resident Permit2ClaimPolicy reads (RHI-5798).
+    expect(session.claimPolicies).toHaveLength(1)
+    expect(session.claimPoliciesEnforcedVia1271).toBe(true)
+    // ...but the on-chain claim (lockTag) surface stays empty — the policy is
+    // enforced via the erc1271 list, so getSessionData must not re-encode it.
+    expect(getSessionData(session).claimPolicies).toHaveLength(0)
+    expect(
+      getSessionData(session).erc7739Policies.erc1271Policies.length,
+    ).toBeGreaterThan(1)
   })
 })

--- a/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
@@ -1,0 +1,70 @@
+import { pad, toHex } from 'viem'
+import { base } from 'viem/chains'
+import { describe, expect, test } from 'vitest'
+
+import { accountA } from '../../../../test/consts'
+import { PERMIT2_CLAIM_POLICY_ADDRESS } from '../policies/claim/permit2'
+import { resolveSessionData, toSession } from './resolve'
+
+// Kept out of resolve.test.ts because that file imports fast-check (declared in
+// package.json but not installed in every working copy); these are plain
+// example-based tests for the OneTimeUseId wiring (RHI-5798).
+describe('resolveSessionData — one-time-use session', () => {
+  const POLICY = '0x00000000000000000000000000000000000000aa' as const
+  const owners = { type: 'ecdsa' as const, accounts: [accountA] }
+  const onceEntry = { policy: POLICY, initData: pad(toHex(42n), { size: 32 }) }
+
+  function oneTimeUseSession() {
+    return resolveSessionData({
+      chain: base,
+      owners,
+      claimPolicies: [{ type: 'permit2' }],
+      oneTimeUse: { id: 42n },
+      policyAddresses: { oneTimeUseId: POLICY },
+    })
+  }
+
+  test('installs the once-policy on EVERY action (executor route enforces via checkAction)', () => {
+    const data = oneTimeUseSession()
+    expect(data.actions.length).toBeGreaterThan(0)
+    for (const action of data.actions) {
+      expect(action.actionPolicies).toContainEqual(onceEntry)
+    }
+  })
+
+  test('co-locates the Permit2 claim policy with the once-policy on the 1271 list, and empties claimPolicies', () => {
+    const data = oneTimeUseSession()
+    const list = data.erc7739Policies.erc1271Policies
+    // [ Permit2ClaimPolicy (digest-binding partner), once-policy ] — no sudo
+    expect(list).toHaveLength(2)
+    expect(list[0].policy).toBe(PERMIT2_CLAIM_POLICY_ADDRESS)
+    expect(list[1]).toEqual(onceEntry)
+    // the claim policy moved OFF the claim surface onto the 1271 surface
+    expect(data.claimPolicies).toHaveLength(0)
+  })
+
+  test('leaves a normal session untouched (sudo-only 1271 list, no once-policy on actions)', () => {
+    const data = resolveSessionData({ chain: base, owners })
+    expect(data.erc7739Policies.erc1271Policies).toHaveLength(1)
+    for (const action of data.actions) {
+      expect(action.actionPolicies).not.toContainEqual(onceEntry)
+    }
+  })
+
+  test('throws when oneTimeUse is set without policyAddresses.oneTimeUseId', () => {
+    expect(() =>
+      resolveSessionData({ chain: base, owners, oneTimeUse: { id: 42n } }),
+    ).toThrow(/oneTimeUseId/)
+  })
+
+  test('toSession also empties claimPolicies (no leak onto the claim surface via getSessionData)', () => {
+    const session = toSession({
+      chain: base,
+      owners,
+      claimPolicies: [{ type: 'permit2' }],
+      oneTimeUse: { id: 42n },
+      policyAddresses: { oneTimeUseId: POLICY },
+    })
+    expect(session.claimPolicies).toHaveLength(0)
+  })
+})

--- a/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.one-time-use.test.ts
@@ -44,6 +44,20 @@ describe('resolveSessionData — one-time-use session', () => {
     expect(data.claimPolicies).toHaveLength(0)
   })
 
+  // Both surfaces are the same AND-list, and each policy only recognises its
+  // own digest shape, so no signature can satisfy both. The builder refuses the
+  // combination, but a SessionDefinition can be written by hand.
+  test('refuses a 1271 policy combined with a Permit2 claim policy', () => {
+    expect(() =>
+      resolveSessionData({
+        chain: base,
+        owners,
+        claimPolicies: [{ type: 'permit2' }],
+        erc1271Policies: [{ policy: POLICY, initData: '0x' }],
+      }),
+    ).toThrow('cannot be combined')
+  })
+
   test('leaves a normal session untouched (sudo-only 1271 list, no once-policy on actions)', () => {
     const data = resolveSessionData({ chain: base, owners })
     expect(data.erc7739Policies.erc1271Policies).toHaveLength(1)

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -143,10 +143,13 @@ export function resolveSessionData(
       policy: addresses.oneTimeUseId,
       id: definition.oneTimeUse.id,
     })
-    // The executor route enforces via ACTION policies (checkAction), not the 1271
-    // list, so the burn only bounds it when the once-policy sits on EVERY action
-    // the session permits — otherwise an executor settlement falls through to the
-    // permissive sudo fallback and the id is never read.
+    // Install the once-policy on EVERY action: on the executor route the contract's
+    // on-chain guard (a `consume` may only name the session's own id) runs via
+    // checkAction, once per execution, so a settler can't dodge it by composing the
+    // batch out of some other permitted action. checkAction only fires in
+    // verify-execution mode, which prepareIntentSessions forces for one-time-use
+    // sessions (see there). Replay of a burned id is additionally blocked on the
+    // 1271 surface below, which is consulted in every mode.
     actions = actions.map((action) => ({
       ...action,
       actionPolicies: [...action.actionPolicies, once],
@@ -209,6 +212,7 @@ export function toSession(
     // (lockTag) surface — otherwise they'd settle on both surfaces.
     claimPolicies: [...(definition.claimPolicies ?? []), ...expandedClaims],
     claimPoliciesEnforcedVia1271: Boolean(definition.oneTimeUse),
+    oneTimeUse: Boolean(definition.oneTimeUse),
   }
 }
 

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -201,13 +201,14 @@ export function toSession(
     salt: data.salt,
     erc7739Policies: data.erc7739Policies,
     actions: data.actions,
-    // For a one-time-use session the claim policies live on the erc1271 surface
-    // (see resolveSessionData); keep them off the claim surface here too, or
-    // getSessionData would re-encode them into lockTagPolicies and settle them on
-    // both surfaces.
-    claimPolicies: definition.oneTimeUse
-      ? []
-      : [...(definition.claimPolicies ?? []), ...expandedClaims],
+    // Keep the raw claim policies on the high-level session for both routes: the
+    // permit2 settlement signature builds their calldata from here (see
+    // claimPolicyData in session-signing). For a one-time-use session they are
+    // enforced via the erc1271 surface (already in data.erc7739Policies), so the
+    // flag tells getSessionData NOT to re-encode them onto the on-chain claim
+    // (lockTag) surface — otherwise they'd settle on both surfaces.
+    claimPolicies: [...(definition.claimPolicies ?? []), ...expandedClaims],
+    claimPoliciesEnforcedVia1271: Boolean(definition.oneTimeUse),
   }
 }
 

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -8,6 +8,7 @@ import {
 import { resolveValidator } from '../resolve'
 import { resolveCrossChainPermission } from './cross-chain-permits'
 import { getPermissionIdFromData } from './digest'
+import { oneTimeUseIdErc1271Policy } from './one-time-use'
 import {
   DEFAULT_POLICY_ADDRESSES,
   resolvePolicyAddresses,
@@ -102,7 +103,7 @@ export function resolveSessionData(
       policies: [{ type: 'sudo' }],
     },
   ]
-  const actions =
+  let actions: ResolvedAction[] =
     userActions.length || permitFallbackPolicies.length
       ? [...userActions, ...injectedActions].map(
           (action): ResolvedAction => ({
@@ -120,7 +121,7 @@ export function resolveSessionData(
           }),
         )
       : [sudoAction]
-  const claimPolicies = [
+  let claimPolicies: { policy: Address; initData: Hex }[] = [
     ...(definition.claimPolicies ?? []),
     ...expandedPermits.map(({ claim }) => claim),
   ].map((policy) => ({
@@ -129,6 +130,36 @@ export function resolveSessionData(
       resolvePermit2ClaimPolicy(policy),
     ),
   }))
+  let erc1271Policies: { policy: Address; initData: Hex }[] = [
+    { policy: addresses.sudo, initData: '0x' },
+  ]
+  if (definition.oneTimeUse) {
+    if (!addresses.oneTimeUseId) {
+      throw new Error(
+        'oneTimeUse requires policyAddresses.oneTimeUseId (no canonical deployment yet)',
+      )
+    }
+    const once = oneTimeUseIdErc1271Policy({
+      policy: addresses.oneTimeUseId,
+      id: definition.oneTimeUse.id,
+    })
+    // The executor route enforces via ACTION policies (checkAction), not the 1271
+    // list, so the burn only bounds it when the once-policy sits on EVERY action
+    // the session permits — otherwise an executor settlement falls through to the
+    // permissive sudo fallback and the id is never read.
+    actions = actions.map((action) => ({
+      ...action,
+      actionPolicies: [...action.actionPolicies, once],
+    }))
+    // The Permit2/arbiter route enforces via the 1271 list. The once-policy's
+    // settling proof only binds when the digest-binding Permit2 claim policy sits
+    // on the SAME surface (the 1271 list is an AND: it bounds WHAT may settle, the
+    // once-policy bounds HOW MANY TIMES), so the claim policies move here from
+    // `claimPolicies`. A permit2 one-time-use session must therefore supply a claim
+    // policy; an executor-only session may have none.
+    erc1271Policies = [...claimPolicies, once]
+    claimPolicies = []
+  }
   return {
     sessionValidator: validator.address,
     sessionValidatorInitData: validator.initData,
@@ -137,7 +168,7 @@ export function resolveSessionData(
       allowedERC7739Content: [
         { contentNames: [''], appDomainSeparator: zeroHash },
       ],
-      erc1271Policies: [{ policy: addresses.sudo, initData: '0x' }],
+      erc1271Policies,
     },
     actions,
     claimPolicies,
@@ -170,7 +201,13 @@ export function toSession(
     salt: data.salt,
     erc7739Policies: data.erc7739Policies,
     actions: data.actions,
-    claimPolicies: [...(definition.claimPolicies ?? []), ...expandedClaims],
+    // For a one-time-use session the claim policies live on the erc1271 surface
+    // (see resolveSessionData); keep them off the claim surface here too, or
+    // getSessionData would re-encode them into lockTagPolicies and settle them on
+    // both surfaces.
+    claimPolicies: definition.oneTimeUse
+      ? []
+      : [...(definition.claimPolicies ?? []), ...expandedClaims],
   }
 }
 

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -130,9 +130,13 @@ export function resolveSessionData(
       resolvePermit2ClaimPolicy(policy),
     ),
   }))
-  let erc1271Policies: { policy: Address; initData: Hex }[] = [
-    { policy: addresses.sudo, initData: '0x' },
-  ]
+  // Extra pre-encoded 1271 policies (e.g. an IntentExecutor settlement-layer
+  // policy). They are enforcing, so they replace the default sudo entry to keep
+  // the 1271 list a strict AND rather than letting sudo pass everything.
+  const extraErc1271 = definition.erc1271Policies ?? []
+  let erc1271Policies: { policy: Address; initData: Hex }[] = extraErc1271.length
+    ? [...extraErc1271]
+    : [{ policy: addresses.sudo, initData: '0x' }]
   if (definition.oneTimeUse) {
     if (!addresses.oneTimeUseId) {
       throw new Error(
@@ -160,7 +164,7 @@ export function resolveSessionData(
     // once-policy bounds HOW MANY TIMES), so the claim policies move here from
     // `claimPolicies`. A permit2 one-time-use session must therefore supply a claim
     // policy; an executor-only session may have none.
-    erc1271Policies = [...claimPolicies, once]
+    erc1271Policies = [...claimPolicies, ...extraErc1271, once]
     claimPolicies = []
   }
   return {

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -132,11 +132,16 @@ export function resolveSessionData(
   }))
   // Extra pre-encoded 1271 policies (e.g. an IntentExecutor settlement-layer
   // policy). They are enforcing, so they replace the default sudo entry to keep
-  // the 1271 list a strict AND rather than letting sudo pass everything.
+  // the 1271 list a strict AND rather than letting sudo pass everything. A
+  // route-gating 1271 policy (settlement-layer) and Permit2 claim policies gate
+  // different routes on this shared AND-list, so the caller must not combine them
+  // (defineSpendSession guards this); doing so yields a session that cannot
+  // settle rather than a bypass.
   const extraErc1271 = definition.erc1271Policies ?? []
-  let erc1271Policies: { policy: Address; initData: Hex }[] = extraErc1271.length
-    ? [...extraErc1271]
-    : [{ policy: addresses.sudo, initData: '0x' }]
+  let erc1271Policies: { policy: Address; initData: Hex }[] =
+    extraErc1271.length
+      ? [...extraErc1271]
+      : [{ policy: addresses.sudo, initData: '0x' }]
   if (definition.oneTimeUse) {
     if (!addresses.oneTimeUseId) {
       throw new Error(

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -224,7 +224,9 @@ export function toSession(
     // stops being enforced from the second use on.
     hasExplicitPermissions:
       Boolean(definition.permissions?.length) ||
-      expanded.some(({ fallbackPolicies }) => fallbackPolicies.length > 0),
+      expanded.some(({ fallbackPolicies }) =>
+        fallbackPolicies.some((policy) => policy.type === 'spending-limits'),
+      ),
     permissionId: getPermissionIdFromData(data),
     sessionValidator: data.sessionValidator,
     sessionValidatorInitData: data.sessionValidatorInitData,

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -207,15 +207,24 @@ export function toSession(
       ? { wrappedNativeToken: options.wrappedNativeToken }
       : {}),
   })
-  const expandedClaims = (definition.crossChainPermits ?? []).map(
-    (input) =>
-      expandCrossChainPermit(resolveCrossChainPermission(input), environment)
-        .claim,
+  const expanded = (definition.crossChainPermits ?? []).map((input) =>
+    expandCrossChainPermit(resolveCrossChainPermission(input), environment),
   )
+  const expandedClaims = expanded.map(({ claim }) => claim)
   return {
     chain: definition.chain,
     owners: definition.owners,
-    hasExplicitPermissions: Boolean(definition.permissions?.length),
+    // Whether this session has policies that only run on the ACTION surface,
+    // which is what decides `verifyExecutions` downstream: an enabled session
+    // without them drops to plain ERC-1271 (mode 1), where `checkAction` never
+    // fires. A cross-chain permit's `maxAmount` is exactly such a policy — it
+    // is expanded into a spending-limit on the fallback action, and unlike the
+    // permit deadline it has no counterpart on the claim policy — so a session
+    // carrying one must keep verify-execution mode, or the cap it advertises
+    // stops being enforced from the second use on.
+    hasExplicitPermissions:
+      Boolean(definition.permissions?.length) ||
+      expanded.some(({ fallbackPolicies }) => fallbackPolicies.length > 0),
     permissionId: getPermissionIdFromData(data),
     sessionValidator: data.sessionValidator,
     sessionValidatorInitData: data.sessionValidatorInitData,

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -135,9 +135,18 @@ export function resolveSessionData(
   // the 1271 list a strict AND rather than letting sudo pass everything. A
   // route-gating 1271 policy (settlement-layer) and Permit2 claim policies gate
   // different routes on this shared AND-list, so the caller must not combine them
-  // (defineSpendSession guards this); doing so yields a session that cannot
-  // settle rather than a bypass.
+  // (experimental_defineSpendSession guards it too, ahead of this); combining
+  // them yields a session that cannot settle rather than a bypass, so it is
+  // refused here as well — a SessionDefinition can be built by hand.
   const extraErc1271 = definition.erc1271Policies ?? []
+  if (extraErc1271.length && claimPolicies.length) {
+    throw new Error(
+      'erc1271Policies and Permit2 claim policies cannot be combined: they gate ' +
+        'different settlement routes on one AND-list, so no signature satisfies ' +
+        'both. Use claimPolicies/permits for the Permit2 route, or ' +
+        'erc1271Policies for the IntentExecutor route.',
+    )
+  }
   let erc1271Policies: { policy: Address; initData: Hex }[] =
     extraErc1271.length
       ? [...extraErc1271]

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -107,6 +107,9 @@ export interface SessionPolicyAddresses {
   readonly timeFrame?: Address
   readonly usageLimit?: Address
   readonly valueLimit?: Address
+  // Required when a session sets `oneTimeUse`; no default until the policy has a
+  // canonical deployment.
+  readonly oneTimeUseId?: Address
 }
 
 export type CrossChainSettlementLayer = 'SAME_CHAIN' | 'ECO' | 'ACROSS'
@@ -161,6 +164,15 @@ export interface SessionDefinition {
   claimPolicies?: Permit2ClaimPolicy[]
   crossChainPermits?: CrossChainPermissionInput[]
   policyAddresses?: SessionPolicyAddresses
+  // Pins a one-time-use id on the session (RHI-5798): the session settles at most
+  // once per chain. Requires `policyAddresses.oneTimeUseId`, and each settlement
+  // must carry the matching burn op (see buildOneTimeUseBurnOp) in its
+  // `preClaimExecutions`.
+  oneTimeUse?: OneTimeUseSessionConfig
+}
+
+export interface OneTimeUseSessionConfig {
+  readonly id: bigint
 }
 
 export interface ResolvedPolicy {

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -207,6 +207,11 @@ export interface Session {
   erc7739Policies: ResolvedERC7739Policies
   actions: readonly ResolvedAction[]
   claimPolicies: readonly Permit2ClaimPolicy[]
+  // When true, `claimPolicies` are enforced via the ERC-1271 surface (already
+  // encoded into `erc7739Policies.erc1271Policies`) and must NOT be re-encoded
+  // onto the on-chain claim (lockTag) surface. They stay on the high-level
+  // session so the permit2 settlement signature can still build their calldata.
+  claimPoliciesEnforcedVia1271?: boolean
 }
 
 export interface SessionData {

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -212,6 +212,11 @@ export interface Session {
   // onto the on-chain claim (lockTag) surface. They stay on the high-level
   // session so the permit2 settlement signature can still build their calldata.
   claimPoliciesEnforcedVia1271?: boolean
+  // A one-time-use session (RHI-5798). The executor route's on-chain guard runs
+  // via checkAction, which only fires in verify-execution mode, so this forces
+  // that mode in prepareIntentSessions even for an already-enabled session — see
+  // there for why dropping to plain ERC-1271 would make the guard inert.
+  oneTimeUse?: boolean
 }
 
 export interface SessionData {

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -110,9 +110,6 @@ export interface SessionPolicyAddresses {
   // Required when a session sets `oneTimeUse`; no default until the policy has a
   // canonical deployment.
   readonly oneTimeUseId?: Address
-  // The IntentExecutor settlement-layer policy (smart-sessions-v2 #46). No
-  // default until it has a canonical deployment.
-  readonly intentExecutorPolicy?: Address
 }
 
 export type CrossChainSettlementLayer = 'SAME_CHAIN' | 'ECO' | 'ACROSS'

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -110,6 +110,9 @@ export interface SessionPolicyAddresses {
   // Required when a session sets `oneTimeUse`; no default until the policy has a
   // canonical deployment.
   readonly oneTimeUseId?: Address
+  // The IntentExecutor settlement-layer policy (smart-sessions-v2 #46). No
+  // default until it has a canonical deployment.
+  readonly intentExecutorPolicy?: Address
 }
 
 export type CrossChainSettlementLayer = 'SAME_CHAIN' | 'ECO' | 'ACROSS'
@@ -169,6 +172,10 @@ export interface SessionDefinition {
   // must carry the matching burn op (see buildOneTimeUseBurnOp) in its
   // `preClaimExecutions`.
   oneTimeUse?: OneTimeUseSessionConfig
+  // Pre-encoded ERC-1271 policy entries to install on the session's 1271 surface
+  // (e.g. an IntentExecutor settlement-layer policy). Enforcing 1271 policies drop
+  // the default sudo entry, so the 1271 list stays a strict AND.
+  erc1271Policies?: ResolvedPolicy[]
 }
 
 export interface OneTimeUseSessionConfig {

--- a/src/smart-sessions/experimental/spend-session.test.ts
+++ b/src/smart-sessions/experimental/spend-session.test.ts
@@ -4,6 +4,13 @@ import { describe, expect, test } from 'vitest'
 import { accountA } from '../../../test/consts'
 import { getSessionData } from '../../modules/validators/smart-sessions/digest'
 import { oneTimeUseIdPolicyAbi } from '../../modules/validators/smart-sessions/one-time-use'
+import { SUDO_POLICY_ADDRESS } from '../../modules/validators/smart-sessions/policies/addresses'
+import {
+  CCTP_LAYER_ID,
+  addressToBytes32,
+  encodeCctpAdapterConfig,
+  intentExecutorPolicyEntry,
+} from '../../modules/validators/smart-sessions/policies/settlement-layer'
 import {
   ARG_POLICY_ADDRESS,
   SPENDING_LIMITS_POLICY_ADDRESS,
@@ -356,6 +363,66 @@ describe('experimental_defineSpendSession — validation & the old way', () => {
         }),
       ).not.toThrow()
     }
+  })
+
+  test('a settlement-layer 1271 policy is installed and replaces sudo', () => {
+    const POLICY: Address = '0x00000000000000000000000000000000000000AA'
+    const IE: Address = '0x00000000005aD9ce1f5035FD62CA96CEf16AdAAF'
+    const entry = intentExecutorPolicyEntry({
+      policy: POLICY,
+      base: { intentExecutor: IE },
+      layers: [
+        {
+          layerId: CCTP_LAYER_ID,
+          config: encodeCctpAdapterConfig({
+            tokenMessenger: '0xBd3fa81B58Ba92a82136038B25aDec7066af3155',
+            mintRecipients: [addressToBytes32(RECIPIENT)],
+            burnTokens: [USDC],
+          }),
+        },
+      ],
+    })
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }] },
+      erc1271Policies: [entry],
+      policyAddresses: { intentExecutorPolicy: POLICY },
+    })
+    const list = getSessionData(session).erc7739Policies.erc1271Policies
+    expect(list.some((p) => isAddressEqual(p.policy, POLICY))).toBe(true)
+    // enforcing 1271 policy drops the default sudo entry
+    expect(list.some((p) => isAddressEqual(p.policy, SUDO_POLICY_ADDRESS))).toBe(
+      false,
+    )
+  })
+
+  test('settlement-layer policy is refused alongside a cross-chain arbiter target', () => {
+    const entry = intentExecutorPolicyEntry({
+      policy: '0x00000000000000000000000000000000000000AA',
+      base: { intentExecutor: '0x00000000005aD9ce1f5035FD62CA96CEf16AdAAF' },
+      layers: [
+        {
+          layerId: CCTP_LAYER_ID,
+          config: encodeCctpAdapterConfig({
+            tokenMessenger: '0xBd3fa81B58Ba92a82136038B25aDec7066af3155',
+            mintRecipients: [addressToBytes32(RECIPIENT)],
+            burnTokens: [USDC],
+          }),
+        },
+      ],
+    })
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: {
+          tokens: [{ token: USDC }],
+          target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
+        },
+        erc1271Policies: [entry],
+      }),
+    ).toThrow(/mutually exclusive/)
   })
 
   test('the old way (no singleUse) still scopes but has no burn op', () => {

--- a/src/smart-sessions/experimental/spend-session.test.ts
+++ b/src/smart-sessions/experimental/spend-session.test.ts
@@ -4,34 +4,44 @@ import { describe, expect, test } from 'vitest'
 import { accountA } from '../../../test/consts'
 import { getSessionData } from '../../modules/validators/smart-sessions/digest'
 import { oneTimeUseIdPolicyAbi } from '../../modules/validators/smart-sessions/one-time-use'
-import { SUDO_POLICY_ADDRESS } from '../../modules/validators/smart-sessions/policies/addresses'
-import {
-  CCTP_LAYER_ID,
-  addressToBytes32,
-  encodeCctpAdapterConfig,
-  intentExecutorPolicyEntry,
-} from '../../modules/validators/smart-sessions/policies/settlement-layer'
 import {
   ARG_POLICY_ADDRESS,
   SPENDING_LIMITS_POLICY_ADDRESS,
+  SUDO_POLICY_ADDRESS,
   TIME_FRAME_POLICY_ADDRESS,
   UNIVERSAL_ACTION_POLICY_ADDRESS,
 } from '../../modules/validators/smart-sessions/policies/addresses'
+import {
+  addressToBytes32,
+  CCTP_LAYER_ID,
+  encodeCctpAdapterConfig,
+  intentExecutorPolicyEntry,
+} from '../../modules/validators/smart-sessions/policies/settlement-layer'
 import { experimental_defineSpendSession } from './spend-session'
 
 const OWNER = { type: 'ecdsa' as const, accounts: [accountA] }
 const USDC: Address = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
 const DAI: Address = '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb'
 const ARB_USDC: Address = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+const OP_USDC: Address = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'
 const RECIPIENT: Address = '0x1111111111111111111111111111111111111111'
 const RECIPIENT_2: Address = '0x2222222222222222222222222222222222222222'
 const ONCE: Address = '0x425Ca0bb0AFd6aba83c15676db11C039b17Dcc0c'
 // Prod Across 7579 arbiter (arbiters.ts). Bound as the claim policy spender.
 const ACROSS_ARBITER: Address = '0x28a4D41776968c1201A807ec51fFB405362B8882'
 
-// The action the builder scopes for a given token (skips the injected fallback /
-// intent-execution / native-wrap / dummy-preclaim actions).
-function tokenAction(session: ReturnType<typeof experimental_defineSpendSession>['session'], token: Address) {
+// Cross-chain target to arbitrum with the destination token wired.
+function arbTarget(settlementLayers?: ('SAME_CHAIN' | 'ECO' | 'ACROSS')[]) {
+  return {
+    chains: [arbitrum],
+    ...(settlementLayers ? { settlementLayers } : {}),
+    tokens: [{ chain: arbitrum, token: ARB_USDC }],
+  }
+}
+
+type Result = ReturnType<typeof experimental_defineSpendSession>
+
+function tokenAction(session: Result['session'], token: Address) {
   return getSessionData(session).actions.find((a) =>
     isAddressEqual(a.actionTarget, token),
   )
@@ -42,7 +52,8 @@ function hasPolicy(
   policy: Address,
 ): boolean {
   return (
-    action?.actionPolicies.some((p) => isAddressEqual(p.policy, policy)) ?? false
+    action?.actionPolicies.some((p) => isAddressEqual(p.policy, policy)) ??
+    false
   )
 }
 
@@ -51,7 +62,7 @@ describe('experimental_defineSpendSession — route selection', () => {
     const { route } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
-      spend: { tokens: [{ token: USDC }] },
+      spend: { tokens: [{ token: USDC, maxAmount: 1n }] },
     })
     expect(route).toBe('executor')
   })
@@ -60,10 +71,7 @@ describe('experimental_defineSpendSession — route selection', () => {
     const { route } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
-      spend: {
-        tokens: [{ token: USDC }],
-        target: { chains: [arbitrum] },
-      },
+      spend: { tokens: [{ token: USDC }], target: arbTarget() },
     })
     expect(route).toBe('permit2')
   })
@@ -72,19 +80,12 @@ describe('experimental_defineSpendSession — route selection', () => {
     const { route } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
-      spend: { tokens: [{ token: USDC }], target: { chains: [base] } },
+      spend: {
+        tokens: [{ token: USDC, maxAmount: 1n }],
+        target: { chains: [base], tokens: [{ chain: base, token: USDC }] },
+      },
     })
     expect(route).toBe('executor')
-  })
-
-  test('explicit route override wins', () => {
-    const { route } = experimental_defineSpendSession({
-      chain: base,
-      owners: OWNER,
-      spend: { tokens: [{ token: USDC }] },
-      route: 'permit2',
-    })
-    expect(route).toBe('permit2')
   })
 })
 
@@ -93,7 +94,10 @@ describe('experimental_defineSpendSession — same-chain scoping', () => {
     const { session } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
-      spend: { tokens: [{ token: USDC, maxAmount: 1n }], recipients: [RECIPIENT] },
+      spend: {
+        tokens: [{ token: USDC, maxAmount: 1n }],
+        recipients: [RECIPIENT],
+      },
     })
     expect(session.claimPolicies).toHaveLength(0)
   })
@@ -104,9 +108,9 @@ describe('experimental_defineSpendSession — same-chain scoping', () => {
       owners: OWNER,
       spend: { tokens: [{ token: USDC, maxAmount: 1_000_000n }] },
     })
-    expect(hasPolicy(tokenAction(session, USDC), SPENDING_LIMITS_POLICY_ADDRESS)).toBe(
-      true,
-    )
+    expect(
+      hasPolicy(tokenAction(session, USDC), SPENDING_LIMITS_POLICY_ADDRESS),
+    ).toBe(true)
   })
 
   test('single recipient → universal-action policy', () => {
@@ -142,9 +146,9 @@ describe('experimental_defineSpendSession — same-chain scoping', () => {
         validAfter: new Date('2025-01-01'),
       },
     })
-    expect(hasPolicy(tokenAction(session, USDC), TIME_FRAME_POLICY_ADDRESS)).toBe(
-      true,
-    )
+    expect(
+      hasPolicy(tokenAction(session, USDC), TIME_FRAME_POLICY_ADDRESS),
+    ).toBe(true)
   })
 
   test('multiple tokens → one scoped action each', () => {
@@ -161,6 +165,16 @@ describe('experimental_defineSpendSession — same-chain scoping', () => {
     expect(tokenAction(session, USDC)).toBeDefined()
     expect(tokenAction(session, DAI)).toBeDefined()
   })
+
+  test('a fully-unrestricted same-chain spend is refused', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: { tokens: [{ token: USDC }] },
+      }),
+    ).toThrow(/unrestricted same-chain spend/)
+  })
 })
 
 describe('experimental_defineSpendSession — cross-chain scoping', () => {
@@ -171,7 +185,7 @@ describe('experimental_defineSpendSession — cross-chain scoping', () => {
       spend: {
         tokens: [{ token: USDC, maxAmount: 1_000_000n }],
         recipients: [RECIPIENT],
-        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
+        target: arbTarget(['ACROSS']),
       },
     })
     expect(session.claimPolicies.length).toBeGreaterThan(0)
@@ -182,16 +196,13 @@ describe('experimental_defineSpendSession — cross-chain scoping', () => {
     const { session } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
-      spend: {
-        tokens: [{ token: USDC }],
-        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
-      },
+      spend: { tokens: [{ token: USDC }], target: arbTarget(['ACROSS']) },
     })
     const spenders = session.claimPolicies[0].spenders ?? []
     expect(spenders.some((s) => isAddressEqual(s, ACROSS_ARBITER))).toBe(true)
   })
 
-  test('multiple target chains are covered', () => {
+  test('multiple target chains each need their destination token', () => {
     const { route, session } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
@@ -200,11 +211,28 @@ describe('experimental_defineSpendSession — cross-chain scoping', () => {
         target: {
           chains: [arbitrum, optimism],
           settlementLayers: ['ACROSS'],
+          tokens: [
+            { chain: arbitrum, token: ARB_USDC },
+            { chain: optimism, token: OP_USDC },
+          ],
         },
       },
     })
     expect(route).toBe('permit2')
     expect(session.claimPolicies.length).toBeGreaterThan(0)
+  })
+
+  test('a cross-chain target missing a destination token is refused', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: {
+          tokens: [{ token: USDC }],
+          target: { chains: [arbitrum] } as any,
+        },
+      }),
+    ).toThrow(/destination token/)
   })
 })
 
@@ -231,7 +259,7 @@ describe('experimental_defineSpendSession — one-time-use', () => {
       spend: {
         tokens: [{ token: USDC }],
         recipients: [RECIPIENT],
-        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
+        target: arbTarget(['ACROSS']),
       },
       singleUse: { id: 9n },
       policyAddresses: { oneTimeUseId: ONCE },
@@ -254,7 +282,10 @@ describe('experimental_defineSpendSession — one-time-use', () => {
     })
     const burn = buildBurnOp()
     expect(isAddressEqual(burn.to, ONCE)).toBe(true)
-    const decoded = decodeFunctionData({ abi: oneTimeUseIdPolicyAbi, data: burn.data })
+    const decoded = decodeFunctionData({
+      abi: oneTimeUseIdPolicyAbi,
+      data: burn.data,
+    })
     expect(decoded.functionName).toBe('consume')
     expect(decoded.args).toEqual([42n])
   })
@@ -263,10 +294,7 @@ describe('experimental_defineSpendSession — one-time-use', () => {
     const { buildBurnOp, route } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
-      spend: {
-        tokens: [{ token: USDC }],
-        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
-      },
+      spend: { tokens: [{ token: USDC }], target: arbTarget(['ACROSS']) },
       singleUse: { id: 7n },
       policyAddresses: { oneTimeUseId: ONCE },
     })
@@ -278,25 +306,98 @@ describe('experimental_defineSpendSession — one-time-use', () => {
     expect(decoded.functionName).toBe('consumeFor')
     expect(decoded.args).toEqual([7n, 0n])
   })
+})
 
-  test('route override changes the burn op (executor id, permit2 shape)', () => {
-    const { buildBurnOp } = experimental_defineSpendSession({
+describe('experimental_defineSpendSession — settlement-layer policy', () => {
+  const IE: Address = '0x00000000005aD9ce1f5035FD62CA96CEf16AdAAF'
+  const POLICY: Address = '0x00000000000000000000000000000000000000AA'
+  const entry = () =>
+    intentExecutorPolicyEntry({
+      policy: POLICY,
+      base: { intentExecutor: IE },
+      layers: [
+        {
+          layerId: CCTP_LAYER_ID,
+          config: encodeCctpAdapterConfig({
+            tokenMessenger: '0xBd3fa81B58Ba92a82136038B25aDec7066af3155',
+            mintRecipients: [addressToBytes32(RECIPIENT)],
+            burnTokens: [USDC],
+          }),
+        },
+      ],
+    })
+
+  test('is installed on the 1271 list and replaces sudo', () => {
+    const { session } = experimental_defineSpendSession({
       chain: base,
       owners: OWNER,
-      spend: { tokens: [{ token: USDC }] },
-      route: 'permit2',
-      singleUse: { id: 5n },
-      policyAddresses: { oneTimeUseId: ONCE },
+      spend: { tokens: [{ token: USDC, maxAmount: 1n }] },
+      erc1271Policies: [entry()],
     })
-    const decoded = decodeFunctionData({
-      abi: oneTimeUseIdPolicyAbi,
-      data: buildBurnOp().data,
-    })
-    expect(decoded.functionName).toBe('consumeFor')
+    const list = getSessionData(session).erc7739Policies.erc1271Policies
+    expect(list.some((p) => isAddressEqual(p.policy, POLICY))).toBe(true)
+    expect(
+      list.some((p) => isAddressEqual(p.policy, SUDO_POLICY_ADDRESS)),
+    ).toBe(false)
+  })
+
+  test('is refused alongside a cross-chain arbiter target', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: { tokens: [{ token: USDC }], target: arbTarget(['ACROSS']) },
+        erc1271Policies: [entry()],
+      }),
+    ).toThrow(/mutually exclusive/)
   })
 })
 
-describe('experimental_defineSpendSession — validation & the old way', () => {
+describe('experimental_defineSpendSession — layer refusal & validation', () => {
+  test('an IntentExecutor layer not yet supported is refused', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: {
+          tokens: [{ token: USDC }],
+          target: { ...arbTarget(), settlementLayers: ['RHINO'] as never },
+        },
+      }),
+    ).toThrow(/not yet supported/)
+  })
+
+  test('an unsupported layer is refused even with a recipient set', () => {
+    // RELAY is availableToday:false, so it refuses on availability first.
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: {
+          tokens: [{ token: USDC }],
+          recipients: [RECIPIENT],
+          target: { ...arbTarget(), settlementLayers: ['RELAY'] as never },
+        },
+      }),
+    ).toThrow(/not yet supported/)
+  })
+
+  test('supported arbiter layers pass validation', () => {
+    for (const layer of ['SAME_CHAIN', 'ECO', 'ACROSS'] as const) {
+      expect(() =>
+        experimental_defineSpendSession({
+          chain: base,
+          owners: OWNER,
+          spend: {
+            tokens: [{ token: USDC, maxAmount: 1n }],
+            recipients: [RECIPIENT],
+            target: arbTarget([layer]),
+          },
+        }),
+      ).not.toThrow()
+    }
+  })
+
   test('singleUse without oneTimeUseId address throws', () => {
     expect(() =>
       experimental_defineSpendSession({
@@ -313,116 +414,19 @@ describe('experimental_defineSpendSession — validation & the old way', () => {
       experimental_defineSpendSession({
         chain: base,
         owners: OWNER,
-        // biome-ignore lint/suspicious/noExplicitAny: exercising the runtime guard
         spend: { tokens: [] as any },
       }),
     ).toThrow(/at least one token/)
   })
 
-  test('an IntentExecutor layer not yet supported is refused', () => {
+  test('empty recipients array throws (must omit or be non-empty)', () => {
     expect(() =>
       experimental_defineSpendSession({
         chain: base,
         owners: OWNER,
-        spend: {
-          tokens: [{ token: USDC }],
-          target: { chains: [arbitrum], settlementLayers: ['RHINO'] },
-        },
+        spend: { tokens: [{ token: USDC, maxAmount: 1n }], recipients: [] },
       }),
-    ).toThrow(/not yet supported/)
-  })
-
-  test('recipient restriction on a layer that cannot enforce it is refused', () => {
-    // RHINO has no on-chain recipient; even once available it cannot bind one.
-    // (Today it is refused earlier for availability, so assert on availability
-    // via a layer that WILL enforce recipient to keep this test about the arg.)
-    expect(() =>
-      experimental_defineSpendSession({
-        chain: base,
-        owners: OWNER,
-        spend: {
-          tokens: [{ token: USDC }],
-          recipients: [RECIPIENT],
-          target: { chains: [arbitrum], settlementLayers: ['RELAY'] },
-        },
-      }),
-    ).toThrow(/not yet supported|recipient/)
-  })
-
-  test('supported arbiter layers pass validation', () => {
-    for (const layer of ['SAME_CHAIN', 'ECO', 'ACROSS'] as const) {
-      expect(() =>
-        experimental_defineSpendSession({
-          chain: base,
-          owners: OWNER,
-          spend: {
-            tokens: [{ token: USDC, maxAmount: 1n }],
-            recipients: [RECIPIENT],
-            target: { chains: [arbitrum], settlementLayers: [layer] },
-          },
-        }),
-      ).not.toThrow()
-    }
-  })
-
-  test('a settlement-layer 1271 policy is installed and replaces sudo', () => {
-    const POLICY: Address = '0x00000000000000000000000000000000000000AA'
-    const IE: Address = '0x00000000005aD9ce1f5035FD62CA96CEf16AdAAF'
-    const entry = intentExecutorPolicyEntry({
-      policy: POLICY,
-      base: { intentExecutor: IE },
-      layers: [
-        {
-          layerId: CCTP_LAYER_ID,
-          config: encodeCctpAdapterConfig({
-            tokenMessenger: '0xBd3fa81B58Ba92a82136038B25aDec7066af3155',
-            mintRecipients: [addressToBytes32(RECIPIENT)],
-            burnTokens: [USDC],
-          }),
-        },
-      ],
-    })
-    const { session } = experimental_defineSpendSession({
-      chain: base,
-      owners: OWNER,
-      spend: { tokens: [{ token: USDC }] },
-      erc1271Policies: [entry],
-      policyAddresses: { intentExecutorPolicy: POLICY },
-    })
-    const list = getSessionData(session).erc7739Policies.erc1271Policies
-    expect(list.some((p) => isAddressEqual(p.policy, POLICY))).toBe(true)
-    // enforcing 1271 policy drops the default sudo entry
-    expect(list.some((p) => isAddressEqual(p.policy, SUDO_POLICY_ADDRESS))).toBe(
-      false,
-    )
-  })
-
-  test('settlement-layer policy is refused alongside a cross-chain arbiter target', () => {
-    const entry = intentExecutorPolicyEntry({
-      policy: '0x00000000000000000000000000000000000000AA',
-      base: { intentExecutor: '0x00000000005aD9ce1f5035FD62CA96CEf16AdAAF' },
-      layers: [
-        {
-          layerId: CCTP_LAYER_ID,
-          config: encodeCctpAdapterConfig({
-            tokenMessenger: '0xBd3fa81B58Ba92a82136038B25aDec7066af3155',
-            mintRecipients: [addressToBytes32(RECIPIENT)],
-            burnTokens: [USDC],
-          }),
-        },
-      ],
-    })
-    expect(() =>
-      experimental_defineSpendSession({
-        chain: base,
-        owners: OWNER,
-        spend: {
-          tokens: [{ token: USDC }],
-          target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
-        },
-        erc1271Policies: [entry],
-      }),
-    ).toThrow(/mutually exclusive/)
+    ).toThrow(/non-empty/)
   })
 
   test('the old way (no singleUse) still scopes but has no burn op', () => {

--- a/src/smart-sessions/experimental/spend-session.test.ts
+++ b/src/smart-sessions/experimental/spend-session.test.ts
@@ -312,6 +312,52 @@ describe('experimental_defineSpendSession — validation & the old way', () => {
     ).toThrow(/at least one token/)
   })
 
+  test('an IntentExecutor layer not yet supported is refused', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: {
+          tokens: [{ token: USDC }],
+          target: { chains: [arbitrum], settlementLayers: ['RHINO'] },
+        },
+      }),
+    ).toThrow(/not yet supported/)
+  })
+
+  test('recipient restriction on a layer that cannot enforce it is refused', () => {
+    // RHINO has no on-chain recipient; even once available it cannot bind one.
+    // (Today it is refused earlier for availability, so assert on availability
+    // via a layer that WILL enforce recipient to keep this test about the arg.)
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: {
+          tokens: [{ token: USDC }],
+          recipients: [RECIPIENT],
+          target: { chains: [arbitrum], settlementLayers: ['RELAY'] },
+        },
+      }),
+    ).toThrow(/not yet supported|recipient/)
+  })
+
+  test('supported arbiter layers pass validation', () => {
+    for (const layer of ['SAME_CHAIN', 'ECO', 'ACROSS'] as const) {
+      expect(() =>
+        experimental_defineSpendSession({
+          chain: base,
+          owners: OWNER,
+          spend: {
+            tokens: [{ token: USDC, maxAmount: 1n }],
+            recipients: [RECIPIENT],
+            target: { chains: [arbitrum], settlementLayers: [layer] },
+          },
+        }),
+      ).not.toThrow()
+    }
+  })
+
   test('the old way (no singleUse) still scopes but has no burn op', () => {
     const { session, buildBurnOp } = experimental_defineSpendSession({
       chain: base,

--- a/src/smart-sessions/experimental/spend-session.test.ts
+++ b/src/smart-sessions/experimental/spend-session.test.ts
@@ -1,0 +1,328 @@
+import { type Address, decodeFunctionData, isAddressEqual } from 'viem'
+import { arbitrum, base, optimism } from 'viem/chains'
+import { describe, expect, test } from 'vitest'
+import { accountA } from '../../../test/consts'
+import { getSessionData } from '../../modules/validators/smart-sessions/digest'
+import { oneTimeUseIdPolicyAbi } from '../../modules/validators/smart-sessions/one-time-use'
+import {
+  ARG_POLICY_ADDRESS,
+  SPENDING_LIMITS_POLICY_ADDRESS,
+  TIME_FRAME_POLICY_ADDRESS,
+  UNIVERSAL_ACTION_POLICY_ADDRESS,
+} from '../../modules/validators/smart-sessions/policies/addresses'
+import { experimental_defineSpendSession } from './spend-session'
+
+const OWNER = { type: 'ecdsa' as const, accounts: [accountA] }
+const USDC: Address = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const DAI: Address = '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb'
+const ARB_USDC: Address = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+const RECIPIENT: Address = '0x1111111111111111111111111111111111111111'
+const RECIPIENT_2: Address = '0x2222222222222222222222222222222222222222'
+const ONCE: Address = '0x425Ca0bb0AFd6aba83c15676db11C039b17Dcc0c'
+// Prod Across 7579 arbiter (arbiters.ts). Bound as the claim policy spender.
+const ACROSS_ARBITER: Address = '0x28a4D41776968c1201A807ec51fFB405362B8882'
+
+// The action the builder scopes for a given token (skips the injected fallback /
+// intent-execution / native-wrap / dummy-preclaim actions).
+function tokenAction(session: ReturnType<typeof experimental_defineSpendSession>['session'], token: Address) {
+  return getSessionData(session).actions.find((a) =>
+    isAddressEqual(a.actionTarget, token),
+  )
+}
+
+function hasPolicy(
+  action: { actionPolicies: readonly { policy: Address }[] } | undefined,
+  policy: Address,
+): boolean {
+  return (
+    action?.actionPolicies.some((p) => isAddressEqual(p.policy, policy)) ?? false
+  )
+}
+
+describe('experimental_defineSpendSession — route selection', () => {
+  test('no target → executor route', () => {
+    const { route } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }] },
+    })
+    expect(route).toBe('executor')
+  })
+
+  test('target on a different chain → permit2 route', () => {
+    const { route } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        target: { chains: [arbitrum] },
+      },
+    })
+    expect(route).toBe('permit2')
+  })
+
+  test('target listing only the session chain → executor route', () => {
+    const { route } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }], target: { chains: [base] } },
+    })
+    expect(route).toBe('executor')
+  })
+
+  test('explicit route override wins', () => {
+    const { route } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }] },
+      route: 'permit2',
+    })
+    expect(route).toBe('permit2')
+  })
+})
+
+describe('experimental_defineSpendSession — same-chain scoping', () => {
+  test('no claim policy on the executor route', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC, maxAmount: 1n }], recipients: [RECIPIENT] },
+    })
+    expect(session.claimPolicies).toHaveLength(0)
+  })
+
+  test('amount cap → spending-limits policy on the token action', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC, maxAmount: 1_000_000n }] },
+    })
+    expect(hasPolicy(tokenAction(session, USDC), SPENDING_LIMITS_POLICY_ADDRESS)).toBe(
+      true,
+    )
+  })
+
+  test('single recipient → universal-action policy', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }], recipients: [RECIPIENT] },
+    })
+    expect(
+      hasPolicy(tokenAction(session, USDC), UNIVERSAL_ACTION_POLICY_ADDRESS),
+    ).toBe(true)
+  })
+
+  test('multiple recipients → arg-policy (allowlist)', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        recipients: [RECIPIENT, RECIPIENT_2],
+      },
+    })
+    expect(hasPolicy(tokenAction(session, USDC), ARG_POLICY_ADDRESS)).toBe(true)
+  })
+
+  test('validUntil/validAfter → time-frame policy', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        validUntil: new Date('2030-01-01'),
+        validAfter: new Date('2025-01-01'),
+      },
+    })
+    expect(hasPolicy(tokenAction(session, USDC), TIME_FRAME_POLICY_ADDRESS)).toBe(
+      true,
+    )
+  })
+
+  test('multiple tokens → one scoped action each', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [
+          { token: USDC, maxAmount: 1n },
+          { token: DAI, maxAmount: 2n },
+        ],
+      },
+    })
+    expect(tokenAction(session, USDC)).toBeDefined()
+    expect(tokenAction(session, DAI)).toBeDefined()
+  })
+})
+
+describe('experimental_defineSpendSession — cross-chain scoping', () => {
+  test('permit2 claim policy is present and typed', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC, maxAmount: 1_000_000n }],
+        recipients: [RECIPIENT],
+        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
+      },
+    })
+    expect(session.claimPolicies.length).toBeGreaterThan(0)
+    expect(session.claimPolicies[0].type).toBe('permit2')
+  })
+
+  test('the settlement-layer arbiter is bound as the claim policy spender', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
+      },
+    })
+    const spenders = session.claimPolicies[0].spenders ?? []
+    expect(spenders.some((s) => isAddressEqual(s, ACROSS_ARBITER))).toBe(true)
+  })
+
+  test('multiple target chains are covered', () => {
+    const { route, session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        target: {
+          chains: [arbitrum, optimism],
+          settlementLayers: ['ACROSS'],
+        },
+      },
+    })
+    expect(route).toBe('permit2')
+    expect(session.claimPolicies.length).toBeGreaterThan(0)
+  })
+})
+
+describe('experimental_defineSpendSession — one-time-use', () => {
+  test('installs the once-policy on every action (executor)', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC, maxAmount: 1n }] },
+      singleUse: { id: 42n },
+      policyAddresses: { oneTimeUseId: ONCE },
+    })
+    const data = getSessionData(session)
+    expect(data.actions.length).toBeGreaterThan(0)
+    for (const action of data.actions) {
+      expect(hasPolicy(action, ONCE)).toBe(true)
+    }
+  })
+
+  test('installs the once-policy on the erc1271 list (permit2)', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        recipients: [RECIPIENT],
+        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
+      },
+      singleUse: { id: 9n },
+      policyAddresses: { oneTimeUseId: ONCE },
+    })
+    const data = getSessionData(session)
+    expect(
+      data.erc7739Policies.erc1271Policies.some((p) =>
+        isAddressEqual(p.policy, ONCE),
+      ),
+    ).toBe(true)
+  })
+
+  test('executor burn op is consume(id)', () => {
+    const { buildBurnOp } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }] },
+      singleUse: { id: 42n },
+      policyAddresses: { oneTimeUseId: ONCE },
+    })
+    const burn = buildBurnOp()
+    expect(isAddressEqual(burn.to, ONCE)).toBe(true)
+    const decoded = decodeFunctionData({ abi: oneTimeUseIdPolicyAbi, data: burn.data })
+    expect(decoded.functionName).toBe('consume')
+    expect(decoded.args).toEqual([42n])
+  })
+
+  test('permit2 burn op is consumeFor(id, 0) placeholder', () => {
+    const { buildBurnOp, route } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        target: { chains: [arbitrum], settlementLayers: ['ACROSS'] },
+      },
+      singleUse: { id: 7n },
+      policyAddresses: { oneTimeUseId: ONCE },
+    })
+    expect(route).toBe('permit2')
+    const decoded = decodeFunctionData({
+      abi: oneTimeUseIdPolicyAbi,
+      data: buildBurnOp().data,
+    })
+    expect(decoded.functionName).toBe('consumeFor')
+    expect(decoded.args).toEqual([7n, 0n])
+  })
+
+  test('route override changes the burn op (executor id, permit2 shape)', () => {
+    const { buildBurnOp } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }] },
+      route: 'permit2',
+      singleUse: { id: 5n },
+      policyAddresses: { oneTimeUseId: ONCE },
+    })
+    const decoded = decodeFunctionData({
+      abi: oneTimeUseIdPolicyAbi,
+      data: buildBurnOp().data,
+    })
+    expect(decoded.functionName).toBe('consumeFor')
+  })
+})
+
+describe('experimental_defineSpendSession — validation & the old way', () => {
+  test('singleUse without oneTimeUseId address throws', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: { tokens: [{ token: USDC }] },
+        singleUse: { id: 1n },
+      }),
+    ).toThrow(/oneTimeUseId/)
+  })
+
+  test('empty tokens throws', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        // biome-ignore lint/suspicious/noExplicitAny: exercising the runtime guard
+        spend: { tokens: [] as any },
+      }),
+    ).toThrow(/at least one token/)
+  })
+
+  test('the old way (no singleUse) still scopes but has no burn op', () => {
+    const { session, buildBurnOp } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC, maxAmount: 500n }],
+        recipients: [RECIPIENT],
+      },
+    })
+    expect(session.oneTimeUse).toBeFalsy()
+    expect(tokenAction(session, USDC)).toBeDefined()
+    expect(() => buildBurnOp()).toThrow(/singleUse/)
+  })
+})

--- a/src/smart-sessions/experimental/spend-session.test.ts
+++ b/src/smart-sessions/experimental/spend-session.test.ts
@@ -192,6 +192,35 @@ describe('experimental_defineSpendSession — cross-chain scoping', () => {
     expect(session.claimPolicies[0].type).toBe('permit2')
   })
 
+  // `hasExplicitPermissions` is what keeps an ENABLED session in
+  // verify-execution mode. A cross-chain `maxAmount` becomes a spending-limit
+  // on the action surface and has no counterpart on the claim policy (unlike
+  // the deadline, which the claim policy carries), so with the flag false the
+  // cap this helper advertises stops being enforced from the second use on.
+  test('a cross-chain amount cap keeps the session in verify-execution mode', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC, maxAmount: 1_000_000n }],
+        recipients: [RECIPIENT],
+        target: arbTarget(['ACROSS']),
+      },
+    })
+    expect(session.hasExplicitPermissions).toBe(true)
+  })
+
+  test('a cross-chain spend with nothing to enforce on-chain does not', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: { tokens: [{ token: USDC }], target: arbTarget(['ACROSS']) },
+    })
+    // No amount cap and no window, so the claim policy is the whole story and
+    // there is no action policy that mode 1 would skip.
+    expect(session.hasExplicitPermissions).toBe(false)
+  })
+
   test('the settlement-layer arbiter is bound as the claim policy spender', () => {
     const { session } = experimental_defineSpendSession({
       chain: base,

--- a/src/smart-sessions/experimental/spend-session.test.ts
+++ b/src/smart-sessions/experimental/spend-session.test.ts
@@ -429,6 +429,23 @@ describe('experimental_defineSpendSession — layer refusal & validation', () =>
     ).toThrow(/non-empty/)
   })
 
+  // An empty chains array read as "same-chain", which silently ignored the
+  // rest of `target` — the destination tokens and the settlement layers with
+  // it. Say so instead of building a session the caller did not describe.
+  test('empty target.chains throws (must omit target for same-chain)', () => {
+    expect(() =>
+      experimental_defineSpendSession({
+        chain: base,
+        owners: OWNER,
+        spend: {
+          tokens: [{ token: USDC, maxAmount: 1n }],
+          recipients: [RECIPIENT],
+          target: { chains: [], tokens: [{ chain: base, token: USDC }] },
+        },
+      }),
+    ).toThrow(/target.chains must be non-empty/)
+  })
+
   test('the old way (no singleUse) still scopes but has no burn op', () => {
     const { session, buildBurnOp } = experimental_defineSpendSession({
       chain: base,

--- a/src/smart-sessions/experimental/spend-session.test.ts
+++ b/src/smart-sessions/experimental/spend-session.test.ts
@@ -210,6 +210,22 @@ describe('experimental_defineSpendSession — cross-chain scoping', () => {
     expect(session.hasExplicitPermissions).toBe(true)
   })
 
+  // The deadline is already enforced via the claim policy's `permitDeadline`,
+  // so it must not flip an already-enabled session into verify-execution mode.
+  test('a cross-chain window alone does not force verify-execution mode', () => {
+    const { session } = experimental_defineSpendSession({
+      chain: base,
+      owners: OWNER,
+      spend: {
+        tokens: [{ token: USDC }],
+        recipients: [RECIPIENT],
+        validUntil: new Date(Date.now() + 86_400_000),
+        target: arbTarget(['ACROSS']),
+      },
+    })
+    expect(session.hasExplicitPermissions).toBe(false)
+  })
+
   test('a cross-chain spend with nothing to enforce on-chain does not', () => {
     const { session } = experimental_defineSpendSession({
       chain: base,

--- a/src/smart-sessions/experimental/spend-session.ts
+++ b/src/smart-sessions/experimental/spend-session.ts
@@ -9,6 +9,7 @@ import type {
   CrossChainPermissionInput,
   CrossChainSettlementLayer,
   Permission,
+  ResolvedPolicy,
   Session,
   SessionDefinition,
   SessionPolicyAddresses,
@@ -176,6 +177,13 @@ export interface DefineSpendSessionInput {
   // Override the auto-selected route (executor for same-chain, permit2 for
   // cross-chain). Rarely needed.
   readonly route?: OneTimeUseSettlementRoute
+  // Pre-encoded ERC-1271 policy entries to install on the session (e.g. an
+  // IntentExecutor settlement-layer policy — see intentExecutorPolicyEntry). This
+  // is the escape hatch for scoping the IntentExecutor-backed layers until the
+  // builder can auto-derive their per-layer configs. Mutually exclusive with the
+  // Permit2 claim policy (arbiter route), so it cannot be combined with a
+  // cross-chain arbiter `target`.
+  readonly erc1271Policies?: ResolvedPolicy[]
   readonly policyAddresses?: SessionPolicyAddresses
   readonly useDevContracts?: boolean
 }
@@ -274,6 +282,16 @@ export function experimental_defineSpendSession(
   const crossChain = isCrossChain(input)
   const route = input.route ?? (crossChain ? 'permit2' : 'executor')
 
+  // A settlement-layer 1271 policy and the Permit2 claim policy both live on the
+  // 1271 AND-list and gate different routes, so they are mutually exclusive.
+  const hasErc1271 = (input.erc1271Policies?.length ?? 0) > 0
+  if (hasErc1271 && crossChain) {
+    throw new Error(
+      'erc1271Policies (settlement-layer policy) is mutually exclusive with a ' +
+        'cross-chain arbiter target (Permit2 claim policy); use one route.',
+    )
+  }
+
   const definition: SessionDefinition = {
     chain: input.chain,
     owners: input.owners,
@@ -282,6 +300,7 @@ export function experimental_defineSpendSession(
       ? { crossChainPermits: [crossChainPermit(input)] }
       : { permissions: sameChainPermissions(input) }),
     ...(input.singleUse ? { oneTimeUse: { id: input.singleUse.id } } : {}),
+    ...(hasErc1271 ? { erc1271Policies: input.erc1271Policies } : {}),
   }
 
   const session = resolveSession(definition, {

--- a/src/smart-sessions/experimental/spend-session.ts
+++ b/src/smart-sessions/experimental/spend-session.ts
@@ -68,10 +68,24 @@ const ARBITER_ENFORCEABLE = {
 // Per-layer scoping capability. Enforceable flags for the adapter layers mirror
 // what each layer's on-chain calldata exposes (e.g. Rhino carries no on-chain
 // recipient; Relay's calldata is opaque) — see RHI-6242.
-export const LAYER_CAPABILITIES: Record<SpendSettlementLayer, LayerCapability> = {
-  SAME_CHAIN: { surface: 'claim-policy', enforceable: ARBITER_ENFORCEABLE, availableToday: true },
-  ECO: { surface: 'claim-policy', enforceable: ARBITER_ENFORCEABLE, availableToday: true },
-  ACROSS: { surface: 'claim-policy', enforceable: ARBITER_ENFORCEABLE, availableToday: true },
+export const LAYER_CAPABILITIES: Readonly<
+  Record<SpendSettlementLayer, LayerCapability>
+> = Object.freeze({
+  SAME_CHAIN: {
+    surface: 'claim-policy',
+    enforceable: ARBITER_ENFORCEABLE,
+    availableToday: true,
+  },
+  ECO: {
+    surface: 'claim-policy',
+    enforceable: ARBITER_ENFORCEABLE,
+    availableToday: true,
+  },
+  ACROSS: {
+    surface: 'claim-policy',
+    enforceable: ARBITER_ENFORCEABLE,
+    availableToday: true,
+  },
   CCTP: {
     surface: 'intent-executor-adapter',
     enforceable: { recipient: true, amount: true, token: true, chain: true },
@@ -89,7 +103,12 @@ export const LAYER_CAPABILITIES: Record<SpendSettlementLayer, LayerCapability> =
   },
   RELAY: {
     surface: 'intent-executor-adapter',
-    enforceable: { recipient: false, amount: false, token: false, chain: false },
+    enforceable: {
+      recipient: false,
+      amount: false,
+      token: false,
+      chain: false,
+    },
     availableToday: false,
   },
   NEAR: {
@@ -97,7 +116,7 @@ export const LAYER_CAPABILITIES: Record<SpendSettlementLayer, LayerCapability> =
     enforceable: { recipient: false, amount: true, token: true, chain: false },
     availableToday: false,
   },
-}
+})
 
 const ARBITER_LAYERS: readonly SpendSettlementLayer[] = [
   'SAME_CHAIN',
@@ -112,6 +131,7 @@ function assertLayersEnforceable(input: DefineSpendSessionInput): void {
   if (!layers || layers.length === 0) return
   const wantsRecipient = (input.spend.recipients?.length ?? 0) > 0
   const wantsAmount = input.spend.tokens.some((t) => t.maxAmount !== undefined)
+  const wantsChain = (input.spend.target?.chains.length ?? 0) > 0
   for (const layer of layers) {
     const cap = LAYER_CAPABILITIES[layer]
     if (!cap.availableToday) {
@@ -121,6 +141,9 @@ function assertLayersEnforceable(input: DefineSpendSessionInput): void {
           `Supported today: ${ARBITER_LAYERS.join(', ')}.`,
       )
     }
+    // Field-enforceability refusals. Every adapter layer is availableToday:false
+    // today, so these are reached only once a layer is flipped on — they keep the
+    // builder from emitting a field-restricted-looking but unrestricted session.
     if (wantsRecipient && !cap.enforceable.recipient) {
       throw new Error(
         `Settlement layer "${layer}" cannot enforce a recipient restriction; ` +
@@ -131,6 +154,12 @@ function assertLayersEnforceable(input: DefineSpendSessionInput): void {
       throw new Error(
         `Settlement layer "${layer}" cannot enforce an amount cap; ` +
           `remove maxAmount or drop "${layer}".`,
+      )
+    }
+    if (wantsChain && !cap.enforceable.chain) {
+      throw new Error(
+        `Settlement layer "${layer}" cannot enforce a target-chain restriction; ` +
+          `drop "${layer}".`,
       )
     }
   }
@@ -150,15 +179,16 @@ export interface SpendTarget {
   // supported layers. Layers not enforceable today are refused (see
   // LAYER_CAPABILITIES).
   readonly settlementLayers?: SpendSettlementLayer[]
-  // Destination-chain token addresses, when they differ from the source token.
-  // Defaults to reusing the source token address on each target chain.
-  readonly tokens?: { readonly chain: Chain; readonly token: Address }[]
+  // Destination-chain token address for each target chain. Required for every
+  // target chain — token addresses differ per chain, so there is no safe default.
+  readonly tokens: { readonly chain: Chain; readonly token: Address }[]
 }
 
 export interface SpendIntent {
   readonly tokens: [SpendToken, ...SpendToken[]]
-  // Addresses the funds may be sent to. Omit to bind the recipient to the
-  // account itself.
+  // Addresses the funds may be sent to. Same-chain: omit to allow ANY recipient
+  // (pair with maxAmount or singleUse to bound the spend). Cross-chain: omit to
+  // bind the recipient to the account. Must be non-empty when provided.
   readonly recipients?: Address[]
   // Omit for a same-chain spend.
   readonly target?: SpendTarget
@@ -174,9 +204,6 @@ export interface DefineSpendSessionInput {
   // `buildBurnOp()` yields the burn op to inject into the intent's source calls.
   // Requires `policyAddresses.oneTimeUseId`.
   readonly singleUse?: { readonly id: bigint }
-  // Override the auto-selected route (executor for same-chain, permit2 for
-  // cross-chain). Rarely needed.
-  readonly route?: OneTimeUseSettlementRoute
   // Pre-encoded ERC-1271 policy entries to install on the session (e.g. an
   // IntentExecutor settlement-layer policy — see intentExecutorPolicyEntry). This
   // is the escape hatch for scoping the IntentExecutor-backed layers until the
@@ -197,9 +224,8 @@ export interface SpendSession {
 }
 
 function isCrossChain(input: DefineSpendSessionInput): boolean {
-  const target = input.spend.target
   return (
-    target !== undefined && target.chains.some((c) => c.id !== input.chain.id)
+    input.spend.target?.chains.some((c) => c.id !== input.chain.id) ?? false
   )
 }
 
@@ -211,9 +237,17 @@ function crossChainPermit(
 ): CrossChainPermissionInput {
   const { chain, spend } = input
   const target = spend.target as SpendTarget
-  const destTokenFor = (c: Chain, sourceToken: Address): Address =>
-    target.tokens?.find((t) => t.chain.id === c.id)?.token ?? sourceToken
-  const recipients = spend.recipients ?? [undefined]
+  const destTokenFor = (c: Chain): Address => {
+    const entry = target.tokens?.find((t) => t.chain.id === c.id)
+    if (!entry) {
+      throw new Error(
+        `cross-chain spend needs a destination token for chain ${c.id} ` +
+          `(target.tokens) — token addresses differ per chain`,
+      )
+    }
+    return entry.token
+  }
+  const recipients: (Address | undefined)[] = spend.recipients ?? [undefined]
   return {
     from: spend.tokens.map((t) => ({
       chain,
@@ -221,13 +255,11 @@ function crossChainPermit(
       maxAmount: t.maxAmount,
     })),
     to: target.chains.flatMap((c) =>
-      spend.tokens.flatMap((t) =>
-        recipients.map((recipient) => ({
-          chain: c,
-          token: destTokenFor(c, t.token),
-          ...(recipient ? { recipient } : {}),
-        })),
-      ),
+      recipients.map((recipient) => ({
+        chain: c,
+        token: destTokenFor(c),
+        ...(recipient ? { recipient } : {}),
+      })),
     ),
     // Only arbiter layers reach here — assertLayersEnforceable refuses the rest.
     settlementLayers: target.settlementLayers as
@@ -256,7 +288,9 @@ function sameChainPermissions(input: DefineSpendSessionInput): Permission[] {
     address: t.token,
     functions: {
       transfer: {
-        ...(recipientConstraint ? { params: { recipient: recipientConstraint } } : {}),
+        ...(recipientConstraint
+          ? { params: { recipient: recipientConstraint } }
+          : {}),
         ...(t.maxAmount !== undefined
           ? { spendingLimit: { token: t.token, amount: t.maxAmount } }
           : {}),
@@ -278,9 +312,34 @@ export function experimental_defineSpendSession(
       'spend session with singleUse requires policyAddresses.oneTimeUseId',
     )
   }
+  if (input.spend.recipients?.length === 0) {
+    throw new Error(
+      'spend.recipients must be non-empty; omit it to allow any recipient ' +
+        '(same-chain) or bind to the account (cross-chain)',
+    )
+  }
   assertLayersEnforceable(input)
   const crossChain = isCrossChain(input)
-  const route = input.route ?? (crossChain ? 'permit2' : 'executor')
+  const route: OneTimeUseSettlementRoute = crossChain ? 'permit2' : 'executor'
+
+  // A same-chain spend with no restriction at all resolves to a sudo transfer
+  // action (any recipient, any amount) — never emit that silently. Require at
+  // least one bound: a recipient allowlist, an amount cap, a time window, or the
+  // single-use burn.
+  if (!crossChain) {
+    const bounded =
+      (input.spend.recipients?.length ?? 0) > 0 ||
+      input.spend.tokens.some((t) => t.maxAmount !== undefined) ||
+      input.spend.validUntil !== undefined ||
+      input.spend.validAfter !== undefined ||
+      input.singleUse !== undefined
+    if (!bounded) {
+      throw new Error(
+        'unrestricted same-chain spend: provide recipients, a token maxAmount, ' +
+          'validUntil/validAfter, or singleUse',
+      )
+    }
+  }
 
   // A settlement-layer 1271 policy and the Permit2 claim policy both live on the
   // 1271 AND-list and gate different routes, so they are mutually exclusive.

--- a/src/smart-sessions/experimental/spend-session.ts
+++ b/src/smart-sessions/experimental/spend-session.ts
@@ -26,6 +26,115 @@ import type { OwnerSet } from '../../modules/validators/types'
 // `singleUse` selects the new Quorum-signer one-time-use method; omitting it is
 // the "old way" (explicit policy config, no burn op).
 
+// The settlement layers a spend may target. The three arbiter-based layers are
+// enforceable today via the Permit2 claim policy; the IntentExecutor-backed
+// layers need the settlement-layer adapter policy (smart-sessions-v2 #46) to
+// scope per-session, so they are declared here but refused until that lands.
+export type SpendSettlementLayer =
+  | 'SAME_CHAIN'
+  | 'ECO'
+  | 'ACROSS'
+  | 'RHINO'
+  | 'RELAY'
+  | 'CCTP'
+  | 'NEAR'
+  | 'OFT'
+
+export interface LayerCapability {
+  // How the layer is scoped: the Permit2 claim policy (arbiter route) or the
+  // per-layer IntentExecutor adapter ACL (adapter route).
+  readonly surface: 'claim-policy' | 'intent-executor-adapter'
+  // Which spend fields the layer can actually enforce. A `false` here means a
+  // restriction on that field would be fiction — the builder refuses it.
+  readonly enforceable: {
+    readonly recipient: boolean
+    readonly amount: boolean
+    readonly token: boolean
+    readonly chain: boolean
+  }
+  // False until the IntentExecutor settlement-layer policy family is deployed and
+  // the SDK exposes an ERC-1271-policy input. Arbiter layers are true today.
+  readonly availableToday: boolean
+}
+
+const ARBITER_ENFORCEABLE = {
+  recipient: true,
+  amount: true,
+  token: true,
+  chain: true,
+} as const
+
+// Per-layer scoping capability. Enforceable flags for the adapter layers mirror
+// what each layer's on-chain calldata exposes (e.g. Rhino carries no on-chain
+// recipient; Relay's calldata is opaque) — see RHI-6242.
+export const LAYER_CAPABILITIES: Record<SpendSettlementLayer, LayerCapability> = {
+  SAME_CHAIN: { surface: 'claim-policy', enforceable: ARBITER_ENFORCEABLE, availableToday: true },
+  ECO: { surface: 'claim-policy', enforceable: ARBITER_ENFORCEABLE, availableToday: true },
+  ACROSS: { surface: 'claim-policy', enforceable: ARBITER_ENFORCEABLE, availableToday: true },
+  CCTP: {
+    surface: 'intent-executor-adapter',
+    enforceable: { recipient: true, amount: true, token: true, chain: true },
+    availableToday: false,
+  },
+  RHINO: {
+    surface: 'intent-executor-adapter',
+    enforceable: { recipient: false, amount: true, token: true, chain: false },
+    availableToday: false,
+  },
+  OFT: {
+    surface: 'intent-executor-adapter',
+    enforceable: { recipient: true, amount: true, token: true, chain: true },
+    availableToday: false,
+  },
+  RELAY: {
+    surface: 'intent-executor-adapter',
+    enforceable: { recipient: false, amount: false, token: false, chain: false },
+    availableToday: false,
+  },
+  NEAR: {
+    surface: 'intent-executor-adapter',
+    enforceable: { recipient: false, amount: true, token: true, chain: false },
+    availableToday: false,
+  },
+}
+
+const ARBITER_LAYERS: readonly SpendSettlementLayer[] = [
+  'SAME_CHAIN',
+  'ECO',
+  'ACROSS',
+]
+
+// Refuses any requested settlement layer the builder cannot honestly enforce,
+// rather than emitting a restricted-looking-but-unrestricted session.
+function assertLayersEnforceable(input: DefineSpendSessionInput): void {
+  const layers = input.spend.target?.settlementLayers
+  if (!layers || layers.length === 0) return
+  const wantsRecipient = (input.spend.recipients?.length ?? 0) > 0
+  const wantsAmount = input.spend.tokens.some((t) => t.maxAmount !== undefined)
+  for (const layer of layers) {
+    const cap = LAYER_CAPABILITIES[layer]
+    if (!cap.availableToday) {
+      throw new Error(
+        `Settlement layer "${layer}" is not yet supported by defineSpendSession ` +
+          `(needs the IntentExecutor settlement-layer policy; see RHI-6242). ` +
+          `Supported today: ${ARBITER_LAYERS.join(', ')}.`,
+      )
+    }
+    if (wantsRecipient && !cap.enforceable.recipient) {
+      throw new Error(
+        `Settlement layer "${layer}" cannot enforce a recipient restriction; ` +
+          `remove recipients or drop "${layer}".`,
+      )
+    }
+    if (wantsAmount && !cap.enforceable.amount) {
+      throw new Error(
+        `Settlement layer "${layer}" cannot enforce an amount cap; ` +
+          `remove maxAmount or drop "${layer}".`,
+      )
+    }
+  }
+}
+
 export interface SpendToken {
   readonly token: Address
   // Upper bound on the amount this session may move for this token. Omit for no cap.
@@ -37,8 +146,9 @@ export interface SpendTarget {
   // cross-chain spend (Permit2 route); omit `target` entirely for same-chain.
   readonly chains: Chain[]
   // Which settlement layers may fill the cross-chain send. Omit to allow all
-  // supported layers.
-  readonly settlementLayers?: CrossChainSettlementLayer[]
+  // supported layers. Layers not enforceable today are refused (see
+  // LAYER_CAPABILITIES).
+  readonly settlementLayers?: SpendSettlementLayer[]
   // Destination-chain token addresses, when they differ from the source token.
   // Defaults to reusing the source token address on each target chain.
   readonly tokens?: { readonly chain: Chain; readonly token: Address }[]
@@ -111,7 +221,10 @@ function crossChainPermit(
         })),
       ),
     ),
-    settlementLayers: target.settlementLayers,
+    // Only arbiter layers reach here — assertLayersEnforceable refuses the rest.
+    settlementLayers: target.settlementLayers as
+      | CrossChainSettlementLayer[]
+      | undefined,
     validUntil: spend.validUntil,
     validAfter: spend.validAfter,
     allowRecipientNotAccount: spend.recipients !== undefined,
@@ -157,6 +270,7 @@ export function experimental_defineSpendSession(
       'spend session with singleUse requires policyAddresses.oneTimeUseId',
     )
   }
+  assertLayersEnforceable(input)
   const crossChain = isCrossChain(input)
   const route = input.route ?? (crossChain ? 'permit2' : 'executor')
 

--- a/src/smart-sessions/experimental/spend-session.ts
+++ b/src/smart-sessions/experimental/spend-session.ts
@@ -1,0 +1,190 @@
+import { type Address, type Chain, erc20Abi } from 'viem'
+import {
+  buildOneTimeUseBurnOp,
+  type OneTimeUseBurnOp,
+  type OneTimeUseSettlementRoute,
+} from '../../modules/validators/smart-sessions/one-time-use'
+import { toSession as resolveSession } from '../../modules/validators/smart-sessions/resolve'
+import type {
+  CrossChainPermissionInput,
+  CrossChainSettlementLayer,
+  Permission,
+  Session,
+  SessionDefinition,
+  SessionPolicyAddresses,
+} from '../../modules/validators/smart-sessions/types'
+import type { OwnerSet } from '../../modules/validators/types'
+
+// RHI-6242 (experimental): declare a spend in business terms — tokens, amounts,
+// recipients, target chains — and let the SDK formulate the session-policy
+// combination for the appropriate settlement route, instead of hand-wiring
+// arbiter policies. Covers the two scoped use cases:
+//   - same-chain send  → IntentExecutor (executor) route: universal-action
+//     scoping (recipient allowlist + amount cap) + optional one-time-use.
+//   - cross-chain send → Permit2 route: a claim policy bound to the settlement
+//     layer's arbiter (recipient/token/amount scoping) + optional one-time-use.
+// `singleUse` selects the new Quorum-signer one-time-use method; omitting it is
+// the "old way" (explicit policy config, no burn op).
+
+export interface SpendToken {
+  readonly token: Address
+  // Upper bound on the amount this session may move for this token. Omit for no cap.
+  readonly maxAmount?: bigint
+}
+
+export interface SpendTarget {
+  // Destination chains. Any chain other than the session chain makes this a
+  // cross-chain spend (Permit2 route); omit `target` entirely for same-chain.
+  readonly chains: Chain[]
+  // Which settlement layers may fill the cross-chain send. Omit to allow all
+  // supported layers.
+  readonly settlementLayers?: CrossChainSettlementLayer[]
+  // Destination-chain token addresses, when they differ from the source token.
+  // Defaults to reusing the source token address on each target chain.
+  readonly tokens?: { readonly chain: Chain; readonly token: Address }[]
+}
+
+export interface SpendIntent {
+  readonly tokens: [SpendToken, ...SpendToken[]]
+  // Addresses the funds may be sent to. Omit to bind the recipient to the
+  // account itself.
+  readonly recipients?: Address[]
+  // Omit for a same-chain spend.
+  readonly target?: SpendTarget
+  readonly validUntil?: Date
+  readonly validAfter?: Date
+}
+
+export interface DefineSpendSessionInput {
+  readonly chain: Chain
+  readonly owners: OwnerSet
+  readonly spend: SpendIntent
+  // Pins a one-time-use id: the session settles at most once per chain, and
+  // `buildBurnOp()` yields the burn op to inject into the intent's source calls.
+  // Requires `policyAddresses.oneTimeUseId`.
+  readonly singleUse?: { readonly id: bigint }
+  // Override the auto-selected route (executor for same-chain, permit2 for
+  // cross-chain). Rarely needed.
+  readonly route?: OneTimeUseSettlementRoute
+  readonly policyAddresses?: SessionPolicyAddresses
+  readonly useDevContracts?: boolean
+}
+
+export interface SpendSession {
+  readonly session: Session
+  readonly route: OneTimeUseSettlementRoute
+  // The one-time-use burn op to place in the intent's source calls. Throws when
+  // the session was not created with `singleUse`.
+  readonly buildBurnOp: () => OneTimeUseBurnOp
+}
+
+function isCrossChain(input: DefineSpendSessionInput): boolean {
+  const target = input.spend.target
+  return (
+    target !== undefined && target.chains.some((c) => c.id !== input.chain.id)
+  )
+}
+
+// Maps the spend intent onto the existing cross-chain permit expansion, which
+// already selects the settlement-layer arbiter and derives the claim policy plus
+// spending-limit/time-frame guardrails.
+function crossChainPermit(
+  input: DefineSpendSessionInput,
+): CrossChainPermissionInput {
+  const { chain, spend } = input
+  const target = spend.target as SpendTarget
+  const destTokenFor = (c: Chain, sourceToken: Address): Address =>
+    target.tokens?.find((t) => t.chain.id === c.id)?.token ?? sourceToken
+  const recipients = spend.recipients ?? [undefined]
+  return {
+    from: spend.tokens.map((t) => ({
+      chain,
+      token: t.token,
+      maxAmount: t.maxAmount,
+    })),
+    to: target.chains.flatMap((c) =>
+      spend.tokens.flatMap((t) =>
+        recipients.map((recipient) => ({
+          chain: c,
+          token: destTokenFor(c, t.token),
+          ...(recipient ? { recipient } : {}),
+        })),
+      ),
+    ),
+    settlementLayers: target.settlementLayers,
+    validUntil: spend.validUntil,
+    validAfter: spend.validAfter,
+    allowRecipientNotAccount: spend.recipients !== undefined,
+  }
+}
+
+// Same-chain scoping: one universal-action permission per token restricting the
+// ERC-20 `transfer` to the allowed recipients and amount. This is the "standard
+// action policy" enforced on the executor route via checkAction.
+function sameChainPermissions(input: DefineSpendSessionInput): Permission[] {
+  const { spend } = input
+  const recipients = spend.recipients
+  const recipientConstraint =
+    recipients === undefined
+      ? undefined
+      : recipients.length === 1
+        ? { condition: 'equal' as const, value: recipients[0] }
+        : { anyOf: recipients as [Address, ...Address[]] }
+  return spend.tokens.map((t) => ({
+    abi: erc20Abi,
+    address: t.token,
+    functions: {
+      transfer: {
+        ...(recipientConstraint ? { params: { recipient: recipientConstraint } } : {}),
+        ...(t.maxAmount !== undefined
+          ? { spendingLimit: { token: t.token, amount: t.maxAmount } }
+          : {}),
+        ...(spend.validUntil ? { validUntil: spend.validUntil } : {}),
+        ...(spend.validAfter ? { validAfter: spend.validAfter } : {}),
+      },
+    },
+  })) as Permission[]
+}
+
+export function experimental_defineSpendSession(
+  input: DefineSpendSessionInput,
+): SpendSession {
+  if (input.spend.tokens.length === 0) {
+    throw new Error('spend session requires at least one token')
+  }
+  if (input.singleUse && !input.policyAddresses?.oneTimeUseId) {
+    throw new Error(
+      'spend session with singleUse requires policyAddresses.oneTimeUseId',
+    )
+  }
+  const crossChain = isCrossChain(input)
+  const route = input.route ?? (crossChain ? 'permit2' : 'executor')
+
+  const definition: SessionDefinition = {
+    chain: input.chain,
+    owners: input.owners,
+    policyAddresses: input.policyAddresses,
+    ...(crossChain
+      ? { crossChainPermits: [crossChainPermit(input)] }
+      : { permissions: sameChainPermissions(input) }),
+    ...(input.singleUse ? { oneTimeUse: { id: input.singleUse.id } } : {}),
+  }
+
+  const session = resolveSession(definition, {
+    environment: input.useDevContracts ? 'development' : 'production',
+  }) as Session
+
+  return {
+    session,
+    route,
+    buildBurnOp: () => {
+      const policy = input.policyAddresses?.oneTimeUseId
+      if (!input.singleUse || !policy) {
+        throw new Error(
+          'buildBurnOp is only available for a singleUse spend session',
+        )
+      }
+      return buildOneTimeUseBurnOp({ policy, id: input.singleUse.id, route })
+    },
+  }
+}

--- a/src/smart-sessions/experimental/spend-session.ts
+++ b/src/smart-sessions/experimental/spend-session.ts
@@ -136,7 +136,8 @@ function assertLayersEnforceable(input: DefineSpendSessionInput): void {
     const cap = LAYER_CAPABILITIES[layer]
     if (!cap.availableToday) {
       throw new Error(
-        `Settlement layer "${layer}" is not yet supported by defineSpendSession ` +
+        `Settlement layer "${layer}" is not yet supported by ` +
+          `experimental_defineSpendSession ` +
           `(needs the IntentExecutor settlement-layer policy; see RHI-6242). ` +
           `Supported today: ${ARBITER_LAYERS.join(', ')}.`,
       )
@@ -316,6 +317,12 @@ export function experimental_defineSpendSession(
     throw new Error(
       'spend.recipients must be non-empty; omit it to allow any recipient ' +
         '(same-chain) or bind to the account (cross-chain)',
+    )
+  }
+  if (input.spend.target && input.spend.target.chains.length === 0) {
+    throw new Error(
+      'spend.target.chains must be non-empty; omit target entirely for a ' +
+        'same-chain spend',
     )
   }
   assertLayersEnforceable(input)

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -18,6 +18,15 @@ import {
   SMART_SESSION_EMISSARY_ADDRESS,
   SMART_SESSION_EMISSARY_ADDRESS_DEV,
 } from '../modules/validators/smart-sessions/module'
+import type {
+  OneTimeUseBurnOp,
+  OneTimeUseSettlementRoute,
+} from '../modules/validators/smart-sessions/one-time-use'
+import {
+  buildOneTimeUseBurnOp,
+  encodeOneTimeUseIdInitData,
+  oneTimeUseIdErc1271Policy,
+} from '../modules/validators/smart-sessions/one-time-use'
 import {
   ARG_POLICY_ADDRESS,
   INTENT_EXECUTION_POLICY_ADDRESS,
@@ -116,5 +125,13 @@ export {
   USAGE_LIMIT_POLICY_ADDRESS,
   VALUE_LIMIT_POLICY_ADDRESS,
   INTENT_EXECUTION_POLICY_ADDRESS,
+  buildOneTimeUseBurnOp,
+  encodeOneTimeUseIdInitData,
+  oneTimeUseIdErc1271Policy,
 }
-export type { ChainDigest, SessionDetails }
+export type {
+  ChainDigest,
+  SessionDetails,
+  OneTimeUseSettlementRoute,
+  OneTimeUseBurnOp,
+}

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -129,9 +129,17 @@ export {
   encodeOneTimeUseIdInitData,
   oneTimeUseIdErc1271Policy,
 }
+export { experimental_defineSpendSession } from './experimental/spend-session'
 export type {
   ChainDigest,
   SessionDetails,
   OneTimeUseSettlementRoute,
   OneTimeUseBurnOp,
 }
+export type {
+  DefineSpendSessionInput,
+  SpendIntent,
+  SpendSession,
+  SpendTarget,
+  SpendToken,
+} from './experimental/spend-session'

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -129,7 +129,10 @@ export {
   encodeOneTimeUseIdInitData,
   oneTimeUseIdErc1271Policy,
 }
-export { experimental_defineSpendSession } from './experimental/spend-session'
+export {
+  experimental_defineSpendSession,
+  LAYER_CAPABILITIES,
+} from './experimental/spend-session'
 export type {
   ChainDigest,
   SessionDetails,
@@ -138,8 +141,10 @@ export type {
 }
 export type {
   DefineSpendSessionInput,
+  LayerCapability,
   SpendIntent,
   SpendSession,
+  SpendSettlementLayer,
   SpendTarget,
   SpendToken,
 } from './experimental/spend-session'

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -133,6 +133,28 @@ export {
   experimental_defineSpendSession,
   LAYER_CAPABILITIES,
 } from './experimental/spend-session'
+export {
+  addressToBytes32,
+  CCTP_LAYER_ID,
+  encodeCctpAdapterConfig,
+  encodeIntentExecutorBaseHeader,
+  encodeIntentExecutorPolicyInitData,
+  encodeRelayAdapterConfig,
+  encodeRhinoAdapterConfig,
+  encodeStaticIntentExecutorPolicyInitData,
+  FLAG_LOCK_ACCOUNT,
+  FLAG_REQUIRE_GAS_REFUND,
+  intentExecutorPolicyEntry,
+  RELAY_LAYER_ID,
+  RHINO_LAYER_ID,
+} from '../modules/validators/smart-sessions/policies/settlement-layer'
+export type {
+  CctpLayerConfig,
+  IntentExecutorBaseConfig,
+  LayerInstall,
+  RelayLayerConfig,
+  RhinoLayerConfig,
+} from '../modules/validators/smart-sessions/policies/settlement-layer'
 export type {
   ChainDigest,
   SessionDetails,

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -38,6 +38,21 @@ import {
   VALUE_LIMIT_POLICY_ADDRESS,
 } from '../modules/validators/smart-sessions/policies/addresses'
 import {
+  addressToBytes32,
+  CCTP_LAYER_ID,
+  encodeCctpAdapterConfig,
+  encodeIntentExecutorBaseHeader,
+  encodeIntentExecutorPolicyInitData,
+  encodeRelayAdapterConfig,
+  encodeRhinoAdapterConfig,
+  encodeStaticIntentExecutorPolicyInitData,
+  FLAG_LOCK_ACCOUNT,
+  FLAG_REQUIRE_GAS_REFUND,
+  intentExecutorPolicyEntry,
+  RELAY_LAYER_ID,
+  RHINO_LAYER_ID,
+} from '../modules/validators/smart-sessions/policies/settlement-layer'
+import {
   toSession as resolveSession,
   SMART_SESSIONS_FALLBACK_TARGET_FLAG,
   SMART_SESSIONS_FALLBACK_TARGET_SELECTOR_FLAG,
@@ -52,6 +67,10 @@ import type {
   SessionDefinition as DomainSessionDefinition,
   SessionDetails,
 } from '../modules/validators/smart-sessions/types'
+import {
+  experimental_defineSpendSession,
+  LAYER_CAPABILITIES,
+} from './experimental/spend-session'
 
 function environment(useDevContracts: boolean | undefined) {
   return useDevContracts === true ? 'development' : 'production'
@@ -128,26 +147,24 @@ export {
   buildOneTimeUseBurnOp,
   encodeOneTimeUseIdInitData,
   oneTimeUseIdErc1271Policy,
-}
-export {
-  experimental_defineSpendSession,
-  LAYER_CAPABILITIES,
-} from './experimental/spend-session'
-export {
+  // IntentExecutor settlement-layer policy (experimental — no deployment yet)
   addressToBytes32,
   CCTP_LAYER_ID,
-  encodeCctpAdapterConfig,
-  encodeIntentExecutorBaseHeader,
-  encodeIntentExecutorPolicyInitData,
-  encodeRelayAdapterConfig,
-  encodeRhinoAdapterConfig,
-  encodeStaticIntentExecutorPolicyInitData,
-  FLAG_LOCK_ACCOUNT,
-  FLAG_REQUIRE_GAS_REFUND,
-  intentExecutorPolicyEntry,
   RELAY_LAYER_ID,
   RHINO_LAYER_ID,
-} from '../modules/validators/smart-sessions/policies/settlement-layer'
+  FLAG_LOCK_ACCOUNT,
+  FLAG_REQUIRE_GAS_REFUND,
+  encodeCctpAdapterConfig,
+  encodeRelayAdapterConfig,
+  encodeRhinoAdapterConfig,
+  encodeIntentExecutorBaseHeader,
+  encodeIntentExecutorPolicyInitData,
+  encodeStaticIntentExecutorPolicyInitData,
+  intentExecutorPolicyEntry,
+  // Spend-session abstraction (experimental)
+  experimental_defineSpendSession,
+  LAYER_CAPABILITIES,
+}
 export type {
   CctpLayerConfig,
   IntentExecutorBaseConfig,

--- a/src/transactions/intents/sessions.ts
+++ b/src/transactions/intents/sessions.ts
@@ -49,8 +49,16 @@ export async function prepareIntentSessions<CompatibilityConfig>(input: {
       if (enabled?.kind !== 'session-enabled') {
         throw new Error(`Session state for chain ${chain.id} is missing`)
       }
+      // A one-time-use session must never drop to plain ERC-1271 (mode 1): the
+      // executor route's on-chain guard (a `consume` may only name the session's
+      // own id) runs via checkAction, which only fires in verify-execution mode
+      // (mode 5). An already-enabled, permission-less session would otherwise take
+      // mode 1 and skip it. Replay of a burned id is still blocked by the 1271
+      // advisory read, but the action-surface guard would be inert — so force it.
       const verifyExecutions =
-        !enabled.enabled || selected.session.hasExplicitPermissions
+        !enabled.enabled ||
+        selected.session.hasExplicitPermissions ||
+        selected.session.oneTimeUse === true
       return [
         chain.id,
         {

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -383,6 +383,38 @@ describe('intent workflow', () => {
     expect(read).toHaveBeenCalledTimes(3)
   })
 
+  test('forces verify-execution mode for an already-enabled one-time-use session', async () => {
+    const session = toSession({
+      chain: mainnet,
+      owners: { type: 'ecdsa', accounts: [account] },
+      claimPolicies: [{ type: 'permit2' }],
+      oneTimeUse: { id: 42n },
+      policyAddresses: {
+        oneTimeUseId: '0x00000000000000000000000000000000000000aa',
+      },
+    })
+    const workflow = context({
+      checkpoints: {
+        read: vi.fn(async (checkpoint) => [
+          {
+            kind: 'session-enabled' as const,
+            id: checkpoint.id,
+            enabled: true,
+          },
+        ]),
+      },
+    })
+    const prepared = await prepareIntent(workflow, {
+      ...input,
+      signers: { kind: 'smart-session', byChain: { 1: { session } } },
+    })
+    // A permission-less session enabled on-chain would normally drop to
+    // signatureMode 1 (see the multi-factor/passkey enabled cases → 0x00). A
+    // one-time-use session must stay in mode 5 so checkAction keeps running on
+    // the executor route — otherwise the contract's action-surface guard is inert.
+    expect(prepared.request.options.signatureMode).toBe(5)
+  })
+
   test('uses each prepared stage chain for a shorthand cross-chain session', () => {
     const source = toEvmChainReference(base.id)
     const destination = toEvmChainReference(arbitrum.id)

--- a/test/integration/scenarios/spend-session.demo.itest.ts
+++ b/test/integration/scenarios/spend-session.demo.itest.ts
@@ -34,12 +34,9 @@ const BASE_RPC =
 const ARBITRUM_RPC =
   process.env.INTEGRATION_ARB_FORK_RPC ?? 'http://localhost:30002'
 const API_KEY = process.env.INTEGRATION_RHINESTONE_API_KEY ?? 'testuserapikey'
+// Skip the whole suite (rather than throwing at import, which would abort
+// integration-suite discovery) when the deployed policy address isn't provided.
 const POLICY = (process.env.INTEGRATION_ONE_TIME_USE_ID_POLICY ?? '') as Address
-if (!POLICY) {
-  throw new Error(
-    'Set INTEGRATION_ONE_TIME_USE_ID_POLICY to the deployed OneTimeUseIdPolicy address',
-  )
-}
 
 const USDC: Address = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
 const ARB_USDC: Address = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
@@ -96,7 +93,7 @@ function freshId(): bigint {
   return BigInt(Date.now()) * 1000n + BigInt(Math.floor(Math.random() * 1000))
 }
 
-describe('RHI-6242 spend-session demo (local fork)', () => {
+describe.skipIf(!POLICY)('RHI-6242 spend-session demo (local fork)', () => {
   let account: RhinestoneAccount
 
   beforeAll(async () => {

--- a/test/integration/scenarios/spend-session.demo.itest.ts
+++ b/test/integration/scenarios/spend-session.demo.itest.ts
@@ -1,0 +1,217 @@
+import {
+  type Address,
+  createTestClient,
+  encodeAbiParameters,
+  encodeFunctionData,
+  erc20Abi,
+  http,
+  keccak256,
+  pad,
+  parseEther,
+  toHex,
+} from 'viem'
+import { arbitrum, base } from 'viem/chains'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { type RhinestoneAccount, RhinestoneSDK } from '../../../src/index'
+import { experimental_defineSpendSession } from '../../../src/smart-sessions/index'
+import { createOwner } from '../framework/fixtures'
+import { executeIntent, expectOutcome } from '../framework/runner'
+
+// RHI-6242 DEMO — the experimental spend-session abstraction on the local-fork
+// E2E stack. Instead of hand-wiring toSession + claim policies + arbiters, a
+// caller declares the spend (tokens, amounts, recipients, target chains) and the
+// SDK formulates the policy combination and the one-time-use burn op.
+//
+// Runs against the same `e2e:up` stack as one-time-use.itest.ts. Same-chain
+// settles end-to-end (settle-once / reject-twice); cross-chain is exercised
+// through build + submit (its on-chain fill is blocked on the settlement-layer
+// mode-byte collision tracked separately — the abstraction itself is unaffected).
+
+const ORCH_URL =
+  process.env.INTEGRATION_ORCHESTRATOR_URL ?? 'http://localhost:3000'
+const BASE_RPC =
+  process.env.INTEGRATION_BASE_FORK_RPC ?? 'http://localhost:30003'
+const ARBITRUM_RPC =
+  process.env.INTEGRATION_ARB_FORK_RPC ?? 'http://localhost:30002'
+const API_KEY = process.env.INTEGRATION_RHINESTONE_API_KEY ?? 'testuserapikey'
+const POLICY = (process.env.INTEGRATION_ONE_TIME_USE_ID_POLICY ?? '') as Address
+if (!POLICY) {
+  throw new Error(
+    'Set INTEGRATION_ONE_TIME_USE_ID_POLICY to the deployed OneTimeUseIdPolicy address',
+  )
+}
+
+const USDC: Address = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const ARB_USDC: Address = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'
+const USDC_BALANCES_SLOT = 9n
+const RECIPIENT: Address = '0x1111111111111111111111111111111111111111'
+const FUNDING = 100_000_000n // 100 USDC
+const TRANSFER = 1_000_000n // 1 USDC
+
+const fork = createTestClient({
+  mode: 'anvil',
+  chain: base,
+  transport: http(BASE_RPC),
+})
+
+function sdk() {
+  return new RhinestoneSDK({
+    apiKey: API_KEY,
+    endpointUrl: ORCH_URL,
+    useDevContracts: false,
+    provider: {
+      type: 'custom',
+      urls: { [base.id]: BASE_RPC, [arbitrum.id]: ARBITRUM_RPC },
+    },
+  })
+}
+
+async function fundOnFork(account: Address) {
+  await fork.setBalance({ address: account, value: parseEther('10') })
+  const slot = keccak256(
+    encodeAbiParameters(
+      [{ type: 'address' }, { type: 'uint256' }],
+      [account, USDC_BALANCES_SLOT],
+    ),
+  )
+  await fork.setStorageAt({
+    address: USDC,
+    index: slot,
+    value: pad(toHex(FUNDING), { size: 32 }),
+  })
+  await fork.mine({ blocks: 16 })
+}
+
+async function createFundedAccount(): Promise<RhinestoneAccount> {
+  const account = await sdk().createAccount({
+    owners: { type: 'ecdsa', accounts: [createOwner()] },
+    sessions: { enabled: true },
+  })
+  await fundOnFork(account.getAddress())
+  return account
+}
+
+function freshId(): bigint {
+  // Unique per run so a re-run against a persistent fork isn't pre-burned.
+  return BigInt(Date.now()) * 1000n + BigInt(Math.floor(Math.random() * 1000))
+}
+
+describe('RHI-6242 spend-session demo (local fork)', () => {
+  let account: RhinestoneAccount
+
+  beforeAll(async () => {
+    account = await createFundedAccount()
+  })
+
+  // Same-chain: the SDK picks the executor route and scopes the transfer to the
+  // recipient + amount, plus the one-time-use burn. Settles once, rejects twice.
+  test('same-chain single-use spend settles once, then rejects', async () => {
+    const owner = { type: 'ecdsa' as const, accounts: [createOwner()] }
+    const id = freshId()
+    const { session, buildBurnOp } = experimental_defineSpendSession({
+      chain: base,
+      owners: owner,
+      spend: {
+        tokens: [{ token: USDC, maxAmount: TRANSFER }],
+        recipients: [RECIPIENT],
+      },
+      singleUse: { id },
+      policyAddresses: { oneTimeUseId: POLICY },
+    })
+
+    const build = async () => {
+      const details = await account.getSessionDetails([session])
+      const userSignature = await account.signEnableSession(details)
+      return {
+        chain: base,
+        calls: [
+          {
+            to: USDC,
+            value: 0n,
+            data: encodeFunctionData({
+              abi: erc20Abi,
+              functionName: 'transfer',
+              args: [RECIPIENT, TRANSFER],
+            }),
+          },
+        ],
+        sourceCalls: { [base.id]: [buildBurnOp()] },
+        signers: {
+          type: 'session' as const,
+          session,
+          enableData: {
+            userSignature,
+            hashesAndChainIds: details.hashesAndChainIds,
+            sessionToEnableIndex: 0,
+          },
+        },
+      }
+    }
+
+    const first = await executeIntent({
+      account,
+      label: 'spend-demo/same-chain/first',
+      transaction: await build(),
+    })
+    expectOutcome(first, { kind: 'success' })
+
+    const second = await executeIntent({
+      account,
+      label: 'spend-demo/same-chain/second',
+      transaction: await build(),
+    })
+    expect(second.phase).not.toBe('success')
+  })
+
+  // Cross-chain: the SDK picks the permit2 route, binds the claim policy to the
+  // chosen settlement layer's arbiter, and restricts the destination recipient.
+  // Exercised through build + submit; the fill is blocked on the settlement-layer
+  // mode-byte collision (tracked separately), so we assert it builds and reaches
+  // submission rather than a full settle.
+  test('cross-chain single-use spend builds and submits', async () => {
+    const owner = { type: 'ecdsa' as const, accounts: [createOwner()] }
+    const id = freshId()
+    const { session, route, buildBurnOp } = experimental_defineSpendSession({
+      chain: base,
+      owners: owner,
+      spend: {
+        tokens: [{ token: USDC, maxAmount: TRANSFER }],
+        recipients: [RECIPIENT],
+        target: {
+          chains: [arbitrum],
+          settlementLayers: ['ACROSS'],
+          tokens: [{ chain: arbitrum, token: ARB_USDC }],
+        },
+      },
+      singleUse: { id },
+      policyAddresses: { oneTimeUseId: POLICY },
+    })
+    expect(route).toBe('permit2')
+
+    const details = await account.getSessionDetails([session])
+    const userSignature = await account.signEnableSession(details)
+    const execution = await executeIntent({
+      account,
+      label: 'spend-demo/cross-chain',
+      transaction: {
+        sourceChains: [base],
+        targetChain: arbitrum,
+        calls: [],
+        tokenRequests: [{ address: ARB_USDC, amount: 10_000n }],
+        sourceCalls: { [base.id]: [buildBurnOp()] },
+        signers: {
+          type: 'session' as const,
+          session,
+          enableData: {
+            userSignature,
+            hashesAndChainIds: details.hashesAndChainIds,
+            sessionToEnableIndex: 0,
+          },
+        },
+      },
+    })
+    // The abstraction produced a signable, submittable cross-chain intent. The
+    // fill itself is gated on the separate settlement-layer fix.
+    expect(['success', 'submit']).toContain(execution.phase)
+  })
+})


### PR DESCRIPTION
## What

Experimental SDK abstraction for settlement-layer session policies (RHI-6242): declare a spend in business terms — tokens, amounts, recipients, target chains, settlement layers — and let the SDK formulate the underlying session-policy combination, instead of hand-wiring arbiter policies per layer.

`experimental_defineSpendSession(input) → { session, route, buildBurnOp }`:

- **Same-chain** → executor route: universal-action / arg-policy scoping on the ERC-20 `transfer` (recipient allowlist + amount cap) + time-frame.
- **Cross-chain (Across / Eco)** → Permit2 route: a claim policy bound to the settlement layer's arbiter, via the existing cross-chain-permit expansion.
- **`singleUse`** installs the one-time-use policy and yields the burn op; omitting it is the explicit ("old way") config.

### Capability table + honest refusal

A per-layer capability table (`LAYER_CAPABILITIES`) records, for each settlement layer, which of {recipient, amount, token, chain} it can actually enforce and whether it's available today. The builder **refuses** — rather than emitting a restricted-looking but unrestricted session — when a requested layer isn't enforceable yet (the IntentExecutor-backed layers) or can't bind a requested recipient/amount restriction.

### IntentExecutor settlement-layer policy encoding

Faithful byte-packed encoders for the IntentExecutor settlement-layer policy family (smart-sessions-v2 #46): the shared base header, ownable multi-layer and static single-layer initData, and the CCTP / Relay / Rhino adapter config blobs — matching the on-chain decode exactly (big-endian, unpadded; raw 20-byte addresses; raw 32-byte CCTP mint recipients). Installed via a new `erc1271Policies` passthrough on `SessionDefinition` (resolve drops the default sudo entry so the 1271 list stays a strict AND), guarded against combining with the mutually-exclusive Permit2 claim policy.

The policy has **no canonical deployment yet**, so its address is required (like `oneTimeUseId`) and the encoding is validated by **byte-exact unit tests** rather than e2e.

## Why arg-policy can't cover the IntentExecutor layers

For the IntentExecutor-backed layers (Rhino/Relay/CCTP/NEAR/OFT) the bridge deposit is decoded per-execution, so a *single* call's args are at fixed offsets — CCTP is fully pinnable by arg-policy, Rhino/NEAR partially. But the robust, all-layers answer is the decode-level IntentExecutor policy (adapters), because: the wildcard fallback action would let a settler route around per-action pins; Relay's calldata is opaque; and Rhino-native/NEAR have no on-chain recipient. Details in the RHI-6242 discussion.

## Testing

- Unit: `spend-session.test.ts` (route selection, scoping, refusal, one-time-use, erc1271 wiring) + `settlement-layer.test.ts` (byte-exact encoder field placement + size checklist). All green; `tsc --noEmit` clean.
- `test/integration/scenarios/spend-session.demo.itest.ts` — local-fork demo (same-chain settle-once/reject-twice + cross-chain build). On-chain settlement is currently gated by a separate settlement-layer signature issue, tracked independently; the abstraction's formulation is proven by the unit tests.

## Notes

- Experimental surface (`experimental_` prefix).
- **Stacked on #792** (RHI-5798 one-time-use wiring, which this depends on) — base branch `feat/rhi-5798-sdk-onetime`. Merge #792 first.

Closes [RHI-6242](https://linear.app/rhinestone/issue/RHI-6242)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
