### PR TITLE
fix: configure multi-factor passkey and ENS factors statelessly

### DIFF
--- a/.changeset/multi-factor-stateless-factors.md
+++ b/.changeset/multi-factor-stateless-factors.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Fix multi-factor owner sets with a passkey or ENS factor, which previously failed every signature with `InvalidSignature()`. Such factors are now configured and signed in the format the sub-validator's stateless validation path requires. Their derived addresses change, and the order passkey credentials are listed in inside a factor no longer affects the address; ECDSA-only multi-factor accounts are unchanged. An already-deployed account is repaired by re-setting the offending factor with `mfa.setSubValidator`. Note that a nested ENS factor does not enforce owner expiry, because the validator's stateless path deliberately skips that check.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,12 +65,12 @@ generator there with `SDK_VECTORS_OUT` pointing at this checkout's baseline.
 promise with generated configurations (fast-check): which caller-visible
 differences must never move a derived address, and which must.
 
-Invariant: the order owners, recovery guardians, and multi-factor factor members
-are listed in; reordering modules across kinds while each kind keeps its relative
-order; spelling out a default (`threshold: 1`, `sessions: { enabled: false }`,
-`modules: []`); address and passkey public key casing and the uncompressed point
-prefix; the chain the address is requested for and whether the account is
-deployed; repeated derivation, derivation order across accounts, and host
+Invariant: the order owners, recovery guardians, multi-factor factor members, and
+the credentials of a passkey factor are listed in; reordering modules across
+kinds while each kind keeps its relative order; spelling out a default
+(`threshold: 1`, `sessions: { enabled: false }`, `modules: []`); address and
+passkey public key casing and the uncompressed point prefix; the chain the
+address is requested for and whether the account is deployed; repeated derivation, derivation order across accounts, and host
 collation. Derivation never mutates the caller's configuration.
 
 Sensitive by design, and asserted as such: owner set membership, threshold,
@@ -84,10 +84,7 @@ address through; the legacy v0 factory args keep their owner-order sensitivity,
 and the `address` `experimental_getV0InitData` reports comes from the current
 derivation path rather than from those factory args, so the two describe
 different accounts (reconstruction is unaffected — passing the result back as
-`initData` re-derives the address from `factoryData`); and a multi-credential
-passkey factor nested in a multi-factor owner set is
-still installed in caller order, because the salt search only runs for a
-top-level passkey owner.
+`initData` re-derives the address from `factoryData`).
 
 Properties run on a fixed seed so a counterexample reproduces on any host.
 `SDK_PROPERTY_SEED` and `SDK_PROPERTY_RUNS` override the seed and run count for

--- a/src/actions/mfa.test.ts
+++ b/src/actions/mfa.test.ts
@@ -1,7 +1,7 @@
 import { type Address, decodeFunctionData, parseAbi } from 'viem'
 import { base } from 'viem/chains'
 import { describe, expect, test, vi } from 'vitest'
-import { accountA } from '../../test/consts'
+import { accountA, passkeyAccount } from '../../test/consts'
 import { RhinestoneSDK } from '..'
 import { resolveCalls } from '../calls/resolve'
 import { toEvmChainReference } from '../chains/caip2'
@@ -10,6 +10,10 @@ import {
   MULTI_FACTOR_VALIDATOR_ADDRESS,
   MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
 } from '../modules/validators/multi-factor'
+import {
+  encodeWebauthnStatelessData,
+  WEBAUTHN_VALIDATOR_ADDRESS,
+} from '../modules/validators/webauthn'
 import {
   changeThreshold,
   disable,
@@ -138,6 +142,33 @@ describe('MFA actions', () => {
       expectModuleArgument(call.data, expected)
     },
   )
+
+  test('re-sets a passkey factor with the data its validator decodes', () => {
+    const call = setSubValidator(1, {
+      type: 'passkey',
+      accounts: [passkeyAccount],
+    })
+    if (!call.data) throw new Error('Expected management calldata')
+    const decoded = decodeFunctionData({
+      abi: managementActionAbi,
+      data: call.data,
+    })
+    if (decoded.functionName !== 'setValidator') {
+      throw new Error('Expected setValidator')
+    }
+    expect(decoded.args[0].toLowerCase()).toBe(WEBAUTHN_VALIDATOR_ADDRESS)
+    expect(decoded.args[2]).toBe(
+      encodeWebauthnStatelessData({
+        credentials: [
+          {
+            pubKey: passkeyAccount.publicKey,
+            authenticatorId: passkeyAccount.id,
+          },
+        ],
+        threshold: 1,
+      }),
+    )
+  })
 
   test.each(moduleCases)(
     'targets the $name module for management calls',

--- a/src/actions/mfa.test.ts
+++ b/src/actions/mfa.test.ts
@@ -1,4 +1,9 @@
-import { type Address, decodeFunctionData, parseAbi } from 'viem'
+import {
+  type Address,
+  decodeAbiParameters,
+  decodeFunctionData,
+  parseAbi,
+} from 'viem'
 import { base } from 'viem/chains'
 import { describe, expect, test, vi } from 'vitest'
 import { accountA, passkeyAccount } from '../../test/consts'
@@ -6,6 +11,7 @@ import { RhinestoneSDK } from '..'
 import { resolveCalls } from '../calls/resolve'
 import { toEvmChainReference } from '../chains/caip2'
 import type { CallInput, OwnableValidatorConfig } from '../config/account'
+import { ENS_HCA_MODULE } from '../modules/validators/ens'
 import {
   MULTI_FACTOR_VALIDATOR_ADDRESS,
   MULTI_FACTOR_VALIDATOR_V2_ADDRESS,
@@ -168,6 +174,31 @@ describe('MFA actions', () => {
         threshold: 1,
       }),
     )
+  })
+
+  test('re-sets an ENS factor with the data its validator decodes', () => {
+    const call = setSubValidator(1, {
+      type: 'ens',
+      owners: [{ account: accountA, expiration: new Date('2030-01-01') }],
+    })
+    if (!call.data) throw new Error('Expected management calldata')
+    const decoded = decodeFunctionData({
+      abi: managementActionAbi,
+      data: call.data,
+    })
+    if (decoded.functionName !== 'setValidator') {
+      throw new Error('Expected setValidator')
+    }
+    expect(decoded.args[0]).toBe(ENS_HCA_MODULE)
+    expect(
+      decodeAbiParameters(
+        [
+          { name: 'threshold', type: 'uint256' },
+          { name: 'owners', type: 'address[]' },
+        ],
+        decoded.args[2],
+      ),
+    ).toEqual([1n, [accountA.address]])
   })
 
   test.each(moduleCases)(

--- a/src/actions/mfa.ts
+++ b/src/actions/mfa.ts
@@ -7,7 +7,11 @@ import type {
 } from '../config/account'
 import { defineValidator } from '../modules/validators/definition'
 import { MULTI_FACTOR_VALIDATOR_ADDRESS } from '../modules/validators/multi-factor'
-import { resolveValidator } from '../modules/validators/resolve'
+import {
+  resolveAtomicValidator,
+  resolveAtomicValidatorStatelessData,
+  resolveValidator,
+} from '../modules/validators/resolve'
 import type {
   AtomicValidatorDefinition,
   AtomicValidatorInput,
@@ -20,8 +24,14 @@ import {
 
 type MfaFactor = OwnableValidatorConfig | WebauthnValidatorConfig
 
+function factorDefinition(validator: MfaFactor) {
+  return defineValidator(
+    validator as AtomicValidatorInput,
+  ) as AtomicValidatorDefinition
+}
+
 function factorModule(validator: MfaFactor) {
-  return resolveValidator(defineValidator(validator as AtomicValidatorInput))
+  return resolveValidator(factorDefinition(validator))
 }
 
 function multiFactorModule(
@@ -128,7 +138,7 @@ function setSubValidator(
   moduleAddress: Address = MULTI_FACTOR_VALIDATOR_ADDRESS,
 ): CalldataInput {
   const validatorId = padHex(toHex(id), { size: 12 })
-  const validatorModule = factorModule(validator)
+  const definition = factorDefinition(validator)
   return {
     to: moduleAddress,
     value: 0n,
@@ -154,7 +164,11 @@ function setSubValidator(
         },
       ],
       functionName: 'setValidator',
-      args: [validatorModule.address, validatorId, validatorModule.initData],
+      args: [
+        resolveAtomicValidator(definition).address,
+        validatorId,
+        resolveAtomicValidatorStatelessData(definition),
+      ],
     }),
   }
 }

--- a/src/actions/mfa.ts
+++ b/src/actions/mfa.ts
@@ -1,6 +1,7 @@
 import { type Address, encodeFunctionData, type Hex, padHex, toHex } from 'viem'
 import type {
   CalldataInput,
+  ENSValidatorConfig,
   LazyCallInput,
   OwnableValidatorConfig,
   WebauthnValidatorConfig,
@@ -22,7 +23,10 @@ import {
   resolveModuleUninstallation,
 } from './runtime'
 
-type MfaFactor = OwnableValidatorConfig | WebauthnValidatorConfig
+type MfaFactor =
+  | OwnableValidatorConfig
+  | ENSValidatorConfig
+  | WebauthnValidatorConfig
 
 function factorDefinition(validator: MfaFactor) {
   return defineValidator(
@@ -70,7 +74,7 @@ function multiFactorModule(
  * @returns Calls to enable multi-factor authentication
  */
 function enable(
-  validators: (OwnableValidatorConfig | WebauthnValidatorConfig | null)[],
+  validators: (MfaFactor | null)[],
   threshold = 1,
   moduleAddress?: Address,
 ): LazyCallInput {
@@ -134,7 +138,7 @@ function disable(moduleAddress?: Address): LazyCallInput {
  */
 function setSubValidator(
   id: Hex | number,
-  validator: OwnableValidatorConfig | WebauthnValidatorConfig,
+  validator: MfaFactor,
   moduleAddress: Address = MULTI_FACTOR_VALIDATOR_ADDRESS,
 ): CalldataInput {
   const validatorId = padHex(toHex(id), { size: 12 })
@@ -182,7 +186,7 @@ function setSubValidator(
  */
 function removeSubValidator(
   id: Hex | number,
-  validator: OwnableValidatorConfig | WebauthnValidatorConfig,
+  validator: MfaFactor,
   moduleAddress: Address = MULTI_FACTOR_VALIDATOR_ADDRESS,
 ): CalldataInput {
   const validatorId = padHex(toHex(id), { size: 12 })

--- a/src/modules/validators/contribution.test.ts
+++ b/src/modules/validators/contribution.test.ts
@@ -10,6 +10,7 @@ import {
   encodeWebauthnValidatorContribution,
   generateWebauthnCredentialId,
   parseWebauthnSignature,
+  WEBAUTHN_STATELESS_ACCOUNT,
 } from './webauthn'
 
 const validator = {
@@ -286,6 +287,81 @@ describe('validator contribution codecs', () => {
         contributions: [value, { ...value, ownerId: 'b' }],
       }),
     ).toThrow('exactly one')
+  })
+
+  test('carries a passkey factor as the assertions its validator decodes', () => {
+    const publicKey = `0x${'44'.repeat(64)}` as Hex
+    const factorContribution = encodeValidatorContribution(
+      {
+        kind: 'ordered-threshold',
+        validator,
+        ownerOrder: ['passkey'],
+        threshold: 1,
+        recoveryEncoding: 'ethereum',
+        webauthn: {
+          account: WEBAUTHN_STATELESS_ACCOUNT,
+          usePrecompile: false,
+          format: 'stateless',
+          credentials: [{ ownerId: 'passkey', publicKey }],
+        },
+      },
+      [
+        {
+          kind: 'webauthn',
+          ownerId: 'passkey',
+          publicKey,
+          signature: `0x${'22'.repeat(64)}`,
+          authenticatorData: '0x1234',
+          clientDataJSON: '{"type":"webauthn.get","challenge":"value"}',
+          challengeIndex: 0,
+          typeIndex: 0,
+          userVerificationRequired: false,
+        },
+      ],
+    )
+    const [factors] = decodeAbiParameters(
+      [
+        {
+          type: 'tuple[]',
+          components: [{ type: 'bytes32' }, { type: 'bytes' }],
+        },
+      ],
+      encodeValidatorContribution(
+        {
+          kind: 'nested-threshold',
+          validator,
+          factorOrder: ['passkey'],
+          threshold: 1,
+        },
+        [
+          {
+            kind: 'factor',
+            factorId: 'passkey',
+            publicId: 1,
+            validator: account,
+            contribution: factorContribution,
+          },
+        ],
+      ),
+    )
+    const [assertions] = decodeAbiParameters(
+      [
+        {
+          type: 'tuple[]',
+          components: [
+            { type: 'bytes' },
+            { type: 'string' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+            { type: 'uint256' },
+          ],
+        },
+      ],
+      factors[0][1],
+    )
+    expect(assertions).toHaveLength(1)
+    expect(assertions[0][0]).toBe('0x1234')
   })
 
   test('normalizes MFA ids and preserves configured factor order', () => {

--- a/src/modules/validators/ens.ts
+++ b/src/modules/validators/ens.ts
@@ -1,4 +1,4 @@
-import { encodeAbiParameters, maxUint48 } from 'viem'
+import { encodeAbiParameters, type Hex, maxUint48 } from 'viem'
 import type { ResolvedModule } from '../types'
 import { compareHexValues } from './ordering'
 import type { AtomicValidatorDefinition } from './types'
@@ -6,10 +6,8 @@ import type { AtomicValidatorDefinition } from './types'
 export const ENS_HCA_MODULE =
   '0x5049ecBd4d961aE6DFEED9b7ccCe7f026454970E' as const
 
-export function resolveEnsValidator(
-  definition: AtomicValidatorDefinition,
-): ResolvedModule {
-  const owners = definition.owners
+function ensOwners(definition: AtomicValidatorDefinition) {
+  return definition.owners
     .map((owner) => {
       if (owner.kind !== 'ens') {
         throw new Error('ENS validator contains a non-ENS owner')
@@ -22,6 +20,33 @@ export function resolveEnsValidator(
       }
     })
     .sort((left, right) => compareHexValues(left.addr, right.addr))
+}
+
+/**
+ * The configuration the ENS validator's stateless path expects: the threshold
+ * followed by the sorted owner addresses, without expirations. That path
+ * deliberately skips the expiration check, because expiry lives in the
+ * validator's own storage and a stateless caller has none — so an expired owner
+ * still satisfies an ENS factor nested under multi-factor.
+ */
+export function encodeEnsStatelessData(
+  definition: AtomicValidatorDefinition,
+): Hex {
+  return encodeAbiParameters(
+    [
+      { name: 'threshold', type: 'uint256' },
+      { name: 'owners', type: 'address[]' },
+    ],
+    [
+      BigInt(definition.threshold),
+      ensOwners(definition).map((owner) => owner.addr),
+    ],
+  )
+}
+
+export function resolveEnsValidator(
+  definition: AtomicValidatorDefinition,
+): ResolvedModule {
   return {
     kind: 'validator',
     address: ENS_HCA_MODULE,
@@ -37,7 +62,7 @@ export function resolveEnsValidator(
           ],
         },
       ],
-      [BigInt(definition.threshold), owners],
+      [BigInt(definition.threshold), ensOwners(definition)],
     ),
     deInitData: '0x',
     additionalContext: '0x',

--- a/src/modules/validators/multi-factor.ts
+++ b/src/modules/validators/multi-factor.ts
@@ -16,9 +16,12 @@ export const MULTI_FACTOR_VALIDATOR_ADDRESS: Address =
 export const MULTI_FACTOR_VALIDATOR_V2_ADDRESS: Address =
   '0x0000007261E4E2F1a892A58fd0708c9321e76020'
 
+// Multi-factor validates a factor through `validateSignatureWithData`, handing
+// back the blob stored for that slot, so the slot holds the sub-validator's
+// stateless configuration rather than its install data.
 export type AtomicValidatorResolver = (
   definition: MultiFactorValidatorDefinition['validators'][number],
-) => ResolvedModule
+) => { readonly module: ResolvedModule; readonly statelessData: Hex }
 
 export function encodeValidatorId(id: number | Hex): Hex {
   return pad(typeof id === 'number' ? toHex(id) : id, { size: 12 })
@@ -29,13 +32,13 @@ export function resolveMultiFactorValidator(
   resolveAtomic: AtomicValidatorResolver,
 ): ResolvedModule {
   const validators = definition.validators.map((validator) => {
-    const module = resolveAtomic(validator)
+    const { module, statelessData } = resolveAtomic(validator)
     return {
       packedValidatorAndId: concat([
         encodeValidatorId(validator.publicId),
         module.address,
       ]),
-      data: module.initData,
+      data: statelessData,
     }
   })
   return {

--- a/src/modules/validators/ownable.ts
+++ b/src/modules/validators/ownable.ts
@@ -25,6 +25,27 @@ function moduleAddress(definition: AtomicValidatorDefinition) {
     : OWNABLE_VALIDATOR_ADDRESS
 }
 
+/**
+ * The configuration `OwnableValidator.validateSignatureWithData` expects: the
+ * threshold followed by the sorted, uniquified owner list. Byte-identical to
+ * the validator's install data, which is why the same encoder produces both.
+ */
+export function encodeOwnableStatelessData(input: {
+  readonly owners: readonly `0x${string}`[]
+  readonly threshold: number
+}): Hex {
+  return encodeAbiParameters(
+    [
+      { name: 'threshold', type: 'uint256' },
+      { name: 'owners', type: 'address[]' },
+    ],
+    [
+      BigInt(input.threshold),
+      input.owners.map((owner) => owner.toLowerCase() as `0x${string}`).sort(),
+    ],
+  )
+}
+
 export function resolveOwnableAddresses(input: {
   readonly owners: readonly `0x${string}`[]
   readonly threshold: number
@@ -33,27 +54,14 @@ export function resolveOwnableAddresses(input: {
   return {
     kind: 'validator',
     address: input.address ?? OWNABLE_VALIDATOR_ADDRESS,
-    initData: encodeAbiParameters(
-      [
-        { name: 'threshold', type: 'uint256' },
-        { name: 'owners', type: 'address[]' },
-      ],
-      [
-        BigInt(input.threshold),
-        input.owners
-          .map((owner) => owner.toLowerCase() as `0x${string}`)
-          .sort(),
-      ],
-    ),
+    initData: encodeOwnableStatelessData(input),
     deInitData: '0x',
     additionalContext: '0x',
   }
 }
 
-export function resolveOwnableValidator(
-  definition: AtomicValidatorDefinition,
-): ResolvedModule {
-  const owners = definition.owners
+function ownableDefinitionOwners(definition: AtomicValidatorDefinition) {
+  return definition.owners
     .map((owner) => {
       if (owner.kind === 'webauthn') {
         throw new Error('Ownable validator contains a WebAuthn owner')
@@ -61,10 +69,24 @@ export function resolveOwnableValidator(
       return owner.account.address.toLowerCase() as `0x${string}`
     })
     .sort()
+}
+
+export function resolveOwnableValidator(
+  definition: AtomicValidatorDefinition,
+): ResolvedModule {
   return resolveOwnableAddresses({
-    owners,
+    owners: ownableDefinitionOwners(definition),
     threshold: definition.threshold,
     address: moduleAddress(definition),
+  })
+}
+
+export function resolveOwnableStatelessData(
+  definition: AtomicValidatorDefinition,
+): Hex {
+  return encodeOwnableStatelessData({
+    owners: ownableDefinitionOwners(definition),
+    threshold: definition.threshold,
   })
 }
 

--- a/src/modules/validators/resolve.test.ts
+++ b/src/modules/validators/resolve.test.ts
@@ -21,9 +21,17 @@ import {
   OWNABLE_V0_VALIDATOR_ADDRESS,
   resolveOwnableValidator,
 } from './ownable'
-import { resolveAtomicValidator, resolveValidator } from './resolve'
-import type { AtomicValidatorDefinition } from './types'
 import {
+  resolveAtomicValidator,
+  resolveAtomicValidatorStatelessData,
+  resolveValidator,
+} from './resolve'
+import type {
+  AtomicValidatorDefinition,
+  MultiFactorValidatorDefinition,
+} from './types'
+import {
+  generateWebauthnCredentialId,
   parseWebauthnPublicKey,
   resolveWebauthnCredentials,
   resolveWebauthnValidator,
@@ -91,6 +99,89 @@ describe('validator resolution', () => {
     )
     expect(module.address).toBe(MULTI_FACTOR_VALIDATOR_V2_ADDRESS)
     expect(module.initData.startsWith('0x01')).toBe(true)
+  })
+
+  test('gives each MFA factor the stateless data its validator decodes', () => {
+    const definition = validator({
+      type: 'multi-factor',
+      threshold: 2,
+      validators: [
+        { type: 'ecdsa', accounts: [accountA, accountB], threshold: 2 },
+        { type: 'passkey', accounts: [passkeyAccount] },
+        { type: 'ens', owners: [{ account: accountC }] },
+      ],
+    }) as MultiFactorValidatorDefinition
+    const initData = resolveValidator(definition).initData
+    expect(initData.slice(0, 4)).toBe('0x02')
+    const [factors] = decodeAbiParameters(
+      [
+        {
+          type: 'tuple[]',
+          components: [
+            { name: 'packedValidatorAndId', type: 'bytes32' },
+            { name: 'data', type: 'bytes' },
+          ],
+        },
+      ],
+      `0x${initData.slice(4)}`,
+    )
+    const [ecdsa, passkey, ens] = factors.map((factor) => factor.data)
+
+    // Ownable's stateless data is its install data, so ECDSA-only MFA accounts
+    // keep their bytes.
+    expect(ecdsa).toBe(
+      resolveAtomicValidator(definition.validators[0]).initData,
+    )
+    expect([passkey, ens]).not.toContain(
+      resolveAtomicValidator(definition.validators[1]).initData,
+    )
+
+    const owners = (data: `0x${string}`) =>
+      decodeAbiParameters(
+        [
+          { name: 'threshold', type: 'uint256' },
+          { name: 'owners', type: 'address[]' },
+        ],
+        data,
+      )
+    expect(owners(ecdsa)).toEqual([2n, [accountB.address, accountA.address]])
+    expect(owners(ens)).toEqual([1n, [accountC.address]])
+
+    const [context, account] = decodeAbiParameters(
+      [
+        {
+          name: 'context',
+          type: 'tuple',
+          components: [
+            { name: 'usePrecompile', type: 'bool' },
+            { name: 'threshold', type: 'uint256' },
+            { name: 'credentialIds', type: 'bytes32[]' },
+            {
+              name: 'credentialData',
+              type: 'tuple[]',
+              components: [
+                { name: 'pubKeyX', type: 'uint256' },
+                { name: 'pubKeyY', type: 'uint256' },
+                { name: 'requireUV', type: 'bool' },
+              ],
+            },
+          ],
+        },
+        { name: 'account', type: 'address' },
+      ],
+      passkey,
+    )
+    expect(account).toBe('0x0000000000000000000000000000000000000000')
+    expect(context.threshold).toBe(1n)
+    expect(context.credentialIds).toEqual(
+      context.credentialData.map((credential) =>
+        generateWebauthnCredentialId(
+          credential.pubKeyX,
+          credential.pubKeyY,
+          account,
+        ),
+      ),
+    )
   })
 
   test('selects default MFA modules and exposes signing capabilities', () => {
@@ -304,6 +395,12 @@ describe('validator resolution', () => {
       const base = validator({ type: 'ecdsa', accounts: [accountA] })
       expect(() =>
         resolveAtomicValidator({ ...base, kind } as AtomicValidatorDefinition),
+      ).toThrow('requires feature input')
+      expect(() =>
+        resolveAtomicValidatorStatelessData({
+          ...base,
+          kind,
+        } as AtomicValidatorDefinition),
       ).toThrow('requires feature input')
     },
   )

--- a/src/modules/validators/resolve.ts
+++ b/src/modules/validators/resolve.ts
@@ -1,12 +1,14 @@
+import type { Hex } from 'viem'
 import type { ResolvedModule } from '../types'
-import { resolveEnsValidator } from './ens'
+import { encodeEnsStatelessData, resolveEnsValidator } from './ens'
 import { resolveMultiFactorValidator } from './multi-factor'
-import { resolveOwnableValidator } from './ownable'
+import { resolveOwnableStatelessData, resolveOwnableValidator } from './ownable'
 import type {
   AtomicValidatorDefinition,
   ResolvedValidatorDefinition,
 } from './types'
 import {
+  resolveWebauthnStatelessData,
   resolveWebauthnValidator,
   type WebauthnCredentialOrdering,
 } from './webauthn'
@@ -28,14 +30,42 @@ export function resolveAtomicValidator(
   }
 }
 
+// What a validator's `validateSignatureWithData` expects as its `data`. Only
+// Ownable's happens to equal its install data; for WebAuthn and ENS the two
+// differ, and multi-factor factor slots need this one.
+export function resolveAtomicValidatorStatelessData(
+  definition: AtomicValidatorDefinition,
+): Hex {
+  switch (definition.kind) {
+    case 'ecdsa':
+      return resolveOwnableStatelessData(definition)
+    case 'ens':
+      return encodeEnsStatelessData(definition)
+    case 'passkey':
+      return resolveWebauthnStatelessData(definition)
+    case 'k1':
+    case 'smart-session':
+      throw new Error(`Validator ${definition.kind} requires feature input`)
+  }
+}
+
+export function resolveAtomicValidatorFactor(
+  definition: AtomicValidatorDefinition,
+) {
+  return {
+    module: resolveAtomicValidator(definition),
+    statelessData: resolveAtomicValidatorStatelessData(definition),
+  }
+}
+
 // `webauthnOrdering` only applies to a top-level passkey validator: multi-factor
-// stores its sub-validator data without ever calling the sub-validator's
-// `onInstall`, so the ascending rule never runs and its bytes must not move.
+// stores the stateless configuration for its factors, whose credential order is
+// fixed by the pinned account the IDs are derived from.
 export function resolveValidator(
   definition: ResolvedValidatorDefinition,
   webauthnOrdering?: WebauthnCredentialOrdering,
 ): ResolvedModule {
   return definition.kind === 'multi-factor'
-    ? resolveMultiFactorValidator(definition, resolveAtomicValidator)
+    ? resolveMultiFactorValidator(definition, resolveAtomicValidatorFactor)
     : resolveAtomicValidator(definition, webauthnOrdering)
 }

--- a/src/modules/validators/types.ts
+++ b/src/modules/validators/types.ts
@@ -126,7 +126,13 @@ export type ValidatorContributionCodec =
       readonly webauthn?: {
         readonly account: Address
         readonly usePrecompile: boolean
-        readonly format: 'current' | 'v0'
+        readonly format: 'current' | 'v0' | 'stateless'
+        // Every configured credential, needed by the stateless format to check
+        // that a partial signer set is the factor's lowest-ordered prefix.
+        readonly credentials?: readonly {
+          readonly ownerId: string
+          readonly publicKey: Hex
+        }[]
       }
     }
   | {

--- a/src/modules/validators/webauthn.test.ts
+++ b/src/modules/validators/webauthn.test.ts
@@ -1,10 +1,14 @@
 import { type Address, decodeAbiParameters, keccak256, toHex } from 'viem'
 import { describe, expect, test } from 'vitest'
 import {
+  encodeWebauthnStatelessData,
+  encodeWebauthnValidatorContribution,
   generateWebauthnCredentialId,
   hasDuplicateWebauthnCredentials,
   orderWebauthnCredentials,
+  parseWebauthnPublicKey,
   resolveWebauthnCredentials,
+  WEBAUTHN_STATELESS_ACCOUNT,
   type WebauthnInstallCredential,
   webauthnCredentialsAreAscending,
 } from './webauthn'
@@ -135,5 +139,188 @@ describe('WebAuthn credential ordering', () => {
     expect(
       [...canonical].sort((a, b) => (a.pubKeyX < b.pubKeyX ? -1 : 1)),
     ).toEqual([...canonical])
+  })
+})
+
+const STATELESS_DATA_ABI = [
+  {
+    name: 'context',
+    type: 'tuple',
+    components: [
+      { name: 'usePrecompile', type: 'bool' },
+      { name: 'threshold', type: 'uint256' },
+      { name: 'credentialIds', type: 'bytes32[]' },
+      {
+        name: 'credentialData',
+        type: 'tuple[]',
+        components: [
+          { name: 'pubKeyX', type: 'uint256' },
+          { name: 'pubKeyY', type: 'uint256' },
+          { name: 'requireUV', type: 'bool' },
+        ],
+      },
+    ],
+  },
+  { name: 'account', type: 'address' },
+] as const
+
+const STATELESS_SIGNATURE_ABI = [
+  {
+    type: 'tuple[]',
+    components: [
+      { type: 'bytes', name: 'authenticatorData' },
+      { type: 'string', name: 'clientDataJSON' },
+      { type: 'uint256', name: 'challengeIndex' },
+      { type: 'uint256', name: 'typeIndex' },
+      { type: 'uint256', name: 'r' },
+      { type: 'uint256', name: 's' },
+    ],
+  },
+] as const
+
+const CREDENTIALS = ['stateless-a', 'stateless-b', 'stateless-c'].map(
+  (tag) => ({ pubKey: publicKeyBytes(tag), authenticatorId: tag }),
+)
+
+function contribution(index: number) {
+  return {
+    ownerId: `owner-${index}`,
+    publicKey: CREDENTIALS[index].pubKey,
+    signature: `0x${'11'.repeat(32)}${'22'.repeat(32)}` as `0x${string}`,
+    authenticatorData: `0x${'77'.repeat(37)}` as `0x${string}`,
+    clientDataJSON: `{"type":"webauthn.get","challenge":"c-${index}"}`,
+    challengeIndex: 0,
+    typeIndex: 0,
+  }
+}
+
+describe('WebAuthn stateless configuration', () => {
+  test('satisfies every check the stateless validation path performs', () => {
+    const [context, account] = decodeAbiParameters(
+      STATELESS_DATA_ABI,
+      encodeWebauthnStatelessData({ credentials: CREDENTIALS, threshold: 2 }),
+    )
+    expect(account).toBe(WEBAUTHN_STATELESS_ACCOUNT)
+    expect(context.usePrecompile).toBe(false)
+    expect(context.credentialIds).toHaveLength(context.credentialData.length)
+    expect(context.credentialIds).toEqual(
+      context.credentialData.map((credential) =>
+        generateWebauthnCredentialId(
+          credential.pubKeyX,
+          credential.pubKeyY,
+          account,
+        ),
+      ),
+    )
+    expect([...context.credentialIds].sort()).toEqual([
+      ...context.credentialIds,
+    ])
+    expect(new Set(context.credentialIds).size).toBe(
+      context.credentialIds.length,
+    )
+    expect(context.threshold).toBe(2n)
+    expect(context.threshold).toBeLessThanOrEqual(
+      BigInt(context.credentialIds.length),
+    )
+  })
+
+  test('is credential-order independent', () => {
+    expect(
+      encodeWebauthnStatelessData({
+        credentials: [...CREDENTIALS].reverse(),
+        threshold: 1,
+      }),
+    ).toBe(
+      encodeWebauthnStatelessData({ credentials: CREDENTIALS, threshold: 1 }),
+    )
+  })
+
+  test('is not interchangeable with the validator install data', () => {
+    const stateless = encodeWebauthnStatelessData({
+      credentials: CREDENTIALS,
+      threshold: 1,
+    })
+    const install = resolveWebauthnCredentials({
+      credentials: CREDENTIALS,
+      threshold: 1,
+    }).initData
+    expect(stateless).not.toBe(install)
+    expect(() => installedCredentials(stateless)).toThrow()
+    expect(() => decodeAbiParameters(STATELESS_DATA_ABI, install)).toThrow()
+  })
+
+  test('signs with the assertions alone, ordered as the configuration is', () => {
+    const [assertions] = decodeAbiParameters(
+      STATELESS_SIGNATURE_ABI,
+      encodeWebauthnValidatorContribution({
+        ownerOrder: ['owner-0', 'owner-1', 'owner-2'],
+        threshold: 3,
+        account: WEBAUTHN_STATELESS_ACCOUNT,
+        usePrecompile: false,
+        format: 'stateless',
+        credentials: CREDENTIALS.map((credential, index) => ({
+          ownerId: `owner-${index}`,
+          publicKey: credential.pubKey,
+        })),
+        contributions: [contribution(2), contribution(0), contribution(1)],
+      }),
+    )
+    const [context] = decodeAbiParameters(
+      STATELESS_DATA_ABI,
+      encodeWebauthnStatelessData({ credentials: CREDENTIALS, threshold: 3 }),
+    )
+    expect(assertions.map((assertion) => assertion.clientDataJSON)).toEqual(
+      context.credentialData.map((credential) => {
+        const index = CREDENTIALS.findIndex(
+          (entry) =>
+            parseWebauthnPublicKey(entry.pubKey).x === credential.pubKeyX,
+        )
+        return contribution(index).clientDataJSON
+      }),
+    )
+  })
+
+  test('rejects a partial signer set that is not the configured prefix', () => {
+    const credentials = CREDENTIALS.map((credential, index) => ({
+      ownerId: `owner-${index}`,
+      publicKey: credential.pubKey,
+    }))
+    const configuredOrder = decodeAbiParameters(
+      STATELESS_DATA_ABI,
+      encodeWebauthnStatelessData({ credentials: CREDENTIALS, threshold: 1 }),
+    )[0].credentialData.map((credential) =>
+      CREDENTIALS.findIndex(
+        (entry) =>
+          parseWebauthnPublicKey(entry.pubKey).x === credential.pubKeyX,
+      ),
+    )
+    const signWith = (indexes: readonly number[]) =>
+      encodeWebauthnValidatorContribution({
+        ownerOrder: ['owner-0', 'owner-1', 'owner-2'],
+        threshold: 1,
+        account: WEBAUTHN_STATELESS_ACCOUNT,
+        usePrecompile: false,
+        format: 'stateless',
+        credentials,
+        contributions: indexes.map(contribution),
+      })
+    expect(() => signWith([configuredOrder[0]])).not.toThrow()
+    expect(() => signWith([configuredOrder[1]])).toThrow('lowest-ordered')
+    expect(() => signWith([configuredOrder[0], configuredOrder[2]])).toThrow(
+      'lowest-ordered',
+    )
+  })
+
+  test('requires the configured credentials to check that prefix', () => {
+    expect(() =>
+      encodeWebauthnValidatorContribution({
+        ownerOrder: ['owner-0'],
+        threshold: 1,
+        account: WEBAUTHN_STATELESS_ACCOUNT,
+        usePrecompile: false,
+        format: 'stateless',
+        contributions: [contribution(0)],
+      }),
+    ).toThrow('configured credentials')
   })
 })

--- a/src/modules/validators/webauthn.ts
+++ b/src/modules/validators/webauthn.ts
@@ -1,6 +1,7 @@
 import {
   type Address,
   bytesToHex,
+  decodeAbiParameters,
   encodeAbiParameters,
   type Hex,
   hexToBytes,
@@ -14,6 +15,14 @@ import type { AtomicValidatorDefinition } from './types'
 export const WEBAUTHN_VALIDATOR_ADDRESS: Address =
   '0x0000000000578c4cb0e472a5462da43c495c3f33'
 export const WEBAUTHN_V0_VALIDATOR_ADDRESS = WEBAUTHN_VALIDATOR_ADDRESS
+
+// The account address carried by a stateless WebAuthn configuration. The
+// validator only uses it to re-derive the credential IDs in the same blob and
+// check they match, never to read storage, so any constant works as long as the
+// IDs are derived from it. The real account address cannot be used: it is
+// derived from the init data that would contain it.
+export const WEBAUTHN_STATELESS_ACCOUNT: Address =
+  '0x0000000000000000000000000000000000000000'
 
 export const WEBAUTHN_MOCK_SIGNATURE =
   '0x0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001b9b86eb98fda3ed4d797d9e690588dfadf17b329a76a47cec935bebf92d7ddc80000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000001700000000000000000000000000000000000000000000000000000000000000019b2e9410bb6850f9f660a03d609d5a844fb96bcdc87a15139b03ee22c70f469100d2b865a215c3bf786387064effa8fcedcb1d625b5148f8a1236d5e3ff11acf000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763050000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000867b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22396a4546696a75684557724d34534f572d7443684a625545484550343456636a634a2d42716f3166544d38222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a38303830222c2263726f73734f726967696e223a66616c73657d0000000000000000000000000000000000000000000000000000' as const
@@ -133,6 +142,37 @@ export function generateWebauthnCredentialId(
   )
 }
 
+const WEBAUTHN_AUTH_ABI = {
+  type: 'tuple[]',
+  name: 'webAuthns',
+  components: [
+    { type: 'bytes', name: 'authenticatorData' },
+    { type: 'string', name: 'clientDataJSON' },
+    { type: 'uint256', name: 'challengeIndex' },
+    { type: 'uint256', name: 'typeIndex' },
+    { type: 'uint256', name: 'r' },
+    { type: 'uint256', name: 's' },
+  ],
+} as const
+
+// The same mock assertion `WEBAUTHN_MOCK_SIGNATURE` carries, in the shape the
+// stateless path expects, so a passkey factor can be gas-estimated.
+export function webauthnStatelessMockSignature(): Hex {
+  return encodeAbiParameters(
+    [WEBAUTHN_AUTH_ABI],
+    [
+      decodeAbiParameters(
+        [
+          { type: 'bytes32[]', name: 'credIds' },
+          { type: 'bool', name: 'usePrecompile' },
+          WEBAUTHN_AUTH_ABI,
+        ],
+        WEBAUTHN_MOCK_SIGNATURE,
+      )[2],
+    ],
+  )
+}
+
 export function encodeWebauthnSignatures(
   credentialIds: readonly Hex[],
   usePrecompile: boolean,
@@ -150,24 +190,24 @@ export function encodeWebauthnSignatures(
     [
       { type: 'bytes32[]', name: 'credIds' },
       { type: 'bool', name: 'usePrecompile' },
-      {
-        type: 'tuple[]',
-        name: 'webAuthns',
-        components: [
-          { type: 'bytes', name: 'authenticatorData' },
-          { type: 'string', name: 'clientDataJSON' },
-          { type: 'uint256', name: 'challengeIndex' },
-          { type: 'uint256', name: 'typeIndex' },
-          { type: 'uint256', name: 'r' },
-          { type: 'uint256', name: 's' },
-        ],
-      },
+      WEBAUTHN_AUTH_ABI,
     ],
     [
       ordered.map(({ credentialId }) => credentialId),
       usePrecompile,
       ordered.map(({ signature }) => signature),
     ],
+  )
+}
+
+// The signature format the validator's stateless path expects: the assertions
+// alone, paired with the configuration's credentials by position.
+export function encodeWebauthnStatelessSignatures(
+  signatures: readonly WebAuthnSignature[],
+): Hex {
+  return encodeAbiParameters(
+    [WEBAUTHN_AUTH_ABI],
+    [signatures.map(normalizeWebauthnSignature)],
   )
 }
 
@@ -196,12 +236,38 @@ export function encodeWebauthnSignatureV0(
   )
 }
 
+// Orders owners the way the stateless configuration lays their credentials out.
+function statelessCredentialOrder(
+  credentials: readonly { readonly ownerId: string; readonly publicKey: Hex }[],
+): readonly string[] {
+  return [...credentials]
+    .map((credential) => {
+      const publicKey = parseWebauthnPublicKey(credential.publicKey)
+      return {
+        ownerId: credential.ownerId,
+        credentialId: generateWebauthnCredentialId(
+          publicKey.x,
+          publicKey.y,
+          WEBAUTHN_STATELESS_ACCOUNT,
+        ),
+      }
+    })
+    .sort((left, right) =>
+      compareHexValues(left.credentialId, right.credentialId),
+    )
+    .map(({ ownerId }) => ownerId)
+}
+
 export function encodeWebauthnValidatorContribution(input: {
   readonly ownerOrder: readonly string[]
   readonly threshold: number
   readonly account: Address
   readonly usePrecompile: boolean
-  readonly format: 'current' | 'v0'
+  readonly format: 'current' | 'v0' | 'stateless'
+  readonly credentials?: readonly {
+    readonly ownerId: string
+    readonly publicKey: Hex
+  }[]
   readonly contributions: readonly {
     readonly ownerId: string
     readonly publicKey: Hex
@@ -249,6 +315,37 @@ export function encodeWebauthnValidatorContribution(input: {
       throw new Error('WebAuthn V0 accepts exactly one contribution')
     }
     return encodeWebauthnSignatureV0(signatures[0], input.usePrecompile)
+  }
+  if (input.format === 'stateless') {
+    if (!input.credentials) {
+      throw new Error(
+        'Stateless WebAuthn contributions require the configured credentials',
+      )
+    }
+    const configuredOrder = statelessCredentialOrder(input.credentials)
+    const signingOrder = statelessCredentialOrder(
+      ordered.map((contribution) => ({
+        ownerId: contribution.ownerId,
+        publicKey: contribution.publicKey,
+      })),
+    )
+    const expected = configuredOrder.slice(0, signingOrder.length)
+    if (signingOrder.some((ownerId, index) => expected[index] !== ownerId)) {
+      throw new Error(
+        'A WebAuthn factor pairs each signature with the credential at the same position, so a partial signer set must be the lowest-ordered credentials of that factor',
+      )
+    }
+    const byOwnerId = new Map(
+      ordered.map((contribution, index) => [
+        contribution.ownerId,
+        signatures[index],
+      ]),
+    )
+    return encodeWebauthnStatelessSignatures(
+      signingOrder.map(
+        (ownerId) => byOwnerId.get(ownerId) as WebAuthnSignature,
+      ),
+    )
   }
   const credentialIds = ordered.map((contribution) => {
     const publicKey = parseWebauthnPublicKey(contribution.publicKey)
@@ -406,6 +503,91 @@ export function webauthnDefinitionCredentials(
       pubKey: owner.account.publicKey,
       authenticatorId: owner.account.id,
     }
+  })
+}
+
+/**
+ * The configuration `WebAuthnValidator.validateSignatureWithData` expects, which
+ * is *not* the validator's install data: a verification context plus the account
+ * the credential IDs were derived from. Multi-factor stores this blob verbatim
+ * and hands it back on every factor validation.
+ *
+ * Written for the deployed validator ({@link WEBAUTHN_VALIDATOR_ADDRESS}); a
+ * future deployment that drops the account from credential-ID derivation would
+ * need its own encoder.
+ */
+export function encodeWebauthnStatelessData(input: {
+  readonly credentials: readonly WebauthnCredential[]
+  readonly threshold: number
+  readonly usePrecompile?: boolean
+}): Hex {
+  const credentials = orderWebauthnCredentials(
+    toWebauthnInstallCredentials(input.credentials),
+    { kind: 'credential-id', account: WEBAUTHN_STATELESS_ACCOUNT },
+  )
+  return encodeAbiParameters(
+    [
+      {
+        name: 'context',
+        type: 'tuple',
+        components: [
+          { name: 'usePrecompile', type: 'bool' },
+          { name: 'threshold', type: 'uint256' },
+          { name: 'credentialIds', type: 'bytes32[]' },
+          {
+            name: 'credentialData',
+            type: 'tuple[]',
+            components: [
+              { name: 'pubKeyX', type: 'uint256' },
+              { name: 'pubKeyY', type: 'uint256' },
+              { name: 'requireUV', type: 'bool' },
+            ],
+          },
+        ],
+      },
+      { name: 'account', type: 'address' },
+    ],
+    [
+      {
+        usePrecompile: input.usePrecompile ?? false,
+        threshold: BigInt(input.threshold),
+        credentialIds: credentials.map((credential) =>
+          generateWebauthnCredentialId(
+            credential.pubKeyX,
+            credential.pubKeyY,
+            WEBAUTHN_STATELESS_ACCOUNT,
+          ),
+        ),
+        credentialData: [...credentials],
+      },
+      WEBAUTHN_STATELESS_ACCOUNT,
+    ],
+  )
+}
+
+// A passkey factor signs through the sub-validator's stateless path: the
+// assertions alone, paired with credentials derived from the pinned account.
+export function webauthnStatelessCodecContext(
+  definition: AtomicValidatorDefinition,
+) {
+  return {
+    account: WEBAUTHN_STATELESS_ACCOUNT,
+    usePrecompile: false,
+    format: 'stateless' as const,
+    credentials: definition.owners.flatMap((owner) =>
+      owner.kind === 'webauthn'
+        ? [{ ownerId: owner.id, publicKey: owner.account.publicKey }]
+        : [],
+    ),
+  }
+}
+
+export function resolveWebauthnStatelessData(
+  definition: AtomicValidatorDefinition,
+): Hex {
+  return encodeWebauthnStatelessData({
+    credentials: webauthnDefinitionCredentials(definition),
+    threshold: definition.threshold,
   })
 }
 

--- a/src/signing/context.ts
+++ b/src/signing/context.ts
@@ -10,6 +10,7 @@ import type {
   ValidatorContributionCodec,
   ValidatorSigningPurpose,
 } from '../modules/validators/types'
+import { webauthnStatelessCodecContext } from '../modules/validators/webauthn'
 import { signingTopology } from './plan'
 import type {
   ArtifactAssemblyPlan,
@@ -153,11 +154,7 @@ export function getSigningValidatorFactors(
         factor.kind === 'passkey'
           ? {
               ...normalizedCodec,
-              webauthn: {
-                account: context.account.address,
-                usePrecompile: false,
-                format: 'current' as const,
-              },
+              webauthn: webauthnStatelessCodecContext(factor),
             }
           : normalizedCodec,
     }

--- a/src/transactions/intents/session-signing.ts
+++ b/src/transactions/intents/session-signing.ts
@@ -24,9 +24,11 @@ import {
 } from '../../modules/validators/smart-sessions/policies/claim'
 import type { ResolvedSessionSignerSet } from '../../modules/validators/smart-sessions/types'
 import type {
+  AtomicValidatorDefinition,
   ResolvedValidatorDefinition,
   ValidatorContributionCodec,
 } from '../../modules/validators/types'
+import { webauthnStatelessCodecContext } from '../../modules/validators/webauthn'
 import type { SigningContext } from '../../signing/context'
 import { getAccountSignatureEnvelope } from '../../signing/context'
 import type { IntentSigningPlanCreationInput } from '../../signing/intent-plans/types'
@@ -387,7 +389,7 @@ function sessionOwnerSigning(
             id: factor.id,
             publicId: factor.publicId,
             validator: resolveAtomicValidator(factor).address,
-            codec: withWebauthnContext(
+            codec: withFactorWebauthnContext(
               requireAtomicSignerCodec(
                 getValidatorCapabilities(
                   factor,
@@ -397,8 +399,7 @@ function sessionOwnerSigning(
                   false,
                 ).contributionCodec,
               ),
-              factor.kind === 'passkey',
-              account,
+              factor,
             ),
           })),
         }
@@ -507,6 +508,18 @@ function withWebauthnContext(
       format: 'current',
     },
   }
+}
+
+function withFactorWebauthnContext(
+  codec: Extract<
+    ValidatorContributionCodec,
+    { readonly kind: 'ordered-threshold' }
+  >,
+  factor: AtomicValidatorDefinition,
+) {
+  return factor.kind === 'passkey'
+    ? { ...codec, webauthn: webauthnStatelessCodecContext(factor) }
+    : codec
 }
 
 function sessionAccountEnvelope(

--- a/src/transactions/user-operations/domain.test.ts
+++ b/src/transactions/user-operations/domain.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   WEBAUTHN_MOCK_SIGNATURE,
   WEBAUTHN_VALIDATOR_ADDRESS,
+  webauthnStatelessMockSignature,
 } from '../../modules/validators/webauthn'
 import type { SigningContext } from '../../signing/context'
 import { createAccountSigningContext } from '../../signing/context'
@@ -202,9 +203,29 @@ describe('UserOperation domain', () => {
           toHex(1, { size: 12 }),
           WEBAUTHN_VALIDATOR_ADDRESS,
         ]),
-        data: WEBAUTHN_MOCK_SIGNATURE,
+        data: webauthnStatelessMockSignature(),
       },
     ])
+    // The factor stub must decode the way the validator's stateless path reads
+    // it: the assertions alone.
+    expect(() =>
+      decodeAbiParameters(
+        [
+          {
+            type: 'tuple[]',
+            components: [
+              { type: 'bytes', name: 'authenticatorData' },
+              { type: 'string', name: 'clientDataJSON' },
+              { type: 'uint256', name: 'challengeIndex' },
+              { type: 'uint256', name: 'typeIndex' },
+              { type: 'uint256', name: 'r' },
+              { type: 'uint256', name: 's' },
+            ],
+          },
+        ],
+        factors[1].data,
+      ),
+    ).not.toThrow()
   })
 
   test('polls until a receipt is available', async () => {

--- a/src/transactions/user-operations/validator-account.ts
+++ b/src/transactions/user-operations/validator-account.ts
@@ -3,7 +3,10 @@ import type { AccountRuntime } from '../../accounts/adapter'
 import { encodeMultiFactorContribution } from '../../modules/validators/multi-factor'
 import { encodeOwnableMockSignature } from '../../modules/validators/ownable'
 import { resolveValidator } from '../../modules/validators/resolve'
-import { WEBAUTHN_MOCK_SIGNATURE } from '../../modules/validators/webauthn'
+import {
+  WEBAUTHN_MOCK_SIGNATURE,
+  webauthnStatelessMockSignature,
+} from '../../modules/validators/webauthn'
 import type { SigningContext } from '../../signing/context'
 
 export function getUserOperationStubSignature(
@@ -26,7 +29,7 @@ export function getUserOperationStubSignature(
         validator: resolveValidator(validator).address,
         contribution:
           validator.kind === 'passkey'
-            ? WEBAUTHN_MOCK_SIGNATURE
+            ? webauthnStatelessMockSignature()
             : encodeOwnableMockSignature(validator.owners.length),
       })),
     })

--- a/test/vectors/accounts/account-deployment.json
+++ b/test/vectors/accounts/account-deployment.json
@@ -41,9 +41,14 @@
     },
     {
       "id": "kernel-multi-factor",
-      "address": "0x3DEa352bb92E9d1f3a28fd66e36710554376fAB4",
+      "address": "0x23bDE6c87FbE2D600eA5ee80014C23d621C7330c",
       "factory": "0xd703aae79538628d27099b8c4f621be4ccd142d5",
-      "factoryDataHash": "0x91386e4feb9753c580b542713b8e4d9f8d1e38ec2f53d34af6bc02eb3c89e58a"
+      "factoryDataHash": "0x7de0b32d4546028d96b2fef37cf676f8ca011449427f99c65331bd5da93bba82",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested passkey factor is configured (and ordered) the way its stateless validation path requires"
+      }
     },
     {
       "id": "kernel-passkey-single",
@@ -157,27 +162,47 @@
     },
     {
       "id": "nexus-multi-factor",
-      "address": "0x8bdf768B73988Ba4B10DE74f65a3E52Cddc780E0",
+      "address": "0x7953332B34329A9B3D6789a546Dc804475732D01",
       "factory": "0x0000000099d5576c73a3b190dabeeaa0f128ce6b",
-      "factoryDataHash": "0xaf4e9f86adfa9af78ad8398df49f756283ee973a0b6c6d331867f2b38fbad7c3"
+      "factoryDataHash": "0x8b180ee8314a9615379be54aa420937afc15cd1cf0a2db1da127033095849e3b",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested passkey factor is configured (and ordered) the way its stateless validation path requires"
+      }
     },
     {
       "id": "nexus-multi-factor-ecdsa-ens",
-      "address": "0x3Da8246511eb3218531687153e2247AE66Be679d",
+      "address": "0xFcA9c26D01F969cA03b0195BD153f48b177aCFCb",
       "factory": "0x0000000099d5576c73a3b190dabeeaa0f128ce6b",
-      "factoryDataHash": "0xdbf049fbd821984af4e5c36eaffb7d7396d4199a4881c0292f940e33d9d8edc5"
+      "factoryDataHash": "0x883384f7b7af5398e8460dcb572f1d0c203b011fe2055f16a94dd49aae37cd39",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested ENS factor is configured the way its stateless validation path requires"
+      }
     },
     {
       "id": "nexus-multi-factor-module-override",
-      "address": "0x150E73e7511E5d69046Eb37C69f9b10b5f6F0B6f",
+      "address": "0x1E32e14ce34a18b4abd8603512215a177715aaaa",
       "factory": "0x0000000099d5576c73a3b190dabeeaa0f128ce6b",
-      "factoryDataHash": "0x6c712ffc62fe28816b04ba33fcb3cc5f76765759e091b5300e4f2c63a37dce7c"
+      "factoryDataHash": "0x1cfe2fddeae328aa0495c8bd11c484896ce14149b1ef105b161e3656739cd891",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested passkey factor is configured (and ordered) the way its stateless validation path requires"
+      }
     },
     {
       "id": "nexus-multi-factor-threshold-2",
-      "address": "0xc692A5228840ddc31cd3B6A4a5Fce0f284914276",
+      "address": "0x9b6F54C7B64F3c6AC19595d54C6723e2E3357B6c",
       "factory": "0x0000000099d5576c73a3b190dabeeaa0f128ce6b",
-      "factoryDataHash": "0x483b3ddeccc40bddd0a68747522b4a20463b4492b48b3cd89bf1a53656e05d24"
+      "factoryDataHash": "0x7fd98bc1f4e0d0ce2066d3c33e5437698d6d5de2ac3010f84374b6b43fe6f237",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested passkey factor is configured (and ordered) the way its stateless validation path requires"
+      }
     },
     {
       "id": "nexus-passkey-module-override",
@@ -341,9 +366,14 @@
     },
     {
       "id": "safe-multi-factor",
-      "address": "0xbd352153856c2aF987D8CfAE3e74c286B8aff76F",
+      "address": "0x8c8FB88455C63AAc5A50053AB8D400488bCEE749",
       "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
-      "factoryDataHash": "0x821981c1c35057219a3b974755960aa274c12ecd907600a633ee1335af34a360"
+      "factoryDataHash": "0xcdf5a05700ac396510f160893c68495e113b0fdeb5da268f51c966665323766e",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested passkey factor is configured (and ordered) the way its stateless validation path requires"
+      }
     },
     {
       "id": "safe-nonce",
@@ -404,9 +434,14 @@
     },
     {
       "id": "startale-multi-factor",
-      "address": "0xbdbcd5d746d385205db5aa3424fe17ed1cbf2703",
+      "address": "0xb054f4797f2b998157388307ea30622449360795",
       "factory": "0x0000003b3e7b530b4f981ae80d9350392defef90",
-      "factoryDataHash": "0x025537e67eaf059689071c877f504ee23873dd6708333dba4cf374eca65efc34"
+      "factoryDataHash": "0x135700ffe5408b799828478da57311427753c7ff5fd2155a9f6ca09168dcc929",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested passkey factor is configured (and ordered) the way its stateless validation path requires"
+      }
     },
     {
       "id": "startale-passkey-single",
@@ -445,9 +480,14 @@
     },
     {
       "id": "v0-safe-multi-factor",
-      "address": "0xbd352153856c2aF987D8CfAE3e74c286B8aff76F",
+      "address": "0x8c8FB88455C63AAc5A50053AB8D400488bCEE749",
       "factory": "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67",
-      "factoryDataHash": "0x697ed601643b2708bdd0c7338703976fa111bd52d89bedad0a4403c60af2670b"
+      "factoryDataHash": "0x927eb7070a2cfe72dc1e93b0011d286632abddfb81cedbf463a461dc0085c5fa",
+      "deliberateChange": {
+        "sinceSha": "afb934d220e1638c849ab5b716e72153cfa54dbe",
+        "bump": "patch",
+        "reason": "multi-factor factor slots hold the sub-validator stateless configuration, so a nested passkey factor is configured (and ordered) the way its stateless validation path requires"
+      }
     },
     {
       "id": "v0-safe-passkey-single",

--- a/test/vectors/accounts/invariants.test.ts
+++ b/test/vectors/accounts/invariants.test.ts
@@ -542,6 +542,30 @@ describe('derivation is invariant under owner order', () => {
     )
   })
 
+  // A nested passkey factor is stored as the sub-validator's stateless
+  // configuration, whose credentials are ordered by their ID under a pinned
+  // account, so caller order cannot reach the derived address.
+  test('multi-passkey factors nested in a multi-factor set are order independent', () => {
+    const factors = (accounts: WebAuthnAccount[]) => ({
+      account: { type: 'nexus' as const },
+      owners: {
+        type: 'multi-factor' as const,
+        validators: [
+          { type: 'passkey' as const, accounts },
+          { type: 'ecdsa' as const, accounts: [accountA] },
+        ],
+      },
+    })
+    const first = passkey('property:nested-a')
+    const second = passkey('property:nested-b')
+    const baseline = deriveStatic(factors([first, second]))
+    const swapped = deriveStatic(factors([second, first]))
+    if (!derived(baseline) || !derived(swapped)) {
+      throw new Error('multi-factor configurations must derive')
+    }
+    expect(swapped.address).toBe(baseline.address)
+  })
+
   test('the order recovery guardians are listed in is ignored', () => {
     fc.assert(
       fc.property(configArbitrary, seedArbitrary, (config, seed) => {
@@ -938,31 +962,6 @@ describe('documented derivation exceptions', () => {
       }),
       propertyParameters({ numRuns: 50 }),
     )
-  })
-
-  // Known gap, pinned so it cannot widen: the salt search that makes a
-  // multi-credential passkey set order independent only runs for a top-level
-  // passkey owner, so credentials nested in a multi-factor factor are still
-  // installed in caller order.
-  test('multi-passkey factors nested in a multi-factor set stay order sensitive', () => {
-    const factors = (accounts: WebAuthnAccount[]) => ({
-      account: { type: 'nexus' as const },
-      owners: {
-        type: 'multi-factor' as const,
-        validators: [
-          { type: 'passkey' as const, accounts },
-          { type: 'ecdsa' as const, accounts: [accountA] },
-        ],
-      },
-    })
-    const first = passkey('property:nested-a')
-    const second = passkey('property:nested-b')
-    const baseline = deriveStatic(factors([first, second]))
-    const swapped = deriveStatic(factors([second, first]))
-    if (!derived(baseline) || !derived(swapped)) {
-      throw new Error('multi-factor configurations must derive')
-    }
-    expect(swapped.address).not.toBe(baseline.address)
   })
 
   // `getV0InitData` reports the current path's address with the v0 factory


### PR DESCRIPTION
- Multi-factor validates each factor through `IStatelessValidator.validateSignatureWithData`, but factor slots carried the sub-validator's **install** data. For WebAuthn and ENS the two formats differ, so the factor call reverted — escaping the threshold loop and surfacing as `InvalidSignature()` even when a valid ECDSA factor was present.
- Adds explicit per-kind stateless encoders (`encodeOwnableStatelessData`, `encodeEnsStatelessData`, `encodeWebauthnStatelessData`) and uses them for factor slots and `mfa.setSubValidator` (the on-chain repair path for deployed accounts). ECDSA factor bytes are byte-identical to before.
- The WebAuthn stateless blob's account address is only self-consistency-checked against its own credential IDs, so it is pinned to the zero address — removing the counterfactual-address circularity. Credentials are ordered by credential ID under that pinned address.
- Adds a `stateless` WebAuthn contribution format (`abi.encode(WebAuthnAuth[])`) with a prefix guard, since the validator pairs assertions with credentials positionally; `getSigningValidatorFactors`, the session-signing factor codecs, and the userOp stub signature point at the stateless shapes. Root (non-MFA) passkey and ENS paths are untouched.
- A nested ENS factor does not enforce owner expiry — the validator's stateless path deliberately skips it; documented at the call site.
- Derived addresses move for multi-factor sets with a passkey or ENS factor: exactly eight address-derivation vector cases updated with `deliberateChange` notes, and the pinned nested-passkey order-sensitivity gap inverts into an order-independence invariant (`docs/testing.md` updated).
- Patch changeset; export surface unchanged.

Closes [RHI-6296](https://linear.app/rhinestone/issue/RHI-6296/sdk-passkey-factor-under-a-multi-factor-owner-always-fails-with)
Follow-up (v1 backport): [RHI-6362](https://linear.app/rhinestone/issue/RHI-6362/sdk-v1-backport-the-multi-factor-passkeyens-factor-fix)