### PR TITLE
chore: downgrade restrict-session changeset to minor

### DIFF
--- a/.changeset/restrict-session-to-aggregators.md
+++ b/.changeset/restrict-session-to-aggregators.md
@@ -1,5 +1,5 @@
 ---
-'@rhinestone/sdk': major
+'@rhinestone/sdk': minor
 ---
 
 Restrict a smart session to swapping one token for another through named venues. `SessionDefinition` gains `swap`, which compiles to a scoped approve plus one scoped action per venue and drops the wildcard intent-execution fallback, so the session key can only run those calls.


### PR DESCRIPTION
- Bump `.changeset/restrict-session-to-aggregators.md` from `major` to `minor` so the next release isn't a breaking one.

Needs to land before the release PR (#815) is merged.