### PR TITLE
feat: support weighted Quorum Signers in v1

### DIFF
--- a/.changeset/support-v1-quorum-signer.md
+++ b/.changeset/support-v1-quorum-signer.md
@@ -1,0 +1,5 @@
+---
+"@rhinestone/sdk": minor
+---
+
+Add weighted Quorum Signer configuration, signing flows, and headless signing helpers.

--- a/src/accounts/index.test.ts
+++ b/src/accounts/index.test.ts
@@ -1,4 +1,4 @@
-import type { Account, Hex } from 'viem'
+import { type Account, type Hex, hashTypedData } from 'viem'
 import { mainnet } from 'viem/chains'
 import { describe, expect, test, vi } from 'vitest'
 import { accountA, accountB, passkeyAccount } from '../../test/consts'
@@ -6,7 +6,7 @@ import {
   getQuorumSignableHash,
   getQuorumValidator,
 } from '../modules/validators/quorum'
-import { getAddress, getEip1271Signature } from '.'
+import { getAddress, getEip1271Signature, getTypedDataPackedSignature } from '.'
 import { wrapMessageHash as wrapKernelMessageHash } from './kernel'
 
 describe('Accounts', () => {
@@ -64,6 +64,55 @@ describe('Accounts', () => {
     test.todo('With ECDSA, single key')
     test.todo('With ECDSA, multisig')
     test.todo('With Passkey')
+
+    test('Quorum-backed sessions raw-sign typed data with the session validator', async () => {
+      const module = '0x0000000000000000000000000000000000000042'
+      const innerSignature = `0x${'11'.repeat(64)}1b` as Hex
+      const rawSign = vi.fn().mockResolvedValue(innerSignature)
+      const sessionOwner = { ...accountA, sign: rawSign } as Account
+      const config = {
+        owners: { type: 'ecdsa' as const, accounts: [accountB] },
+      }
+      const configuredOwners = {
+        type: 'quorum' as const,
+        owners: [{ account: sessionOwner, weight: 1n }],
+        thresholdWeight: 1n,
+        module,
+      }
+      const parameters = {
+        domain: {
+          name: 'Test',
+          version: '1',
+          chainId: mainnet.id,
+          verifyingContract: accountB.address,
+        },
+        types: { Test: [{ name: 'value', type: 'uint256' }] },
+        primaryType: 'Test' as const,
+        message: { value: 1n },
+      }
+      const account = getAddress(config)
+
+      await getTypedDataPackedSignature(
+        config,
+        { type: 'owner', kind: 'quorum', accounts: [sessionOwner] },
+        mainnet,
+        {
+          address: '0x0000000000000000000000000000000000000043',
+          isRoot: false,
+        },
+        parameters,
+        configuredOwners,
+      )
+
+      expect(rawSign).toHaveBeenCalledWith({
+        hash: getQuorumSignableHash({
+          validator: module,
+          chainId: mainnet.id,
+          account,
+          hash: hashTypedData(parameters),
+        }),
+      })
+    })
 
     test('Kernel wraps the application hash before Quorum binding', async () => {
       const module = '0x0000000000000000000000000000000000000042'

--- a/src/accounts/index.test.ts
+++ b/src/accounts/index.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, test } from 'vitest'
+import type { Account, Hex } from 'viem'
+import { mainnet } from 'viem/chains'
+import { describe, expect, test, vi } from 'vitest'
 import { accountA, accountB, passkeyAccount } from '../../test/consts'
-import { getAddress } from '.'
+import {
+  getQuorumSignableHash,
+  getQuorumValidator,
+} from '../modules/validators/quorum'
+import { getAddress, getEip1271Signature } from '.'
+import { wrapMessageHash as wrapKernelMessageHash } from './kernel'
 
 describe('Accounts', () => {
   describe('Get Address', () => {
@@ -14,6 +21,34 @@ describe('Accounts', () => {
       })
       expect(address).toEqual('0x0681de31e060b384F0b08A3bAC99E9bDFf302474')
     })
+    test('Quorum owner order does not affect the account address', () => {
+      const module = '0x0000000000000000000000000000000000000042'
+      const owners = [
+        { account: accountA, weight: 1n },
+        { account: accountB, weight: 2n },
+      ]
+
+      expect(
+        getAddress({
+          owners: {
+            type: 'quorum',
+            owners,
+            thresholdWeight: 2n,
+            module,
+          },
+        }),
+      ).toBe(
+        getAddress({
+          owners: {
+            type: 'quorum',
+            owners: [...owners].reverse(),
+            thresholdWeight: 2n,
+            module,
+          },
+        }),
+      )
+    })
+
     test('Safe, passkey owner with a session', () => {
       const address = getAddress({
         owners: {
@@ -29,5 +64,41 @@ describe('Accounts', () => {
     test.todo('With ECDSA, single key')
     test.todo('With ECDSA, multisig')
     test.todo('With Passkey')
+
+    test('Kernel wraps the application hash before Quorum binding', async () => {
+      const module = '0x0000000000000000000000000000000000000042'
+      const innerSignature = `0x${'11'.repeat(64)}1b` as Hex
+      const rawSign = vi.fn().mockResolvedValue(innerSignature)
+      const owner = { ...accountA, sign: rawSign } as Account
+      const config = {
+        account: { type: 'kernel' as const },
+        owners: {
+          type: 'quorum' as const,
+          owners: [{ account: owner, weight: 1n }],
+          thresholdWeight: 1n,
+          module,
+        },
+      }
+      const account = getAddress(config)
+      const hash = `0x${'22'.repeat(32)}` as Hex
+      const validator = getQuorumValidator(config.owners)
+
+      await getEip1271Signature(
+        config,
+        undefined,
+        mainnet,
+        { address: validator.address, isRoot: true },
+        hash,
+      )
+
+      expect(rawSign).toHaveBeenCalledWith({
+        hash: getQuorumSignableHash({
+          validator: module,
+          chainId: mainnet.id,
+          account,
+          hash: wrapKernelMessageHash(hash, account),
+        }),
+      })
+    })
   })
 })

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -27,6 +27,7 @@ import type { Module } from '../modules/common'
 import { isValidatorInitialized } from '../modules/read'
 import { getOwnerValidator } from '../modules/validators'
 import { getSocialRecoveryValidator } from '../modules/validators/core'
+import { getQuorumSignableHash } from '../modules/validators/quorum'
 import type { ResolvedSessionSignerSet } from '../modules/validators/smart-sessions'
 import type {
   AccountProviderConfig,
@@ -466,46 +467,65 @@ async function getEip1271Signature(
   }
 
   signers = signers ?? convertOwnerSetToSignerSet(config.owners!)
-  const signFn = (hash: Hex) =>
-    signMessage(signers, config.owners!, chain, address, hash, false)
   const account = getAccountProvider(config)
   const address = getAddress(config)
+  const accountHash =
+    account.type === 'kernel' ? wrapKernelMessageHash(hash, address) : hash
+  const signableHash =
+    config.owners?.type === 'quorum' &&
+    signers.type === 'owner' &&
+    signers.kind === 'quorum' &&
+    validator.address.toLowerCase() === config.owners.module.toLowerCase()
+      ? getQuorumSignableHash({
+          validator: config.owners.module,
+          chainId: chain.id,
+          account: address,
+          hash: accountHash,
+        })
+      : accountHash
+  const signature = await signMessage(
+    signers,
+    config.owners!,
+    chain,
+    address,
+    signableHash,
+    false,
+  )
+  return await packEip1271Signature(
+    config,
+    signature,
+    validator,
+    transformSignature,
+  )
+}
+
+async function packEip1271Signature(
+  config: RhinestoneConfig,
+  signature: Hex,
+  validator: ValidatorConfig,
+  transformSignature: (signature: Hex) => Hex = (signature) => signature,
+): Promise<Hex> {
+  const account = getAccountProvider(config)
   switch (account.type) {
-    case 'safe': {
-      const signature = await signFn(hash)
+    case 'safe':
       return packSafeSignature(signature, validator, transformSignature)
-    }
-    case 'nexus': {
-      const signature = await signFn(hash)
-      const defaultValidatorAddress = getNexusDefaultValidatorAddress(
-        account.version,
-      )
+    case 'nexus':
       return packNexusSignature(
         signature,
         validator,
         transformSignature,
-        defaultValidatorAddress,
+        getNexusDefaultValidatorAddress(account.version),
       )
-    }
-    case 'passport': {
-      const signature = await signFn(hash)
+    case 'passport':
       return packPassportSignature(signature, validator, transformSignature)
-    }
-    case 'kernel': {
-      const signature = await signFn(wrapKernelMessageHash(hash, address))
+    case 'kernel':
       return packKernelSignature(signature, validator, transformSignature)
-    }
-    case 'startale': {
-      const signature = await signFn(hash)
+    case 'startale':
       return packStartaleSignature(signature, validator, transformSignature)
-    }
-    case 'hca': {
-      const signature = await signFn(hash)
+    case 'hca':
       return packHcaSignature(signature, validator, transformSignature)
-    }
-    default: {
+    default:
       throw new Error(`Unsupported account type: ${(account as any).type}`)
-    }
   }
 }
 
@@ -544,6 +564,21 @@ async function getTypedDataPackedSignature<
 ): Promise<Hex> {
   if (config.account?.type === 'eoa') {
     throw new EoaSigningNotSupportedError('packed signatures')
+  }
+
+  if (
+    configuredOwners.type === 'quorum' &&
+    config.owners?.type === 'quorum' &&
+    validator.address.toLowerCase() === config.owners.module.toLowerCase()
+  ) {
+    return getEip1271Signature(
+      config,
+      signers,
+      chain,
+      validator,
+      hashTypedData(parameters),
+      transformSignature,
+    )
   }
 
   const address = getAddress(config)
@@ -841,6 +876,7 @@ async function getSmartAccount(
   config: RhinestoneConfig,
   client: PublicClient,
   chain: Chain,
+  selectedSigners?: SignerSet & { type: 'owner' },
 ) {
   // EOA accounts don't need smart account functionality
   if (config.account?.type === 'eoa') {
@@ -854,7 +890,7 @@ async function getSmartAccount(
   const account = getAccountProvider(config)
   const address = getAddress(config)
   const ownerValidator = getOwnerValidator(config)
-  const signers: SignerSet = convertOwnerSetToSignerSet(config.owners)
+  const signers = selectedSigners ?? convertOwnerSetToSignerSet(config.owners)
   const signFn = (hash: Hex) =>
     signMessage(signers, config.owners!, chain, address, hash, true)
   switch (account.type) {
@@ -1017,6 +1053,7 @@ export {
   getSmartAccount,
   getGuardianSmartAccount,
   getEip1271Signature,
+  packEip1271Signature,
   getEmissarySignature,
   getTypedDataPackedSignature,
   // Errors

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -566,17 +566,31 @@ async function getTypedDataPackedSignature<
     throw new EoaSigningNotSupportedError('packed signatures')
   }
 
-  if (
-    configuredOwners.type === 'quorum' &&
-    config.owners?.type === 'quorum' &&
-    validator.address.toLowerCase() === config.owners.module.toLowerCase()
-  ) {
-    return getEip1271Signature(
-      config,
-      signers,
+  if (configuredOwners.type === 'quorum') {
+    const address = getAddress(config)
+    const account = getAccountProvider(config)
+    const hash = hashTypedData(parameters)
+    const accountHash =
+      account.type === 'kernel' ? wrapKernelMessageHash(hash, address) : hash
+    const quorumSigners =
+      signers ?? convertOwnerSetToSignerSet(configuredOwners)
+    const signature = await signMessage(
+      quorumSigners,
+      configuredOwners,
       chain,
+      address,
+      getQuorumSignableHash({
+        validator: configuredOwners.module,
+        chainId: chain.id,
+        account: address,
+        hash: accountHash,
+      }),
+      false,
+    )
+    return await packEip1271Signature(
+      config,
+      signature,
       validator,
-      hashTypedData(parameters),
       transformSignature,
     )
   }

--- a/src/accounts/safe.ts
+++ b/src/accounts/safe.ts
@@ -437,6 +437,7 @@ function getOwners(config: RhinestoneAccountConfig) {
     case 'ecdsa':
     case 'ens':
       return ownerSet.accounts.map((account) => account.address)
+    case 'quorum':
     case 'passkey':
       return [NO_SAFE_OWNER_ADDRESS]
     case 'multi-factor':
@@ -453,6 +454,7 @@ function getThreshold(config: RhinestoneAccountConfig) {
     case 'ecdsa':
     case 'ens':
       return ownerSet.threshold ? BigInt(ownerSet.threshold) : 1n
+    case 'quorum':
     case 'passkey':
       return 1n
     case 'multi-factor':

--- a/src/accounts/signing/common.test.ts
+++ b/src/accounts/signing/common.test.ts
@@ -2,7 +2,7 @@ import { decodeAbiParameters, type Hex } from 'viem'
 import { toWebAuthnAccount } from 'viem/account-abstraction'
 import { mainnet } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
-import { accountA, passkeyAccount } from '../../../test/consts'
+import { accountA, accountB, passkeyAccount } from '../../../test/consts'
 import {
   ENS_HCA_MODULE,
   OWNABLE_VALIDATOR_ADDRESS,
@@ -126,6 +126,54 @@ const signedPasskeyAccountB = {
     signature: `0x${'33'.repeat(64)}` as Hex,
   }),
 } as typeof passkeyAccountB
+
+describe('quorum signing', () => {
+  const module = '0x0000000000000000000000000000000000000042' as const
+  const configuredOwners: OwnerSet = {
+    type: 'quorum',
+    module,
+    owners: [
+      { account: accountA, weight: 1n },
+      { account: accountB, weight: 2n },
+    ],
+    thresholdWeight: 2n,
+  }
+
+  test('raw-signs a threshold-satisfying subset and packs a regular envelope', async () => {
+    const signature = await signMessage(
+      {
+        type: 'owner',
+        kind: 'quorum',
+        accounts: [accountB],
+      },
+      configuredOwners,
+      mainnet,
+      accountA.address,
+      `0x${'44'.repeat(32)}`,
+      false,
+    )
+
+    expect(signature.startsWith(`0x00${accountB.address.slice(2)}`)).toBe(true)
+    expect(signature.slice(44, 48)).toBe('0041')
+  })
+
+  test('rejects an underweight selected subset', async () => {
+    await expect(
+      signMessage(
+        {
+          type: 'owner',
+          kind: 'quorum',
+          accounts: [accountA],
+        },
+        configuredOwners,
+        mainnet,
+        accountA.address,
+        `0x${'44'.repeat(32)}`,
+        false,
+      ),
+    ).rejects.toThrow('Insufficient validator contribution weight')
+  })
+})
 
 describe('multi-factor signing', () => {
   const configuredOwners: OwnerSet = {

--- a/src/accounts/signing/common.ts
+++ b/src/accounts/signing/common.ts
@@ -9,6 +9,7 @@ import {
   encodePacked,
   type Hex,
   hashMessage,
+  hexToBytes,
   pad,
   padHex,
   toHex,
@@ -21,6 +22,13 @@ import {
   OWNABLE_VALIDATOR_ADDRESS,
   WEBAUTHN_V0_VALIDATOR_ADDRESS,
 } from '../../modules/validators/core'
+import {
+  encodeQuorumErc1271Signature,
+  encodeQuorumOwnerSignatures,
+  getQuorumConfigOwners,
+  getQuorumSignableHash,
+  getQuorumValidator,
+} from '../../modules/validators/quorum'
 import {
   packSignature as packSmartSessionSignature,
   type ResolvedSessionSignerSet,
@@ -43,6 +51,13 @@ function convertOwnerSetToSignerSet(owners: OwnerSet): SignerSet {
         kind: 'ecdsa',
         accounts: owners.accounts,
         module: owners.module ?? OWNABLE_VALIDATOR_ADDRESS,
+      }
+    }
+    case 'quorum': {
+      return {
+        type: 'owner',
+        kind: 'quorum',
+        accounts: owners.owners.map(({ account }) => account),
       }
     }
     case 'ens': {
@@ -234,12 +249,21 @@ async function signWithSession(
     : hashMessage({
         raw: encodePacked(['bytes32', 'bytes32'], [padHex(address), hash]),
       })
+  const validatorHash =
+    signers.session.owners.type === 'quorum'
+      ? getQuorumSignableHash({
+          validator: signers.session.owners.module,
+          chainId: chain.id,
+          account: address,
+          hash: signedHash,
+        })
+      : signedHash
   const validatorSignature = await signMain(
     sessionSigners,
     signers.session.owners,
     chain,
     address,
-    signedHash,
+    validatorHash,
     false,
   )
   return packSmartSessionSignature(signers, validatorSignature)
@@ -256,6 +280,69 @@ async function signWithGuardians<T>(
     ),
   )
   return concat(signatures)
+}
+
+async function selectAccountChain(account: Account, chain: Chain) {
+  const transport = account.client?.transport
+  if (!transport) return
+  const walletClient = createWalletClient({
+    chain,
+    transport: custom(transport),
+    account,
+  })
+  await walletClient.switchChain({ id: chain.id })
+}
+
+async function signQuorumHash(
+  signers: SignerSet & { type: 'owner'; kind: 'quorum' },
+  configuredOwners: OwnerSet & { type: 'quorum' },
+  chain: Chain | undefined,
+  hash: Hex,
+): Promise<Hex> {
+  getQuorumValidator(configuredOwners)
+  const configured = new Map(
+    configuredOwners.owners.map(({ account, weight }) => [
+      account.address.toLowerCase(),
+      weight,
+    ]),
+  )
+  const selected = new Set<string>()
+  let selectedWeight = 0n
+  for (const account of signers.accounts) {
+    const ownerId = account.address.toLowerCase()
+    const weight = configured.get(ownerId)
+    if (weight === undefined) {
+      throw new Error(`Unknown validator owner ${ownerId}`)
+    }
+    if (selected.has(ownerId)) {
+      throw new Error(`Duplicate validator owner ${ownerId}`)
+    }
+    selected.add(ownerId)
+    selectedWeight += weight
+  }
+  if (selectedWeight < configuredOwners.thresholdWeight) {
+    throw new Error(
+      `Insufficient validator contribution weight: required ${configuredOwners.thresholdWeight}, received ${selectedWeight}`,
+    )
+  }
+
+  const signatures = await Promise.all(
+    signers.accounts.map(async (account) => {
+      if (chain) await selectAccountChain(account, chain)
+      if (!account.sign) {
+        throw new Error('Account does not support raw hash signing')
+      }
+      return {
+        ownerId: account.address.toLowerCase(),
+        signature: normalizeRecovery(await account.sign({ hash })),
+      }
+    }),
+  )
+  return encodeQuorumOwnerSignatures({
+    owners: getQuorumConfigOwners(configuredOwners),
+    thresholdWeight: configuredOwners.thresholdWeight,
+    signatures,
+  })
 }
 
 async function signWithOwners<T>(
@@ -283,24 +370,31 @@ async function signWithOwners<T>(
     updateV: boolean,
     chain: Chain,
   ): Promise<Hex> {
-    const client = account.client
-    const transport = client?.transport
-    if (transport) {
-      // Switch chain
-      const walletClient = createWalletClient({
-        chain,
-        transport: custom(transport),
-        account,
-      })
-      await walletClient.switchChain({
-        id: chain.id,
-      })
-    }
-    // Sign
+    await selectAccountChain(account, chain)
     return signingFunctions.signEcdsa(account, params, updateV)
   }
 
+  if (configuredOwners.type === 'quorum' && signers.kind !== 'quorum') {
+    throw new Error('Quorum owners require quorum signers')
+  }
+  if (configuredOwners.type !== 'quorum' && signers.kind === 'quorum') {
+    throw new Error('Quorum signers require quorum owners')
+  }
+
   switch (signers.kind) {
+    case 'quorum': {
+      if (configuredOwners.type !== 'quorum' || typeof params !== 'string') {
+        throw new Error('Quorum signing requires a raw hash')
+      }
+      return encodeQuorumErc1271Signature({
+        signatures: await signQuorumHash(
+          signers,
+          configuredOwners,
+          chain,
+          params as Hex,
+        ),
+      })
+    }
     case 'ecdsa': {
       // Ownable validator uses `v` value to determine which validation mode to use
       // ENS validator (based on Ownable) also uses the same signature format
@@ -377,9 +471,16 @@ async function signWithOwners<T>(
   }
 }
 
+function normalizeRecovery(signature: Hex): Hex {
+  const bytes = hexToBytes(signature)
+  if (bytes.length !== 65 || bytes[64] >= 27) return signature
+  return concat([signature.slice(0, -2) as Hex, toHex(bytes[64] + 27)])
+}
+
 export {
   convertOwnerSetToSignerSet,
   signWithMultiFactorAuth,
+  signQuorumHash,
   signWithSession,
   signWithGuardians,
   signWithOwners,

--- a/src/accounts/signing/quorum.ts
+++ b/src/accounts/signing/quorum.ts
@@ -1,0 +1,119 @@
+import type { Address, Hex } from 'viem'
+import {
+  buildQuorumMerkleTree,
+  encodeQuorumMerkleSignature as encodeMerkleSignature,
+  encodeQuorumOwnerSignatures as encodeOwnerSignatures,
+  encodeQuorumErc1271Signature as encodeRegularSignature,
+  getQuorumMerkleRootSignableHash,
+  getQuorumSignableHash,
+  type QuorumMerkleOperation,
+} from '../../modules/validators/quorum'
+import type { AccountType } from '../../types'
+import { wrapMessageHash as wrapKernelMessageHash } from '../kernel'
+
+/** One Quorum Signer owner used to assemble a weighted signature. */
+export interface QuorumSigningOwner {
+  /** Stable owner identifier used to associate an independently collected signature. */
+  ownerId: string
+  /** EOA or EIP-1271 signer address configured in the Quorum validator. */
+  signer: Address
+  /** Weight contributed when this owner's signature validates. */
+  weight: bigint
+}
+
+/** One independently collected signature over a Quorum signing digest. */
+export interface QuorumOwnerSignature {
+  /** Identifier matching one configured {@link QuorumSigningOwner}. */
+  ownerId: string
+  /** Raw ECDSA or EIP-1271 signature bytes. */
+  signature: Hex
+}
+
+/** Account-bound operation included in a Quorum Merkle signing batch. */
+export interface QuorumMerkleSigningOperation {
+  /** Smart account that will validate this operation. */
+  account: Address
+  /** Validator-specific operation digest placed in the account-bound Merkle leaf. */
+  digest: Hex
+}
+
+/** Merkle root and one proof-bearing result for every input operation. */
+export interface QuorumMerkleSigningTree {
+  /** Shared root signed by the owner quorum. */
+  root: Hex
+  /** Proofs in the same order as the input operations. */
+  operations: readonly QuorumMerkleOperation[]
+}
+
+/** Bind an ERC-1271 application hash to one Quorum validator, chain, and account. */
+export function getQuorumErc1271SignableHash(input: {
+  /** Deployed Quorum Signer validator address. */
+  validator: Address
+  /** Chain on which ERC-1271 validation will execute. */
+  chainId: number
+  /** Smart account that will call the validator. */
+  account: Address
+  /** Application hash passed to the smart account's ERC-1271 entry point. */
+  hash: Hex
+  /** Smart account implementation, when it transforms ERC-1271 hashes. */
+  accountType?: AccountType
+}): Hex {
+  return getQuorumSignableHash({
+    validator: input.validator,
+    chainId: input.chainId,
+    account: input.account,
+    hash:
+      input.accountType === 'kernel'
+        ? wrapKernelMessageHash(input.hash, input.account)
+        : input.hash,
+  })
+}
+
+/** Build account-bound Merkle leaves and proofs for a Quorum signing batch. */
+export function buildQuorumSigningTree(
+  operations: readonly QuorumMerkleSigningOperation[],
+): QuorumMerkleSigningTree {
+  return buildQuorumMerkleTree(operations)
+}
+
+/** Derive the chain-agnostic EIP-712 digest owners sign for a Quorum Merkle root. */
+export function getQuorumSigningTreeHash(input: {
+  /** Deployed Quorum Signer validator address shared by the target chains. */
+  validator: Address
+  /** Root returned by {@link buildQuorumSigningTree}. */
+  root: Hex
+}): Hex {
+  return getQuorumMerkleRootSignableHash(input)
+}
+
+/** Pack weighted owner signatures without selecting a regular or Merkle envelope. */
+export function encodeQuorumOwnerSignatures(input: {
+  /** Complete configured owner policy, including weights. */
+  owners: readonly QuorumSigningOwner[]
+  /** Minimum aggregate weight required by the validator. */
+  thresholdWeight: bigint
+  /** Independently collected signatures over one common Quorum digest. */
+  signatures: readonly QuorumOwnerSignature[]
+}): Hex {
+  return encodeOwnerSignatures(input)
+}
+
+/** Pack a regular ERC-1271 Quorum signature for one operation digest. */
+export function encodeQuorumErc1271Signature(input: {
+  /** Weighted owner entries returned by {@link encodeQuorumOwnerSignatures}. */
+  signatures: Hex
+}): Hex {
+  return encodeRegularSignature(input)
+}
+
+/** Pack one operation's Merkle proof and shared weighted owner signatures. */
+export function encodeQuorumMerkleSignature(input: {
+  /** Operation result returned by {@link buildQuorumSigningTree}. */
+  operation: QuorumMerkleOperation
+  /** Weighted owner entries returned by {@link encodeQuorumOwnerSignatures}. */
+  signatures: Hex
+}): Hex {
+  return encodeMerkleSignature(input)
+}
+
+export type { QuorumMerkleOperation }

--- a/src/execution/signing.test.ts
+++ b/src/execution/signing.test.ts
@@ -1,4 +1,4 @@
-import { type Hex, zeroAddress } from 'viem'
+import { type Hex, type PublicClient, zeroAddress } from 'viem'
 import { base } from 'viem/chains'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { accountA } from '../../test/consts'
@@ -13,7 +13,11 @@ import type {
   SessionSignerSet,
   SignerSet,
 } from '../types'
-import { getTargetExecutionSignature, signIntent } from './utils'
+import {
+  getTargetExecutionSignature,
+  getValidatorAccount,
+  signIntent,
+} from './utils'
 
 const {
   MOCK_EMISSARY,
@@ -23,7 +27,10 @@ const {
   MOCK_VALIDATOR,
   mockGetEmissarySignature,
   mockGetEip1271Signature,
+  mockGetSmartAccount,
   mockIsSessionEnabled,
+  mockPackEip1271Signature,
+  mockSignQuorumHash,
   MOCK_TYPED_DATA,
 } = vi.hoisted(() => {
   const MOCK_ACCOUNT = '0x1111111111111111111111111111111111111111'
@@ -34,7 +41,12 @@ const {
 
   const mockGetEmissarySignature = vi.fn().mockResolvedValue(MOCK_EMISSARY)
   const mockGetEip1271Signature = vi.fn().mockResolvedValue(MOCK_EIP1271)
+  const mockGetSmartAccount = vi.fn().mockResolvedValue({})
   const mockIsSessionEnabled = vi.fn().mockResolvedValue(true)
+  const mockPackEip1271Signature = vi.fn(
+    async (_config, signature) => signature,
+  )
+  const mockSignQuorumHash = vi.fn().mockResolvedValue('0xab')
 
   const MOCK_TYPED_DATA = {
     domain: {
@@ -58,7 +70,10 @@ const {
     MOCK_VALIDATOR: MOCK_VALIDATOR as `0x${string}`,
     mockGetEmissarySignature,
     mockGetEip1271Signature,
+    mockGetSmartAccount,
     mockIsSessionEnabled,
+    mockPackEip1271Signature,
+    mockSignQuorumHash,
     MOCK_TYPED_DATA,
   }
 })
@@ -71,12 +86,13 @@ vi.mock('../accounts', () => ({
   getAddress: vi.fn().mockReturnValue(MOCK_ACCOUNT),
   getEmissarySignature: mockGetEmissarySignature,
   getEip1271Signature: mockGetEip1271Signature,
-  getSmartAccount: vi.fn(),
+  getSmartAccount: mockGetSmartAccount,
   getEip712Domain: vi.fn(),
-  getAccountProvider: vi.fn(),
+  getAccountProvider: vi.fn().mockReturnValue({ type: 'safe' }),
   getInitCode: vi.fn(),
   getGuardianSmartAccount: vi.fn(),
   getTypedDataPackedSignature: vi.fn(),
+  packEip1271Signature: mockPackEip1271Signature,
   toErc6492Signature: vi.fn(),
   is7702: vi.fn().mockReturnValue(false),
   getEip7702InitCall: vi.fn(),
@@ -87,6 +103,7 @@ vi.mock('../accounts', () => ({
 
 vi.mock('../accounts/signing/common', () => ({
   convertOwnerSetToSignerSet: vi.fn(),
+  signQuorumHash: mockSignQuorumHash,
 }))
 
 vi.mock('../accounts/startale', () => ({
@@ -241,6 +258,30 @@ beforeEach(() => {
   mockGetEmissarySignature.mockResolvedValue(MOCK_EMISSARY)
   mockGetEip1271Signature.mockResolvedValue(MOCK_EIP1271)
   mockIsSessionEnabled.mockResolvedValue(true)
+  mockPackEip1271Signature.mockImplementation(
+    async (_config, signature) => signature,
+  )
+  mockSignQuorumHash.mockResolvedValue('0xab')
+})
+
+describe('getValidatorAccount', () => {
+  test('threads selected quorum owners into UserOperation signing', async () => {
+    const quorumSigners: SignerSet = {
+      type: 'owner',
+      kind: 'quorum',
+      accounts: [accountA],
+    }
+    const publicClient = {} as PublicClient
+
+    await getValidatorAccount(config, quorumSigners, publicClient, base)
+
+    expect(mockGetSmartAccount).toHaveBeenCalledWith(
+      config,
+      publicClient,
+      base,
+      quorumSigners,
+    )
+  })
 })
 
 describe('getTargetExecutionSignature', () => {
@@ -375,6 +416,41 @@ describe('signIntent with owner signers', () => {
     expect(mockGetEip1271Signature).toHaveBeenCalled()
     expect(mockGetEmissarySignature).not.toHaveBeenCalled()
     expect(originSignatures).toHaveLength(1)
+  })
+})
+
+describe('signIntent with quorum owners', () => {
+  test('signs one Merkle root and emits a proof envelope per origin', async () => {
+    const quorumConfig: RhinestoneConfig = {
+      ...config,
+      owners: {
+        type: 'quorum',
+        module: MOCK_VALIDATOR,
+        owners: [{ account: accountA, weight: 1n }],
+        thresholdWeight: 1n,
+      },
+    }
+    const quorumSigners: SignerSet = {
+      type: 'owner',
+      kind: 'quorum',
+      accounts: [accountA],
+    }
+
+    const { originSignatures, destinationSignature } = await signIntent(
+      quorumConfig,
+      makeIntentOp(['INTENT_EXECUTOR', 'INTENT_EXECUTOR']),
+      base,
+      quorumSigners,
+    )
+
+    expect(mockSignQuorumHash).toHaveBeenCalledTimes(1)
+    expect(originSignatures).toHaveLength(2)
+    expect(
+      originSignatures.every((signature) => signature.endsWith('ab')),
+    ).toBe(true)
+    expect(mockPackEip1271Signature).toHaveBeenCalledTimes(2)
+    expect(destinationSignature).toBe(originSignatures[1])
+    expect(mockGetEip1271Signature).not.toHaveBeenCalled()
   })
 })
 

--- a/src/execution/utils.ts
+++ b/src/execution/utils.ts
@@ -45,9 +45,14 @@ import {
   getSmartAccount,
   getTypedDataPackedSignature,
   is7702,
+  packEip1271Signature,
   toErc6492Signature,
 } from '../accounts'
-import { convertOwnerSetToSignerSet } from '../accounts/signing/common'
+import { wrapMessageHash as wrapKernelMessageHash } from '../accounts/kernel'
+import {
+  convertOwnerSetToSignerSet,
+  signQuorumHash,
+} from '../accounts/signing/common'
 import { K1_DEFAULT_VALIDATOR_ADDRESS } from '../accounts/startale'
 import {
   createTransport,
@@ -74,6 +79,12 @@ import {
 } from '../modules/validators/core'
 import type { Permit2ClaimMessage } from '../modules/validators/policies/claim/permit2'
 import { buildPermit2ClaimPolicyCalldata } from '../modules/validators/policies/claim/permit2'
+import {
+  buildQuorumMerkleTree,
+  encodeQuorumMerkleSignature,
+  getQuorumMerkleRootSignableHash,
+  getQuorumSignableHash,
+} from '../modules/validators/quorum'
 import type { ResolvedSessionSignerSet } from '../modules/validators/smart-sessions'
 import {
   type Execution,
@@ -1119,6 +1130,15 @@ async function signIntent(
   const ownerValidator = getOwnerValidator(config)
   const isRoot = validator.address === ownerValidator.address
 
+  if (
+    isRoot &&
+    config.owners?.type === 'quorum' &&
+    origin.length > 1 &&
+    (!signers || (signers.type === 'owner' && signers.kind === 'quorum'))
+  ) {
+    return signQuorumIntentOrigins(config, origin, validator, isRoot, signers)
+  }
+
   const originSignatures: OriginSignature[] = []
   for (const typedData of origin) {
     const chain = getChainById(typedData.domain?.chainId as number)
@@ -1159,6 +1179,65 @@ async function signIntent(
   return {
     originSignatures,
     destinationSignature,
+  }
+}
+
+async function signQuorumIntentOrigins(
+  config: RhinestoneConfig,
+  origins: TypedDataDefinition[],
+  validator: Module,
+  isRoot: boolean,
+  signers: SignerSet | undefined,
+) {
+  if (config.owners?.type !== 'quorum') {
+    throw new Error('Quorum owner configuration is missing')
+  }
+  const address = getAddress(config)
+  const account = getAccountProvider(config)
+  const chains = origins.map((typedData) =>
+    getChainById(typedData.domain?.chainId as number),
+  )
+  const quorumSigners = signers ?? convertOwnerSetToSignerSet(config.owners)
+  if (quorumSigners.type !== 'owner' || quorumSigners.kind !== 'quorum') {
+    throw new Error('Quorum owners require quorum signers')
+  }
+  const tree = buildQuorumMerkleTree(
+    origins.map((typedData, index) => {
+      const hash = hashTypedData(typedData)
+      const accountHash =
+        account.type === 'kernel' ? wrapKernelMessageHash(hash, address) : hash
+      return {
+        account: address,
+        digest: getQuorumSignableHash({
+          validator: validator.address,
+          chainId: chains[index].id,
+          account: address,
+          hash: accountHash,
+        }),
+      }
+    }),
+  )
+  const signatures = await signQuorumHash(
+    quorumSigners,
+    config.owners,
+    undefined,
+    getQuorumMerkleRootSignableHash({
+      validator: validator.address,
+      root: tree.root,
+    }),
+  )
+  const originSignatures = await Promise.all(
+    tree.operations.map((operation) =>
+      packEip1271Signature(
+        config,
+        encodeQuorumMerkleSignature({ operation, signatures }),
+        { address: validator.address, isRoot },
+      ),
+    ),
+  )
+  return {
+    originSignatures,
+    destinationSignature: originSignatures.at(-1) as Hex,
   }
 }
 
@@ -1622,7 +1701,7 @@ async function getValidatorAccount(
   // Owners
   const withOwner = signers.type === 'owner' ? signers : null
   if (withOwner) {
-    return getSmartAccount(config, publicClient, chain)
+    return getSmartAccount(config, publicClient, chain, withOwner)
   }
 
   const withGuardians = signers.type === 'guardians' ? signers : null
@@ -1649,6 +1728,9 @@ function getValidator(
     // ECDSA
     if (withOwner.kind === 'ecdsa') {
       // Use the configured owner validator (e.g., ENS) rather than forcing Ownable
+      return getOwnerValidator(config)
+    }
+    if (withOwner.kind === 'quorum') {
       return getOwnerValidator(config)
     }
     // Passkeys (WebAuthn)

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ import {
   signEnableSession as signEnableSessionInternal,
   WEBAUTHN_VALIDATOR_ADDRESS,
 } from './modules'
+import { getQuorumValidator } from './modules/validators/quorum'
 import {
   isSessionEnabled as isSessionEnabledInternal,
   type SessionDetails,
@@ -115,6 +116,8 @@ import type {
   Permit2ClaimPolicy,
   Policy,
   ProviderConfig,
+  QuorumOwner,
+  QuorumValidatorConfig,
   Recovery,
   RhinestoneAccountConfig,
   RhinestoneConfig,
@@ -227,6 +230,9 @@ async function createRhinestoneAccount(
   // Validate that owners field is provided for non-EOA accounts
   if (config.account?.type !== 'eoa' && !config.owners) {
     throw new OwnersFieldRequiredError()
+  }
+  if (config.owners?.type === 'quorum') {
+    getQuorumValidator(config.owners)
   }
 
   /**
@@ -478,6 +484,9 @@ async function createRhinestoneAccount(
    * @returns Account owners
    */
   function getOwners(chain: Chain) {
+    if (config.owners?.type === 'quorum') {
+      throw new Error('getOwners is not supported for Quorum validators')
+    }
     const accountType = getAccountProvider(config).type
     const account = getAddress()
     // For HCA, the module lives behind the factory (custom factories define
@@ -684,6 +693,8 @@ export type {
   PreparedTransactionData,
   PreparedUserOperationData,
   ProviderConfig,
+  QuorumOwner,
+  QuorumValidatorConfig,
   Recovery,
   RhinestoneAccount,
   RhinestoneAccountConfig,

--- a/src/modules/validators/core.ts
+++ b/src/modules/validators/core.ts
@@ -29,6 +29,7 @@ import type {
 
 import { MODULE_TYPE_ID_VALIDATOR, type Module } from '../common'
 import { compareHexValues } from './ordering'
+import { getQuorumMockSignature, getQuorumValidator } from './quorum'
 
 const SMART_SESSION_EMISSARY_ADDRESS_DEV: Address =
   '0x60731de80d78548875f8a67c4fec2a8660194e0c'
@@ -103,6 +104,8 @@ function getMockSignature(ownerSet: OwnerSet): Hex {
       const signatures = owners.map(() => ECDSA_MOCK_SIGNATURE as Hex)
       return concat(signatures)
     }
+    case 'quorum':
+      return getQuorumMockSignature(ownerSet)
     case 'passkey':
       return WEBAUTHN_MOCK_SIGNATURE
     case 'multi-factor': {
@@ -158,6 +161,8 @@ function getValidator(owners: OwnerSet) {
         owners.accounts.map((account) => account.address),
         owners.module,
       )
+    case 'quorum':
+      return getQuorumValidator(owners)
     case 'ens':
       // ENS validation is baked into the HCA account implementation, so the
       // module address is fixed (no override).

--- a/src/modules/validators/quorum.test.ts
+++ b/src/modules/validators/quorum.test.ts
@@ -1,0 +1,184 @@
+import { decodeAbiParameters, type Hex, zeroAddress } from 'viem'
+import { describe, expect, test } from 'vitest'
+import { accountA, accountB } from '../../../test/consts'
+import type { QuorumValidatorConfig } from '../../types'
+import {
+  buildQuorumMerkleTree,
+  encodeQuorumErc1271Signature,
+  encodeQuorumMerkleSignature,
+  encodeQuorumOwnerSignatures,
+  getQuorumMockSignature,
+  getQuorumValidator,
+} from './quorum'
+
+const moduleAddress = '0x0000000000000000000000000000000000000042'
+const signature = `0x${'11'.repeat(64)}1b` as const
+
+function config(
+  overrides: Partial<QuorumValidatorConfig> = {},
+): QuorumValidatorConfig {
+  return {
+    type: 'quorum',
+    module: moduleAddress,
+    owners: [{ account: accountA, weight: 1n }],
+    thresholdWeight: 1n,
+    ...overrides,
+  }
+}
+
+describe('Quorum validator encoding', () => {
+  test('encodes canonical installation data independently of owner order', () => {
+    const owners = [
+      { account: accountB, weight: 2n },
+      { account: accountA, weight: 1n },
+    ]
+    const validator = getQuorumValidator(
+      config({ owners, thresholdWeight: 2n }),
+    )
+    const reversed = getQuorumValidator(
+      config({ owners: [...owners].reverse(), thresholdWeight: 2n }),
+    )
+    const [thresholdWeight, decodedOwners] = decodeAbiParameters(
+      [
+        { type: 'uint256' },
+        {
+          type: 'tuple[]',
+          components: [
+            { name: 'addr', type: 'address' },
+            { name: 'weight', type: 'uint96' },
+          ],
+        },
+      ],
+      validator.initData,
+    )
+
+    expect(reversed.initData).toBe(validator.initData)
+    expect(thresholdWeight).toBe(2n)
+    expect(decodedOwners.map(({ addr }) => BigInt(addr))).toEqual(
+      [...decodedOwners.map(({ addr }) => BigInt(addr))].sort((a, b) =>
+        a < b ? -1 : 1,
+      ),
+    )
+  })
+
+  test('rejects malformed owner policies', () => {
+    expect(() => getQuorumValidator(config({ owners: [] }))).toThrow(
+      'owners length',
+    )
+    expect(() =>
+      getQuorumValidator(
+        config({
+          owners: [
+            { account: { ...accountA, address: zeroAddress }, weight: 1n },
+          ],
+        }),
+      ),
+    ).toThrow('zero address')
+    expect(() =>
+      getQuorumValidator(
+        config({
+          owners: [
+            { account: accountA, weight: 1n },
+            { account: accountA, weight: 1n },
+          ],
+        }),
+      ),
+    ).toThrow('Duplicate quorum owner')
+    expect(() =>
+      getQuorumValidator(
+        config({ owners: [{ account: accountA, weight: 0n }] }),
+      ),
+    ).toThrow('fit uint96')
+    expect(() =>
+      getQuorumValidator(
+        config({ owners: [{ account: accountA, weight: 1n << 96n }] }),
+      ),
+    ).toThrow('fit uint96')
+    expect(() => getQuorumValidator(config({ thresholdWeight: 2n }))).toThrow(
+      'total owner weight',
+    )
+  })
+
+  test('sorts selected signatures and enforces configured weight', () => {
+    const owners = [
+      { ownerId: 'b', signer: accountB.address, weight: 2n },
+      { ownerId: 'a', signer: accountA.address, weight: 1n },
+    ]
+    const encoded = encodeQuorumOwnerSignatures({
+      owners,
+      thresholdWeight: 3n,
+      signatures: [
+        { ownerId: 'b', signature },
+        { ownerId: 'a', signature },
+      ],
+    })
+    const firstAddress = `0x${encoded.slice(2, 42)}`
+
+    expect(BigInt(firstAddress)).toBeLessThan(
+      BigInt(`0x${encoded.slice(176, 216)}`),
+    )
+    expect(() =>
+      encodeQuorumOwnerSignatures({
+        owners,
+        thresholdWeight: 3n,
+        signatures: [{ ownerId: 'b', signature }],
+      }),
+    ).toThrow('Insufficient validator contribution weight')
+    expect(() =>
+      encodeQuorumOwnerSignatures({
+        owners,
+        thresholdWeight: 1n,
+        signatures: [
+          { ownerId: 'a', signature },
+          { ownerId: 'a', signature },
+        ],
+      }),
+    ).toThrow('Duplicate validator owner')
+  })
+
+  test('builds odd-sized trees and proof-bearing envelopes', () => {
+    expect(() =>
+      buildQuorumMerkleTree([
+        { account: accountA.address, digest: `0x${'11'.repeat(32)}` },
+      ]),
+    ).toThrow('at least two operations')
+
+    const tree = buildQuorumMerkleTree([
+      { account: accountA.address, digest: `0x${'11'.repeat(32)}` },
+      { account: accountA.address, digest: `0x${'22'.repeat(32)}` },
+      { account: accountA.address, digest: `0x${'33'.repeat(32)}` },
+    ])
+    const weightedSignatures = `0x${'44'.repeat(88)}` as Hex
+    const envelope = encodeQuorumMerkleSignature({
+      operation: tree.operations[0],
+      signatures: weightedSignatures,
+    })
+
+    expect(tree.operations[2].proof).toHaveLength(1)
+    expect(envelope.slice(0, 4)).toBe('0x02')
+    expect(envelope.endsWith(weightedSignatures.slice(2))).toBe(true)
+    expect(() =>
+      encodeQuorumMerkleSignature({
+        operation: { root: tree.root, proof: [] },
+        signatures: weightedSignatures,
+      }),
+    ).toThrow('between 1 and 32')
+  })
+
+  test('builds a maximum-cost regular mock signature', () => {
+    const mock = getQuorumMockSignature(
+      config({
+        owners: [
+          { account: accountA, weight: 1n },
+          { account: accountB, weight: 1n },
+        ],
+      }),
+    )
+
+    expect(mock.startsWith('0x00')).toBe(true)
+    expect(mock.length).toBe(2 + 2 + 2 * (40 + 4 + 130))
+    expect(() => encodeQuorumErc1271Signature({ signatures: '0x' })).toThrow(
+      'must not be empty',
+    )
+  })
+})

--- a/src/modules/validators/quorum.ts
+++ b/src/modules/validators/quorum.ts
@@ -1,0 +1,342 @@
+import {
+  type Address,
+  concat,
+  encodeAbiParameters,
+  type Hex,
+  hashTypedData,
+  keccak256,
+  size,
+  toHex,
+  zeroAddress,
+} from 'viem'
+import type { QuorumValidatorConfig } from '../../types'
+import type { Module } from '../common'
+import { MODULE_TYPE_ID_VALIDATOR } from '../common'
+import { compareHexValues } from './ordering'
+
+const MAX_QUORUM_OWNERS = 32
+const MAX_UINT96 = (1n << 96n) - 1n
+const MAX_SIGNATURE_LENGTH = 65_535
+const QUORUM_MOCK_SIGNATURE = `0x${'00'.repeat(64)}1b` as const
+const QUORUM_MESSAGE_TYPEHASH = keccak256(
+  toHex(
+    'WeightedOwnableValidatorMessage(address validator,uint256 chainId,address account,bytes32 hash)',
+  ),
+)
+
+interface QuorumSigningOwner {
+  readonly ownerId: string
+  readonly signer: Address
+  readonly weight: bigint
+}
+
+interface QuorumOwnerSignature {
+  readonly ownerId: string
+  readonly signature: Hex
+}
+
+interface QuorumMerkleProof {
+  readonly root: Hex
+  readonly proof: readonly Hex[]
+}
+
+interface QuorumMerkleOperation extends QuorumMerkleProof {
+  readonly account: Address
+  readonly digest: Hex
+  readonly leaf: Hex
+}
+
+function getQuorumSignableHash(input: {
+  readonly validator: Address
+  readonly chainId: number
+  readonly account: Address
+  readonly hash: Hex
+}): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        { type: 'bytes32' },
+        { type: 'address' },
+        { type: 'uint256' },
+        { type: 'address' },
+        { type: 'bytes32' },
+      ],
+      [
+        QUORUM_MESSAGE_TYPEHASH,
+        input.validator,
+        BigInt(input.chainId),
+        input.account,
+        input.hash,
+      ],
+    ),
+  )
+}
+
+function buildQuorumMerkleTree(
+  operations: readonly {
+    readonly account: Address
+    readonly digest: Hex
+  }[],
+): {
+  readonly root: Hex
+  readonly operations: readonly QuorumMerkleOperation[]
+} {
+  if (operations.length < 2) {
+    throw new Error('Quorum Merkle signing requires at least two operations')
+  }
+  const leaves = operations.map(({ account, digest }) =>
+    keccak256(
+      encodeAbiParameters(
+        [{ type: 'address' }, { type: 'bytes32' }],
+        [account, digest],
+      ),
+    ),
+  )
+  const layers: Hex[][] = [leaves]
+  while (layers.at(-1)!.length > 1) {
+    const current = layers.at(-1)!
+    const next: Hex[] = []
+    for (let index = 0; index < current.length; index += 2) {
+      next.push(
+        index + 1 < current.length
+          ? hashQuorumMerklePair(current[index], current[index + 1])
+          : current[index],
+      )
+    }
+    layers.push(next)
+  }
+  const root = layers.at(-1)![0]
+  return {
+    root,
+    operations: operations.map(({ account, digest }, leafIndex) => {
+      const proof: Hex[] = []
+      let index = leafIndex
+      for (const layer of layers.slice(0, -1)) {
+        const siblingIndex = index % 2 === 0 ? index + 1 : index - 1
+        if (siblingIndex < layer.length) proof.push(layer[siblingIndex])
+        index = Math.floor(index / 2)
+      }
+      return { account, digest, leaf: leaves[leafIndex], root, proof }
+    }),
+  }
+}
+
+function getQuorumMerkleRootSignableHash(input: {
+  readonly validator: Address
+  readonly root: Hex
+}): Hex {
+  return hashTypedData({
+    domain: {
+      name: 'Quorum Signer',
+      version: '1',
+      verifyingContract: input.validator,
+    },
+    types: {
+      WeightedMerkleRoot: [{ name: 'root', type: 'bytes32' }],
+    },
+    primaryType: 'WeightedMerkleRoot',
+    message: { root: input.root },
+  })
+}
+
+function getQuorumValidator(config: QuorumValidatorConfig): Module {
+  const owners = resolveOwners(config).sort((left, right) =>
+    compareHexValues(left.signer, right.signer),
+  )
+  validateQuorumConfig(owners, config.thresholdWeight)
+  return {
+    address: config.module,
+    initData: encodeAbiParameters(
+      [
+        { name: 'thresholdWeight', type: 'uint256' },
+        {
+          name: 'owners',
+          type: 'tuple[]',
+          components: [
+            { name: 'addr', type: 'address' },
+            { name: 'weight', type: 'uint96' },
+          ],
+        },
+      ],
+      [
+        config.thresholdWeight,
+        owners.map(({ signer, weight }) => ({ addr: signer, weight })),
+      ],
+    ),
+    deInitData: '0x',
+    additionalContext: '0x',
+    type: MODULE_TYPE_ID_VALIDATOR,
+  }
+}
+
+function encodeQuorumOwnerSignatures(input: {
+  readonly owners: readonly QuorumSigningOwner[]
+  readonly thresholdWeight: bigint
+  readonly signatures: readonly QuorumOwnerSignature[]
+}): Hex {
+  validateQuorumConfig(input.owners, input.thresholdWeight)
+  const configured = new Map(
+    input.owners.map((owner) => [owner.ownerId, owner]),
+  )
+  const contributions = new Map<string, Hex>()
+  for (const contribution of input.signatures) {
+    if (!configured.has(contribution.ownerId)) {
+      throw new Error(`Unknown validator owner ${contribution.ownerId}`)
+    }
+    if (contributions.has(contribution.ownerId)) {
+      throw new Error(`Duplicate validator owner ${contribution.ownerId}`)
+    }
+    contributions.set(contribution.ownerId, contribution.signature)
+  }
+  const selected = input.owners
+    .filter((owner) => contributions.has(owner.ownerId))
+    .sort((left, right) => compareHexValues(left.signer, right.signer))
+  const signedWeight = selected.reduce((sum, owner) => sum + owner.weight, 0n)
+  if (signedWeight < input.thresholdWeight) {
+    throw new Error(
+      `Insufficient validator contribution weight: required ${input.thresholdWeight}, received ${signedWeight}`,
+    )
+  }
+  return encodeQuorumEntries(
+    selected.map((owner) => ({
+      signer: owner.signer,
+      signature: contributions.get(owner.ownerId)!,
+    })),
+  )
+}
+
+function encodeQuorumErc1271Signature(input: {
+  readonly signatures: Hex
+}): Hex {
+  if (input.signatures === '0x') {
+    throw new Error('Quorum owner signatures must not be empty')
+  }
+  return concat(['0x00', input.signatures])
+}
+
+function encodeQuorumMerkleSignature(input: {
+  readonly operation: QuorumMerkleProof
+  readonly signatures: Hex
+}): Hex {
+  if (input.operation.proof.length < 1 || input.operation.proof.length > 32) {
+    throw new Error('Quorum Merkle proof length must be between 1 and 32')
+  }
+  if (input.signatures === '0x') {
+    throw new Error('Quorum Merkle signatures must not be empty')
+  }
+  return concat([
+    toHex(input.operation.proof.length, { size: 1 }),
+    input.operation.root,
+    ...input.operation.proof,
+    input.signatures,
+  ])
+}
+
+function getQuorumMockSignature(config: QuorumValidatorConfig): Hex {
+  const owners = resolveOwners(config)
+  validateQuorumConfig(owners, config.thresholdWeight)
+  return encodeQuorumErc1271Signature({
+    signatures: encodeQuorumEntries(
+      owners
+        .map(({ signer }) => ({ signer, signature: QUORUM_MOCK_SIGNATURE }))
+        .sort((left, right) => compareHexValues(left.signer, right.signer)),
+    ),
+  })
+}
+
+function getQuorumConfigOwners(
+  config: QuorumValidatorConfig,
+): QuorumSigningOwner[] {
+  return resolveOwners(config)
+}
+
+function encodeQuorumEntries(
+  entries: readonly { readonly signer: Address; readonly signature: Hex }[],
+): Hex {
+  if (entries.length === 0) {
+    throw new Error('Quorum signature must not be empty')
+  }
+  let previous: Address | undefined
+  const packed = entries.map(({ signer, signature }) => {
+    if (previous && compareHexValues(previous, signer) >= 0) {
+      throw new Error(
+        'Quorum signer addresses must be strictly sorted and unique',
+      )
+    }
+    previous = signer
+    const signatureLength = size(signature)
+    if (signatureLength > MAX_SIGNATURE_LENGTH) {
+      throw new Error(
+        `Quorum inner signature exceeds ${MAX_SIGNATURE_LENGTH} bytes`,
+      )
+    }
+    return concat([signer, toHex(signatureLength, { size: 2 }), signature])
+  })
+  return concat(packed)
+}
+
+function resolveOwners(config: QuorumValidatorConfig): QuorumSigningOwner[] {
+  return config.owners.map(({ account, weight }) => ({
+    ownerId: account.address.toLowerCase(),
+    signer: account.address,
+    weight,
+  }))
+}
+
+function validateQuorumConfig(
+  owners: readonly { readonly signer: Address; readonly weight: bigint }[],
+  thresholdWeight: bigint,
+): void {
+  if (owners.length < 1 || owners.length > MAX_QUORUM_OWNERS) {
+    throw new Error(
+      `Quorum owners length must be between 1 and ${MAX_QUORUM_OWNERS}`,
+    )
+  }
+  const seen = new Set<string>()
+  let totalWeight = 0n
+  for (const [index, owner] of owners.entries()) {
+    const signer = owner.signer.toLowerCase()
+    if (signer === zeroAddress) {
+      throw new Error(`Quorum owner ${index} cannot be the zero address`)
+    }
+    if (seen.has(signer)) {
+      throw new Error(`Duplicate quorum owner ${owner.signer}`)
+    }
+    seen.add(signer)
+    if (owner.weight <= 0n || owner.weight > MAX_UINT96) {
+      throw new Error(
+        `Quorum owner ${owner.signer} weight must fit uint96 and be non-zero`,
+      )
+    }
+    totalWeight += owner.weight
+  }
+  if (thresholdWeight <= 0n || thresholdWeight > totalWeight) {
+    throw new Error(
+      `Quorum threshold weight must be between 1 and total owner weight ${totalWeight}`,
+    )
+  }
+}
+
+function hashQuorumMerklePair(left: Hex, right: Hex): Hex {
+  return compareHexValues(left, right) < 0
+    ? keccak256(concat([left, right]))
+    : keccak256(concat([right, left]))
+}
+
+export {
+  buildQuorumMerkleTree,
+  encodeQuorumErc1271Signature,
+  encodeQuorumMerkleSignature,
+  encodeQuorumOwnerSignatures,
+  getQuorumConfigOwners,
+  getQuorumMerkleRootSignableHash,
+  getQuorumMockSignature,
+  getQuorumSignableHash,
+  getQuorumValidator,
+}
+export type {
+  QuorumMerkleOperation,
+  QuorumMerkleProof,
+  QuorumOwnerSignature,
+  QuorumSigningOwner,
+}

--- a/src/package.json
+++ b/src/package.json
@@ -50,6 +50,11 @@
       "import": "./dist/src/accounts/signing/passkeys.js",
       "require": "./dist/src/accounts/signing/passkeys.js"
     },
+    "./signing/quorum": {
+      "types": "./dist/src/accounts/signing/quorum.d.ts",
+      "import": "./dist/src/accounts/signing/quorum.js",
+      "require": "./dist/src/accounts/signing/quorum.js"
+    },
     "./actions/smart-sessions": {
       "types": "./dist/src/actions/smart-sessions.d.ts",
       "import": "./dist/src/actions/smart-sessions.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,25 @@ interface OwnableValidatorConfig {
   module?: Address
 }
 
+/** One Quorum Signer owner and its non-zero voting weight. */
+interface QuorumOwner {
+  /** Viem account used to sign this owner's raw operation digest. */
+  account: Account
+  /** Weight contributed by a valid signature from this owner. */
+  weight: bigint
+}
+
+/** Configure a weighted Quorum Signer validator deployed at `module`. */
+interface QuorumValidatorConfig {
+  type: 'quorum'
+  /** Weighted EOA or EIP-1271 owners. The SDK can sign configured EOA accounts. */
+  owners: QuorumOwner[]
+  /** Minimum combined owner weight required to authorize an operation. */
+  thresholdWeight: bigint
+  /** Deployed Quorum Signer validator address shared by the account's chains. */
+  module: Address
+}
+
 interface ENSValidatorConfig {
   type: 'ens'
   accounts: Account[]
@@ -136,6 +155,7 @@ type PaymasterConfig =
 
 type OwnerSet =
   | OwnableValidatorConfig
+  | QuorumValidatorConfig
   | ENSValidatorConfig
   | WebauthnValidatorConfig
   | MultiFactorValidatorConfig
@@ -460,6 +480,11 @@ type OwnerSignerSet =
     }
   | {
       type: 'owner'
+      kind: 'quorum'
+      accounts: Account[]
+    }
+  | {
+      type: 'owner'
       kind: 'passkey'
       accounts: WebAuthnAccount[]
       module?: Address
@@ -623,6 +648,8 @@ export type {
   Permit2ClaimPolicy,
   Policy,
   ProviderConfig,
+  QuorumOwner,
+  QuorumValidatorConfig,
   ScopedAction,
   Recovery,
   RhinestoneAccountConfig,


### PR DESCRIPTION
- Add weighted Quorum owner configuration, canonical validator installation data, and maximum-cost stub signatures.
- Support raw-hash UserOperation signing, account-bound ERC-1271 signatures, and single-root multi-origin Merkle signing.
- Expose headless helpers from `@rhinestone/sdk/signing/quorum` and cover validator, account, signer-selection, and intent behavior.

[skip-linear]

Companion: https://github.com/rhinestonewtf/sdk/pull/782