### PR TITLE
feat(chains): support Stellar as a destination chain

### DIFF
--- a/.changeset/stellar-destination.md
+++ b/.changeset/stellar-destination.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Support Stellar as a destination chain through the new `stellarMainnet` descriptor, so `targetChain: stellarMainnet` addresses `stellar:pubnet` the way `solanaMainnet` and `tronMainnet` already do. Recipients are `G…` account strkeys and token requests take the asset's Soroban contract (`C…`), both passed through unchanged for the orchestrator to validate.

--- a/src/chains/caip2.test.ts
+++ b/src/chains/caip2.test.ts
@@ -9,6 +9,13 @@ import {
   parseCaip2,
   toEvmChainReference,
 } from './caip2'
+import {
+  hyperCorePerp,
+  hyperCoreSpot,
+  solanaMainnet,
+  stellarMainnet,
+  tronMainnet,
+} from './non-evm'
 
 describe('CAIP-2', () => {
   test.each([
@@ -16,6 +23,7 @@ describe('CAIP-2', () => {
     [8453, 'eip155:8453'],
     [792703809, 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
     [728126428, 'tron:mainnet'],
+    [1500148, 'stellar:pubnet'],
     [1337, 'hypercore:mainnet'],
     [1337001, 'hypercore:spot'],
     [1337002, 'hypercore:perp'],
@@ -49,6 +57,40 @@ describe('CAIP-2', () => {
       // `toEvmChainReference` has to let through rather than reject.
       expect(toEvmChainReference(id).caip2).toBe(caip2)
     }
+  })
+
+  // Stellar recipients are `G…` accounts while its token addresses are `C…`
+  // Soroban contracts, so nothing here may lean on a single address shape. The
+  // one thing the SDK must get right is that the chain is genuinely non-EVM:
+  // `isNonEvmChainId` is what routes a bare strkey recipient through unchanged
+  // instead of demanding a hex `Address`.
+  test('treats Stellar as a non-EVM destination', () => {
+    const reference = parseCaip2('stellar:pubnet')
+    expect(reference.kind).toBe('non-evm')
+    expect(reference).toMatchObject({
+      namespace: 'stellar',
+      reference: 'pubnet',
+    })
+    expect(isNonEvmChainId(1500148)).toBe(true)
+    expect(isEvmCaip2('stellar:pubnet')).toBe(false)
+    expect(() => toEvmChainReference(1500148)).toThrow('not EVM-compatible')
+  })
+
+  // A descriptor is only as good as its wire-table entry: without one,
+  // `parseCaip2(chain.caip2)` throws and `targetChain: <descriptor>` fails at
+  // the first hop, while the descriptor itself still typechecks. Generic over
+  // the exported set so the next chain cannot ship half-wired.
+  test.each([
+    ['solanaMainnet', solanaMainnet],
+    ['tronMainnet', tronMainnet],
+    ['stellarMainnet', stellarMainnet],
+    ['hyperCoreSpot', hyperCoreSpot],
+    ['hyperCorePerp', hyperCorePerp],
+  ])('addresses the destination %s names', (_name, chain) => {
+    expect(isCaip2(chain.caip2)).toBe(true)
+    expect(formatCaip2(chainIdFromReference(parseCaip2(chain.caip2)))).toBe(
+      chain.caip2,
+    )
   })
 
   test('rejects malformed and unknown values', () => {

--- a/src/chains/caip2.ts
+++ b/src/chains/caip2.ts
@@ -28,6 +28,7 @@ const NON_EVM_CHAINS = [
     caip2: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
     nonEvm: true,
   },
+  { id: 1500148, caip2: 'stellar:pubnet', nonEvm: true },
 ] as const satisfies ReadonlyArray<{
   id: number
   caip2: string
@@ -125,7 +126,7 @@ export function isEvmCaip2(value: string): value is `eip155:${number}` {
   return evmPattern.test(value)
 }
 
-// True when a numeric chain id is genuinely non-EVM (Solana / Tron). Every
+// True when a numeric chain id is genuinely non-EVM (Solana / Tron / Stellar). Every
 // HyperCore id is EVM-settled, so this is `false` for all of them even though
 // their wire ids are in the non-`eip155` `hypercore:` namespace.
 export function isNonEvmChainId(chainId: number): boolean {

--- a/src/chains/non-evm.ts
+++ b/src/chains/non-evm.ts
@@ -1,5 +1,6 @@
 // Public destination chain descriptors for destinations that aren't a plain
-// viem `Chain`: the non-EVM chains (Solana, Tron) plus HyperCore (an EVM-settled
+// viem `Chain`: the non-EVM chains (Solana, Tron, Stellar) plus HyperCore (an
+// EVM-settled
 // virtual L1). Mirrors the minimal shape of viem's `Chain` (name,
 // nativeCurrency) so callers can pass them anywhere a destination chain is
 // expected — `targetChain: solanaMainnet` reads the same as `targetChain:
@@ -15,6 +16,7 @@ import type { Chain } from 'viem'
 type EvmCaip2ChainId = `eip155:${number}`
 type SolanaCaip2ChainId = `solana:${string}`
 type TronCaip2ChainId = `tron:${string}`
+type StellarCaip2ChainId = `stellar:${string}`
 // One id per HyperCore delivery venue — the venue is the destination, not a
 // flag on the token request (RHI-5510).
 type HyperCoreCaip2ChainId = 'hypercore:spot' | 'hypercore:perp'
@@ -22,6 +24,7 @@ type Caip2ChainId =
   | EvmCaip2ChainId
   | SolanaCaip2ChainId
   | TronCaip2ChainId
+  | StellarCaip2ChainId
   | HyperCoreCaip2ChainId
 
 interface NativeCurrency {
@@ -30,19 +33,20 @@ interface NativeCurrency {
   readonly decimals: number
 }
 
-// Non-EVM (Solana base58 / Tron T-prefix) addresses don't satisfy viem's
-// `Address` template literal. Typed as bare `string` since the shape is
-// chain-namespace specific; the orchestrator validates the format against
-// the destination's CAIP-2 namespace.
+// Non-EVM (Solana base58 / Tron T-prefix / Stellar base32 strkey) addresses
+// don't satisfy viem's `Address` template literal. Typed as bare `string` since
+// the shape is chain-namespace specific; the orchestrator validates the format
+// against the destination's CAIP-2 namespace.
 type NonEvmAddress = string
 
 interface NonEvmChain {
   readonly name: string
   readonly caip2: Caip2ChainId
-  // 'svm' (Solana) / 'tvm' (Tron) are non-EVM VMs; 'hypercore' is an EVM-settled
-  // virtual L1. All three are solver-mediated destinations with no user-signed
-  // destination session.
-  readonly kind: 'svm' | 'tvm' | 'hypercore'
+  // 'svm' (Solana) / 'tvm' (Tron) / 'stellar' are non-EVM VMs; 'hypercore' is an
+  // EVM-settled virtual L1. All are solver-mediated destinations with no
+  // user-signed destination session. Names match the `vmType` the chain facts
+  // publish, so a chain's descriptor and its registry entry read the same.
+  readonly kind: 'svm' | 'tvm' | 'stellar' | 'hypercore'
   readonly nativeCurrency: NativeCurrency
   readonly testnet?: boolean
 }
@@ -61,6 +65,16 @@ const tronMainnet: NonEvmChain = {
   caip2: 'tron:mainnet',
   kind: 'tvm',
   nativeCurrency: { name: 'Tron', symbol: 'TRX', decimals: 6 },
+}
+
+// Stellar addresses classic assets through Soroban contracts, so a token
+// request carries the asset's Stellar Asset Contract (a `C…` strkey) while the
+// recipient is an account (`G…`) — two different shapes in the same namespace.
+const stellarMainnet: NonEvmChain = {
+  name: 'Stellar',
+  caip2: 'stellar:pubnet',
+  kind: 'stellar',
+  nativeCurrency: { name: 'Lumen', symbol: 'XLM', decimals: 7 },
 }
 
 // A HyperCore deposit credits one of two accounts that are not
@@ -85,4 +99,10 @@ const hyperCorePerp: NonEvmChain = {
 }
 
 export type { DestinationChain, NativeCurrency, NonEvmAddress, NonEvmChain }
-export { hyperCorePerp, hyperCoreSpot, solanaMainnet, tronMainnet }
+export {
+  hyperCorePerp,
+  hyperCoreSpot,
+  solanaMainnet,
+  stellarMainnet,
+  tronMainnet,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   hyperCorePerp,
   hyperCoreSpot,
   solanaMainnet,
+  stellarMainnet,
   tronMainnet,
 } from './chains/non-evm'
 import {
@@ -15,10 +16,11 @@ import { WEBAUTHN_VALIDATOR_ADDRESS } from './modules/validators/webauthn'
 
 export {
   RhinestoneSDK,
-  // Non-viem destination chain descriptors (Solana, Tron, HyperCore)
+  // Non-viem destination chain descriptors (Solana, Tron, Stellar, HyperCore)
   hyperCorePerp,
   hyperCoreSpot,
   solanaMainnet,
+  stellarMainnet,
   tronMainnet,
   // Validator addresses
   OWNABLE_VALIDATOR_ADDRESS,

--- a/test/types/public-boundary.ts
+++ b/test/types/public-boundary.ts
@@ -25,6 +25,7 @@ import {
   type SignedIntentData,
   type SignedTransactionData,
   type SignerSet,
+  stellarMainnet,
   type Transaction,
   tronMainnet,
   type UserOperationResult,
@@ -134,6 +135,22 @@ const crossChainNonEvmWithDeadline = {
   customDeadline: 9_999_999_999,
 } as const satisfies Transaction
 
+// Stellar is the case where recipient and token addresses are different
+// shapes in the same namespace: a `G…` account receives an asset named by its
+// `C…` Soroban contract. Neither is hex, so this only compiles while both
+// fields stay widened past viem's `Address`.
+const stellarDelivery = {
+  sourceChains: [mainnet],
+  targetChain: stellarMainnet,
+  tokenRequests: [
+    {
+      address: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75',
+      amount: 1_000_000n,
+    },
+  ],
+  recipient: 'GA2227KIWUQ4WBKNLR53PUFJFX6G5ERZQFMAQWS3FBERXB7QNUEOLCMO',
+} as const satisfies Transaction
+
 // RHI-5510: the delivery venue is the destination, so a caller addresses it by
 // picking a chain. There is no venue field to forget, and no way to express a
 // HyperCore delivery without stating which account it credits — both venues
@@ -215,6 +232,7 @@ void sameChainTransaction
 void registryFreeMfaConfig
 void crossChainWithDeadline
 void crossChainNonEvmWithDeadline
+void stellarDelivery
 void hyperCoreSpotDelivery
 void hyperCorePerpDelivery
 void sponsorLimitKey


### PR DESCRIPTION
Part of RHI-6337.

`parseCaip2('stellar:pubnet')` threw and `isCaip2` returned false, so no caller could target Stellar — while the orchestrator quotes and fills it today. That made the chain unreachable through the SDK regardless of what the backend supports.

`NON_EVM_CHAINS` in `chains/caip2.ts` is the only place a non-EVM chain has to be declared: everything downstream keys off `kind === 'non-evm'` rather than the namespace, so the entry plus a `stellarMainnet` descriptor is the whole change. Recipients (`G…` account strkeys) and token addresses (`C…` Soroban contracts) are different shapes in the same namespace, and both already pass through `normalizeTokenAddress` / `projectIntentRecipient` unchanged for the orchestrator to validate.

The new coherence test is the one worth keeping: a descriptor whose `caip2` has no table entry still typechecks and fails at the first hop instead, so it iterates the exported set rather than naming Stellar.

Verified end to end against the dev orchestrator with the built package: `targetChain: stellarMainnet` delivered 0.5 USDC from Plasma USDT0 via RHINO in 46s — origin `0x21c741d4de78205711f169715c3d249a45128fb149512484cd799d8a805c4726` on 9745, destination `6571984cf078f5987295f8a1c8dda5d3714b2f2c53bfbc707e026ed8a3c4453a` on Stellar, recipient credited on Horizon.
