### PR TITLE
release: map the LZ bridge fill (2.9.0)

### DIFF
--- a/.changeset/lz-bridge-fill.md
+++ b/.changeset/lz-bridge-fill.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Map the `LZ` bridge fill the orchestrator now returns for the LayerZero Value Transfer settlement layer, exposing `quoteId`, `dstChainKey` and `routeTypes` on `Quote.bridgeFill`, and accept `'LZ'` in the `settlementLayers` include/exclude filter.
+
+A bridge fill whose type this SDK version predates no longer throws. It is a delivery-tracking handle rather than part of the signed intent, so an unrecognised one now leaves the route untracked — the same shape as a settlement layer that publishes no handle at all — instead of failing the whole quote.

--- a/src/clients/orchestrator/client.test.ts
+++ b/src/clients/orchestrator/client.test.ts
@@ -252,6 +252,87 @@ describe('orchestrator client', () => {
     expect(extension).toHaveBeenCalledWith(serializedIntentInput)
   })
 
+  test('maps the LZ handle and keeps a route the SDK predates untracked', async () => {
+    const route = (
+      intentId: string,
+      settlementLayer: string,
+      bridgeFill: unknown,
+    ) => ({
+      intentId,
+      expiresAt: 1,
+      estimatedFillTime: { seconds: 2 },
+      settlementLayer,
+      signData: {
+        origin: [],
+        destination: {
+          domain: {},
+          types: {},
+          primaryType: 'Test',
+          message: {},
+        },
+      },
+      cost: {
+        input: [],
+        output: [],
+        fees: {
+          total: { usd: 0 },
+          breakdown: {
+            gas: { usd: 0, sponsored: false },
+            bridge: { usd: 0, sponsored: false },
+            swap: { usd: 0, sponsored: false },
+            app: { usd: 0, sponsored: false },
+            protocol: { usd: 0, sponsored: false },
+            sponsorSurcharge: { usd: 0, sponsored: false },
+          },
+        },
+      },
+      bridgeFill,
+    })
+    const client = createOrchestratorClient({
+      url: 'https://orchestrator.example',
+      auth: createOrchestratorAuth({ kind: 'api-key', apiKey: 'secret' }),
+      fetch: async () =>
+        Response.json({
+          routes: [
+            route('intent-lz', 'LZ', {
+              type: 'LZ',
+              destinationChainId: 8453,
+              quoteId: 'quote-1',
+              dstChainKey: 'base',
+              routeTypes: ['STARGATE_V2_TAXI', 'CCTP_V2'],
+              fillExpirationPeriod: 60,
+              fillStatusTimeout: 30,
+            }),
+            route('intent-future', 'FUTURE', {
+              type: 'FUTURE',
+              destinationChainId: 8453,
+              someHandle: 'handle-1',
+              fillStatusTimeout: 30,
+            }),
+          ],
+        }),
+    })
+
+    const result = await client.createQuote({
+      account: { address, accountType: 'ERC7579' },
+      destinationChainId: 8453,
+      destinationExecutions: [],
+      tokenRequests: [],
+      options: {},
+    })
+
+    expect(result.routes[0]?.bridgeFill).toEqual({
+      type: 'LZ',
+      destinationChainId: 8453,
+      quoteId: 'quote-1',
+      dstChainKey: 'base',
+      routeTypes: ['STARGATE_V2_TAXI', 'CCTP_V2'],
+    })
+    // An unknown layer costs the tracking handle, never the quote.
+    expect(result.routes[1]?.intentId).toBe('intent-future')
+    expect(result.routes[1]).not.toHaveProperty('bridgeFill')
+  })
+
   test('maps error envelope metadata', async () => {
     const client = createOrchestratorClient({
       url: 'https://orchestrator.example',

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -206,9 +206,7 @@ function mapQuoteFromWire(value: WireQuote): OrchestratorQuote {
             value.tokenRequirements,
           ),
         }),
-    ...(value.bridgeFill === undefined
-      ? {}
-      : { bridgeFill: mapBridgeFillFromWire(value.bridgeFill) }),
+    ...mapBridgeFillFromWire(value.bridgeFill),
   }
 }
 
@@ -249,50 +247,75 @@ function mapTokenRequirementsFromWire(
   ) as TokenRequirements
 }
 
-function mapBridgeFillFromWire(
-  value: NonNullable<WireQuote['bridgeFill']>,
-): BridgeFill {
+// A bridge fill is a delivery-tracking handle, not part of what the user signs,
+// so a type this SDK version predates must not fail the whole quote. Returning
+// a key-or-nothing spread leaves an unknown layer as an untracked route, the
+// same shape a layer that publishes no handle already produces.
+function mapBridgeFillFromWire(value: WireQuote['bridgeFill']): {
+  bridgeFill?: BridgeFill
+} {
+  if (value === undefined) return {}
   switch (value.type) {
     case 'OFT':
       return {
-        type: 'OFT',
-        destinationChainId: value.destinationChainId,
+        bridgeFill: {
+          type: 'OFT',
+          destinationChainId: value.destinationChainId,
+        },
       }
     case 'ECO':
       return {
-        type: 'ECO',
-        destinationChainId: value.destinationChainId,
-        intentHash: value.intentHash as Hex,
+        bridgeFill: {
+          type: 'ECO',
+          destinationChainId: value.destinationChainId,
+          intentHash: value.intentHash as Hex,
+        },
       }
     case 'RELAY':
       return {
-        type: 'RELAY',
-        destinationChainId: value.destinationChainId,
-        requestId: value.requestId,
+        bridgeFill: {
+          type: 'RELAY',
+          destinationChainId: value.destinationChainId,
+          requestId: value.requestId,
+        },
       }
     case 'NEAR':
       return {
-        type: 'NEAR',
-        destinationChainId: value.destinationChainId,
-        depositAddress: value.depositAddress as Address,
+        bridgeFill: {
+          type: 'NEAR',
+          destinationChainId: value.destinationChainId,
+          depositAddress: value.depositAddress as Address,
+        },
       }
     case 'RHINO':
       return {
-        type: 'RHINO',
-        destinationChainId: value.destinationChainId,
-        commitmentId: value.commitmentId,
+        bridgeFill: {
+          type: 'RHINO',
+          destinationChainId: value.destinationChainId,
+          commitmentId: value.commitmentId,
+        },
       }
     case 'CCTP':
       return {
-        type: 'CCTP',
-        destinationChainId: value.destinationChainId,
-        sourceDomainId: value.sourceDomainId,
-        destinationDomainId: value.destinationDomainId,
+        bridgeFill: {
+          type: 'CCTP',
+          destinationChainId: value.destinationChainId,
+          sourceDomainId: value.sourceDomainId,
+          destinationDomainId: value.destinationDomainId,
+        },
+      }
+    case 'LZ':
+      return {
+        bridgeFill: {
+          type: 'LZ',
+          destinationChainId: value.destinationChainId,
+          quoteId: value.quoteId,
+          dstChainKey: value.dstChainKey,
+          routeTypes: [...value.routeTypes],
+        },
       }
     default:
-      throw new Error(
-        `Unsupported bridge fill type from orchestrator: ${String((value as { readonly type?: unknown }).type)}`,
-      )
+      return {}
   }
 }
 

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -20,6 +20,7 @@ type CrossChainSettlementLayer =
   | 'NEAR'
   | 'RHINO'
   | 'CCTP'
+  | 'LZ'
 
 type SupportedTokenSymbol = 'ETH' | 'WETH' | 'USDC' | 'USDT' | 'USDT0'
 type SupportedToken = SupportedTokenSymbol | Address
@@ -323,6 +324,13 @@ type BridgeFill =
       destinationChainId: number
       sourceDomainId: number
       destinationDomainId: number
+    }
+  | {
+      type: 'LZ'
+      destinationChainId: number
+      quoteId: string
+      dstChainKey: string
+      routeTypes: string[]
     }
 
 interface Quote {

--- a/src/clients/orchestrator/wire.ts
+++ b/src/clients/orchestrator/wire.ts
@@ -40,14 +40,25 @@ type EcoBridgeFill = {
   readonly intentHash: string
 }
 
-// The ECO solver-network variant is already part of the orchestrator feature
-// branch but not yet in the pinned, published OpenAPI document. Keep the HTTP
-// boundary truthful during that rollout; the next generated-wire sync will add
-// the structurally identical variant to GeneratedWireQuote.
+type LzBridgeFill = {
+  readonly destinationChainId: number
+  readonly fillExpirationPeriod?: number
+  readonly fillStatusTimeout: number
+  readonly type: 'LZ'
+  readonly quoteId: string
+  readonly dstChainKey: string
+  readonly routeTypes: readonly string[]
+}
+
+// The ECO and LZ variants are already served by the orchestrator but not yet in
+// the pinned, published OpenAPI document. Keep the HTTP boundary truthful during
+// that rollout; the next generated-wire sync will add the structurally identical
+// variants to GeneratedWireQuote.
 export type WireQuote = Omit<GeneratedWireQuote, 'bridgeFill'> & {
   readonly bridgeFill?:
     | NonNullable<GeneratedWireQuote['bridgeFill']>
     | EcoBridgeFill
+    | LzBridgeFill
 }
 export type WireQuoteResponse = Omit<GeneratedWireQuoteResponse, 'routes'> & {
   readonly routes: readonly WireQuote[]


### PR DESCRIPTION
Promotes #829 so the LZ bridge-fill fix reaches npm.

The orchestrator on prod returns `bridgeFill: { type: 'LZ', … }`; every published SDK throws on it and fails the whole quote, which took the deposit path down. The layer is currently held off with the `settlement-layer: LZ` kill switch, and this release is what lets the switch come back off.

Consumers on `latest` (2.8.0) need the bump — `deposit-service-processor` pins it exactly.

The Stellar changeset already sitting on `main` is a leftover: `release` consumed it and shipped it as 2.8.0, and the merge takes `release`'s deletion, so this bundles nothing but the LZ fix.
