### PR TITLE
refactor(hypercore): build an order from a ticker, in one call

### DIFF
--- a/.changeset/hypercore-trading-actions.md
+++ b/.changeset/hypercore-trading-actions.md
@@ -4,9 +4,9 @@
 
 Support HyperCore trading from an intent. A transaction to `hyperCorePerp` or `hyperCoreSpot` now takes a `hyperCore.action`, and a new `@rhinestone/sdk/hypercore` subpath builds it.
 
-- `openPerp` and `closePerp` build a marketable IOC order from a market and a size, resolving Hyperliquid's asset index and rounding the price and size onto its grids.
-- `getPerpMarket`, `getPerpMarkets`, `getPerpPosition`, and `getPerpPositions` read Hyperliquid's public info endpoint.
+- `openPerp({ asset, direction, notionalUsd })` and `closePerp({ asset, account })` build a marketable IOC order in one call, resolving Hyperliquid's asset index, mark and open position, and rounding the price and size onto its grids.
+- `getPerpMarket`, `getPerpMarkets`, `getPerpPosition`, and `getPerpPositions` read Hyperliquid's public info endpoint, for the questions asked before building an order: which markets exist, what leverage one allows, whether there is a position to close.
 - `HyperCoreAction` types all seven Hyperliquid L1 actions — `order`, `cancel`, `cancelByCloid`, `modify`, `batchModify`, `updateLeverage`, `updateIsolatedMargin` — for anything the builders do not cover.
-- `HyperCoreError`, `UnknownPerpAssetError`, `PerpOrderTooSmallError`, `MismatchedPerpAssetError`, and `HyperCoreInfoRequestError` are exported from `/errors` with an `isHyperCoreError` guard.
+- `HyperCoreError`, `UnknownPerpAssetError`, `PerpOrderTooSmallError`, `NoOpenPerpPositionError`, and `HyperCoreInfoRequestError` are exported from `/errors` with an `isHyperCoreError` guard.
 
 An action that needs collateral pairs with `tokenRequests` that deliver it; a close, cancel, or leverage change rides a transaction that requests no tokens.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,11 @@ enforced by `scripts/architecture/check.ts`:
   injected at `api/compose.ts`.
 - **`hypercore/`** — a published subpath (`@rhinestone/sdk/hypercore`) that
   builds the Hyperliquid actions an intent carries in `hyperCore.action`. The
-  order builders are pure; the market reads are the only place the SDK talks to
-  a service other than Rhinestone's own, and they take an injectable `fetch`
-  rather than a composed client because nothing else in the SDK depends on them.
+  builders name an asset by ticker and read Hyperliquid's public `info` endpoint
+  themselves for the index, grids and mark an order needs; that read is the only
+  place the SDK talks to a service other than Rhinestone's own, and it takes an
+  injectable `fetch` rather than a composed client because nothing else in the
+  SDK depends on it.
 - **`actions/`, `errors/`, `utils/`, `smart-sessions/`, `jwt-server/`** —
   published subpath surfaces. `actions/` are standalone builders; the rest are
   compatibility barrels re-exporting owning symbols, except `jwt-server/`, a

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -52,7 +52,7 @@ import {
   HyperCoreError,
   HyperCoreInfoRequestError,
   isHyperCoreError,
-  MismatchedPerpAssetError,
+  NoOpenPerpPositionError,
   PerpOrderTooSmallError,
   UnknownPerpAssetError,
 } from '../hypercore/errors'
@@ -141,7 +141,7 @@ export {
   isHyperCoreError,
   HyperCoreError,
   HyperCoreInfoRequestError,
-  MismatchedPerpAssetError,
+  NoOpenPerpPositionError,
   PerpOrderTooSmallError,
   UnknownPerpAssetError,
 }

--- a/src/hypercore/errors.ts
+++ b/src/hypercore/errors.ts
@@ -46,17 +46,17 @@ export class PerpOrderTooSmallError extends HyperCoreError {
   }
 }
 
-/** `closePerp` was given a market and a position for different assets. */
-export class MismatchedPerpAssetError extends HyperCoreError {
-  readonly marketAsset: string
-  readonly positionAsset: string
+/** There is nothing to close: the account holds no position on that asset. */
+export class NoOpenPerpPositionError extends HyperCoreError {
+  readonly asset: string
+  readonly account: string
 
-  constructor(marketAsset: string, positionAsset: string) {
+  constructor(asset: string, account: string) {
     super(
-      `Cannot close a ${positionAsset} position against the ${marketAsset} market. Pass the market for the position's own asset — an order carries the market's asset index, so a mismatch trades the wrong coin.`,
+      `${account} holds no open ${asset} position to close. Check with \`getPerpPosition\` before offering a close — a reduce-only order against nothing is rejected by the exchange.`,
     )
-    this.marketAsset = marketAsset
-    this.positionAsset = positionAsset
+    this.asset = asset
+    this.account = account
   }
 }
 

--- a/src/hypercore/market.ts
+++ b/src/hypercore/market.ts
@@ -2,9 +2,9 @@
 // needs and cannot be derived: the asset INDEX an order carries, the size
 // precision it must round to, and the mark to price against.
 //
-// Separate from the order builders on purpose. The mark is a snapshot, and the
-// limit price built from it is fixed when the intent is signed, so the read is
-// the caller's to place and to repeat.
+// `openPerp` and `closePerp` do these reads themselves. What is exported here is
+// for the questions a caller asks BEFORE building an order: which markets exist,
+// what leverage one allows, whether there is a position to close at all.
 
 import type { Address } from 'viem'
 import { HyperCoreInfoRequestError, UnknownPerpAssetError } from './errors'
@@ -135,10 +135,9 @@ async function getPerpMarkets(
 /**
  * Read one Hyperliquid perpetual market by ticker.
  *
- * The result is what {@link openPerp} and {@link closePerp} price and size
- * against, so read it immediately before building the action: `markPx` is a
- * snapshot, and the limit price derived from it is fixed once the intent is
- * signed.
+ * {@link openPerp} does this read itself, so reach for this when you need the
+ * market's own facts — its mark to quote a size against, or its `maxLeverage`
+ * before offering one.
  *
  * @param asset ticker as Hyperliquid names it — the coin alone, e.g. `BTC`
  * @param options where to reach Hyperliquid's info endpoint
@@ -146,6 +145,7 @@ async function getPerpMarkets(
  * @throws {UnknownPerpAssetError} if no tradeable market carries that ticker
  * @example
  * const market = await getPerpMarket('BTC')
+ * const maxNotional = Number(market.markPx) * market.maxLeverage
  * @see {@link openPerp}
  */
 async function getPerpMarket(
@@ -192,6 +192,9 @@ async function getPerpPositions(
 /**
  * Read an account's open position on one Hyperliquid perpetual market.
  *
+ * {@link closePerp} does this read itself and throws when there is nothing to
+ * close, so this is the check to make before offering a close at all.
+ *
  * @param account the account holding the position
  * @param asset ticker as Hyperliquid names it, e.g. `BTC`
  * @param options where to reach Hyperliquid's info endpoint
@@ -199,7 +202,7 @@ async function getPerpPositions(
  * @example
  * const position = await getPerpPosition(account.getAddress(), 'BTC')
  * if (position) {
- *   const action = closePerp({ market, position })
+ *   // offer a close
  * }
  * @see {@link closePerp}
  */

--- a/src/hypercore/orders.test.ts
+++ b/src/hypercore/orders.test.ts
@@ -2,103 +2,135 @@ import fc from 'fast-check'
 import { describe, expect, test } from 'vitest'
 import {
   HyperCoreError,
-  MismatchedPerpAssetError,
+  NoOpenPerpPositionError,
   PerpOrderTooSmallError,
+  UnknownPerpAssetError,
 } from './errors'
-import type { PerpMarket, PerpPosition } from './market'
+import type { HyperCoreInfoOptions } from './market'
 import { closePerp, formatPerpPrice, formatPerpSize, openPerp } from './orders'
+
+const ACCOUNT = '0x1111111111111111111111111111111111111111' as const
+
+interface StubMarket {
+  name: string
+  szDecimals: number
+  maxLeverage: number
+  markPx: string
+}
 
 // szDecimals 5 leaves a price one decimal place, which is the tightest grid on
 // Hyperliquid and where the rounding rules bite hardest.
-const BTC: PerpMarket = {
-  asset: 'BTC',
-  assetIndex: 0,
+const BTC: StubMarket = {
+  name: 'BTC',
   szDecimals: 5,
   maxLeverage: 40,
   markPx: '64250.5',
 }
 
-const HYPE: PerpMarket = {
-  asset: 'HYPE',
-  assetIndex: 159,
+const HYPE: StubMarket = {
+  name: 'HYPE',
   szDecimals: 2,
   maxLeverage: 5,
   markPx: '38.123',
 }
 
-const decimalsOf = (value: string) => value.split('.')[1]?.length ?? 0
-const significantFiguresOf = (value: string) =>
-  value.replace('-', '').replace('.', '').replace(/^0+/, '').replace(/0+$/, '')
-    .length
+/** Answers the two info calls the builders make, from in-memory fixtures. */
+function stubInfo(input: {
+  markets?: StubMarket[]
+  positions?: { coin: string; szi: string }[]
+}): HyperCoreInfoOptions {
+  const markets = input.markets ?? [BTC, HYPE]
+  const fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? '{}')) as { type?: string }
+    const payload =
+      body.type === 'clearinghouseState'
+        ? {
+            assetPositions: (input.positions ?? []).map((position) => ({
+              type: 'oneWay',
+              position: { ...position, entryPx: '1', leverage: { value: 5 } },
+            })),
+          }
+        : [
+            { universe: markets.map(({ markPx: _markPx, ...rest }) => rest) },
+            markets.map(({ markPx }) => ({ markPx })),
+          ]
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  return { fetch }
+}
 
 describe('openPerp', () => {
-  test('builds a marketable IOC in the requested direction', () => {
-    const action = openPerp({
-      market: BTC,
-      direction: 'long',
-      notionalUsd: 100,
-    })
+  test('builds a marketable IOC in the requested direction', async () => {
+    const action = await openPerp(
+      { asset: 'BTC', direction: 'long', notionalUsd: 100 },
+      stubInfo({}),
+    )
 
     expect(action.type).toBe('order')
     expect(action.grouping).toBe('na')
     expect(action.orders).toHaveLength(1)
     expect(action.orders[0]).toMatchObject({
-      a: BTC.assetIndex,
+      a: 0,
       b: true,
       r: false,
       t: { limit: { tif: 'Ioc' } },
     })
   })
 
-  test('prices a long above the mark and a short below it', () => {
-    const long = openPerp({ market: BTC, direction: 'long', notionalUsd: 100 })
-    const short = openPerp({
-      market: BTC,
-      direction: 'short',
-      notionalUsd: 100,
-    })
+  test('prices a long above the mark and a short below it', async () => {
+    const long = await openPerp(
+      { asset: 'BTC', direction: 'long', notionalUsd: 100 },
+      stubInfo({}),
+    )
+    const short = await openPerp(
+      { asset: 'BTC', direction: 'short', notionalUsd: 100 },
+      stubInfo({}),
+    )
 
     expect(Number(long.orders[0].p)).toBeGreaterThan(Number(BTC.markPx))
     expect(Number(short.orders[0].p)).toBeLessThan(Number(BTC.markPx))
   })
 
-  test('widens the limit with slippage, and 0 bps sits on the mark', () => {
-    const tight = openPerp({
-      market: HYPE,
-      direction: 'long',
-      notionalUsd: 100,
-      slippageBps: 10,
-    })
-    const wide = openPerp({
-      market: HYPE,
-      direction: 'long',
-      notionalUsd: 100,
-      slippageBps: 500,
-    })
-    const none = openPerp({
-      market: HYPE,
-      direction: 'long',
-      notionalUsd: 100,
-      slippageBps: 0,
-    })
+  test('widens the limit with slippage, and 0 bps sits on the mark', async () => {
+    const price = async (slippageBps: number) =>
+      (
+        await openPerp(
+          { asset: 'HYPE', direction: 'long', notionalUsd: 100, slippageBps },
+          stubInfo({}),
+        )
+      ).orders[0].p
 
-    expect(Number(wide.orders[0].p)).toBeGreaterThan(Number(tight.orders[0].p))
-    expect(none.orders[0].p).toBe('38.123')
+    expect(Number(await price(500))).toBeGreaterThan(Number(await price(10)))
+    expect(await price(0)).toBe('38.123')
   })
 
-  // The asset index is what reaches the exchange; a ticker never does. An index
-  // taken from the wrong market places a valid order on a different coin.
-  test('carries the market its own asset index', () => {
-    const action = openPerp({ market: HYPE, direction: 'long', size: '10' })
-    expect(action.orders[0].a).toBe(159)
+  // The asset index is what reaches the exchange; a ticker never does. Resolving
+  // it is the whole reason these builders read the market themselves.
+  test('resolves the ticker to its index in the universe', async () => {
+    const action = await openPerp(
+      { asset: 'HYPE', direction: 'long', size: '10' },
+      stubInfo({}),
+    )
+    expect(action.orders[0].a).toBe(1)
   })
 
-  test('sizes a USD notional at the mark, rounded down to szDecimals', () => {
-    const action = openPerp({
-      market: BTC,
-      direction: 'long',
-      notionalUsd: 100,
-    })
+  test('rejects a ticker no tradeable market carries', async () => {
+    await expect(
+      openPerp(
+        { asset: 'BTC-PERP', direction: 'long', size: '1' },
+        stubInfo({}),
+      ),
+    ).rejects.toThrow(UnknownPerpAssetError)
+  })
+
+  test('sizes a USD notional at the mark, rounded down to szDecimals', async () => {
+    const action = await openPerp(
+      { asset: 'BTC', direction: 'long', notionalUsd: 100 },
+      stubInfo({}),
+    )
 
     // 100 / 64250.5 = 0.0015564…, floored to five decimals.
     expect(action.orders[0].s).toBe('0.00155')
@@ -107,36 +139,39 @@ describe('openPerp', () => {
     )
   })
 
-  test('takes an explicit size in asset units', () => {
-    const action = openPerp({ market: BTC, direction: 'long', size: '0.002' })
+  test('takes an explicit size in asset units', async () => {
+    const action = await openPerp(
+      { asset: 'BTC', direction: 'long', size: '0.002' },
+      stubInfo({}),
+    )
     expect(action.orders[0].s).toBe('0.002')
   })
 
   // The action's bytes are what the authorising agent is derived from, and
   // Hyperliquid normalises before encoding, so "0.00200" is a different order.
-  test('emits sizes and prices without trailing zeros', () => {
-    const action = openPerp({
-      market: HYPE,
-      direction: 'long',
-      size: '10.10',
-      slippageBps: 0,
-    })
+  test('emits sizes and prices without trailing zeros', async () => {
+    const action = await openPerp(
+      { asset: 'HYPE', direction: 'long', size: '10.10', slippageBps: 0 },
+      stubInfo({}),
+    )
     expect(action.orders[0].s).toBe('10.1')
     expect(action.orders[0].p).toBe('38.123')
   })
 
-  test('omits the client order id unless one is given', () => {
-    const withCloid = openPerp({
-      market: BTC,
-      direction: 'long',
-      notionalUsd: 100,
-      cloid: '0x1234567890abcdef1234567890abcdef',
-    })
-    const without = openPerp({
-      market: BTC,
-      direction: 'long',
-      notionalUsd: 100,
-    })
+  test('omits the client order id unless one is given', async () => {
+    const withCloid = await openPerp(
+      {
+        asset: 'BTC',
+        direction: 'long',
+        notionalUsd: 100,
+        cloid: '0x1234567890abcdef1234567890abcdef',
+      },
+      stubInfo({}),
+    )
+    const without = await openPerp(
+      { asset: 'BTC', direction: 'long', notionalUsd: 100 },
+      stubInfo({}),
+    )
 
     expect(withCloid.orders[0].c).toBe('0x1234567890abcdef1234567890abcdef')
     expect('c' in without.orders[0]).toBe(false)
@@ -144,66 +179,67 @@ describe('openPerp', () => {
 
   // Refused at the exchange, which for an intent that delivers collateral means
   // refused after the funds have already landed on HyperCore.
-  test('rejects an order below the exchange minimum', () => {
-    expect(() =>
-      openPerp({ market: BTC, direction: 'long', notionalUsd: 5 }),
-    ).toThrow(PerpOrderTooSmallError)
+  test('rejects an order below the exchange minimum', async () => {
+    await expect(
+      openPerp(
+        { asset: 'BTC', direction: 'long', notionalUsd: 5 },
+        stubInfo({}),
+      ),
+    ).rejects.toThrow(PerpOrderTooSmallError)
   })
 
   // Flooring the size means a notional barely over the minimum can land under
   // it, so the message reports the size it actually built rather than the
   // number the caller passed — otherwise it reads as an off-by-nothing lie.
-  test('reports the rounded size that fell short, not the request', () => {
+  test('reports the rounded size that fell short, not the request', async () => {
     // 10 / 64250.5 floors to 0.00015 at five decimals, which is $9.64.
-    expect(() =>
-      openPerp({ market: BTC, direction: 'long', notionalUsd: 10 }),
-    ).toThrow(/0\.00015 is worth \$9\.64/)
+    await expect(
+      openPerp(
+        { asset: 'BTC', direction: 'long', notionalUsd: 10 },
+        stubInfo({}),
+      ),
+    ).rejects.toThrow(/0\.00015 is worth \$9\.64/)
   })
 
-  test('rejects a size that rounds away to nothing', () => {
-    expect(() =>
-      openPerp({ market: BTC, direction: 'long', size: '0.000001' }),
-    ).toThrow(HyperCoreError)
+  test('rejects a size that rounds away to nothing', async () => {
+    await expect(
+      openPerp(
+        { asset: 'BTC', direction: 'long', size: '0.000001' },
+        stubInfo({}),
+      ),
+    ).rejects.toThrow(HyperCoreError)
   })
 
-  test('rejects slippage that is not whole basis points in range', () => {
+  test('rejects slippage that is not whole basis points in range', async () => {
     for (const slippageBps of [-1, 0.5, 10_001]) {
-      expect(() =>
-        openPerp({
-          market: BTC,
-          direction: 'long',
-          notionalUsd: 100,
-          slippageBps,
-        }),
-      ).toThrow(HyperCoreError)
+      await expect(
+        openPerp(
+          { asset: 'BTC', direction: 'long', notionalUsd: 100, slippageBps },
+          stubInfo({}),
+        ),
+      ).rejects.toThrow(HyperCoreError)
     }
   })
 
-  test('rejects a market with no usable mark price', () => {
-    expect(() =>
-      openPerp({
-        market: { ...BTC, markPx: '' },
-        direction: 'long',
-        notionalUsd: 100,
-      }),
-    ).toThrow(HyperCoreError)
+  test('rejects a market with no usable mark price', async () => {
+    await expect(
+      openPerp(
+        { asset: 'BTC', direction: 'long', notionalUsd: 100 },
+        stubInfo({ markets: [{ ...BTC, markPx: '' }] }),
+      ),
+    ).rejects.toThrow(HyperCoreError)
   })
 })
 
 describe('closePerp', () => {
-  const long: PerpPosition = {
-    asset: 'BTC',
-    size: '0.0013',
-    entryPx: '63000',
-    leverage: 5,
-  }
-  const short: PerpPosition = { ...long, size: '-0.0013' }
+  const long = stubInfo({ positions: [{ coin: 'BTC', szi: '0.0013' }] })
+  const short = stubInfo({ positions: [{ coin: 'BTC', szi: '-0.0013' }] })
 
-  test('sells a long, reduce-only, for the whole position', () => {
-    const action = closePerp({ market: BTC, position: long })
+  test('sells a long, reduce-only, for the whole position', async () => {
+    const action = await closePerp({ asset: 'BTC', account: ACCOUNT }, long)
 
     expect(action.orders[0]).toMatchObject({
-      a: BTC.assetIndex,
+      a: 0,
       b: false,
       s: '0.0013',
       r: true,
@@ -212,44 +248,54 @@ describe('closePerp', () => {
     expect(Number(action.orders[0].p)).toBeLessThan(Number(BTC.markPx))
   })
 
-  test('buys back a short', () => {
-    const action = closePerp({ market: BTC, position: short })
+  test('buys back a short', async () => {
+    const action = await closePerp({ asset: 'BTC', account: ACCOUNT }, short)
 
     expect(action.orders[0].b).toBe(true)
     expect(action.orders[0].s).toBe('0.0013')
     expect(Number(action.orders[0].p)).toBeGreaterThan(Number(BTC.markPx))
   })
 
-  test('closes only part of a position when asked', () => {
-    const action = closePerp({ market: BTC, position: long, size: '0.0005' })
+  test('closes only part of a position when asked', async () => {
+    const action = await closePerp(
+      { asset: 'BTC', account: ACCOUNT, size: '0.0005' },
+      long,
+    )
     expect(action.orders[0].s).toBe('0.0005')
   })
 
-  test('refuses to close more than is open', () => {
-    expect(() =>
-      closePerp({ market: BTC, position: long, size: '0.002' }),
-    ).toThrow(HyperCoreError)
+  test('refuses to close more than is open', async () => {
+    await expect(
+      closePerp({ asset: 'BTC', account: ACCOUNT, size: '0.002' }, long),
+    ).rejects.toThrow(HyperCoreError)
   })
 
-  // An order carries the market's index, so a mismatch would flatten nothing
-  // and open a position on the other coin instead.
-  test('refuses a market and a position for different assets', () => {
-    expect(() => closePerp({ market: HYPE, position: long })).toThrow(
-      MismatchedPerpAssetError,
-    )
+  // Naming the asset once is what makes a market/position mismatch impossible,
+  // so the only thing left to get wrong is closing what is not there.
+  test('refuses to close a position the account does not hold', async () => {
+    await expect(
+      closePerp({ asset: 'HYPE', account: ACCOUNT }, long),
+    ).rejects.toThrow(NoOpenPerpPositionError)
   })
 
   // Hyperliquid exempts reduce-only orders from the minimum; enforcing it here
   // would leave a dust position with no way out.
-  test('closes a position worth less than the order minimum', () => {
-    const dust: PerpPosition = { ...long, size: '0.00001' }
-    expect(closePerp({ market: BTC, position: dust }).orders[0].s).toBe(
-      '0.00001',
-    )
+  test('closes a position worth less than the order minimum', async () => {
+    const dust = stubInfo({ positions: [{ coin: 'BTC', szi: '0.00001' }] })
+    const action = await closePerp({ asset: 'BTC', account: ACCOUNT }, dust)
+    expect(action.orders[0].s).toBe('0.00001')
   })
 })
 
 describe('price and size grids', () => {
+  const decimalsOf = (value: string) => value.split('.')[1]?.length ?? 0
+  const significantFiguresOf = (value: string) =>
+    value
+      .replace('-', '')
+      .replace('.', '')
+      .replace(/^0+/, '')
+      .replace(/0+$/, '').length
+
   test.each([
     // price, szDecimals, roundUp, expected
     [64571.7525, 5, true, '64572'],
@@ -271,32 +317,34 @@ describe('price and size grids', () => {
   // The two rules Hyperliquid enforces on a perp price, and the one that makes
   // the order marketable at all. Rounding onto the grid must not undo the
   // slippage the caller asked for.
-  test('stays on the grid and on the marketable side of the mark', () => {
-    fc.assert(
-      fc.property(
+  test('stays on the grid and on the marketable side of the mark', async () => {
+    await fc.assert(
+      fc.asyncProperty(
         // A mark as the info endpoint reports one: a plain decimal string.
         fc.integer({ min: 1, max: 5_000_000 }),
         fc.integer({ min: 0, max: 6 }),
         fc.integer({ min: 0, max: 5 }),
         fc.integer({ min: 0, max: 1000 }),
         fc.boolean(),
-        (mantissa, markDecimals, szDecimals, slippageBps, isLong) => {
+        async (mantissa, markDecimals, szDecimals, slippageBps, isLong) => {
           const markPx = (mantissa / 10 ** markDecimals).toFixed(markDecimals)
           const mark = Number(markPx)
-          const market: PerpMarket = {
-            asset: 'TEST',
-            assetIndex: 1,
-            szDecimals,
-            maxLeverage: 10,
-            markPx,
-          }
-          const { p } = openPerp({
-            market,
-            direction: isLong ? 'long' : 'short',
-            // Clear the exchange minimum without rounding away on a coarse grid.
-            size: String(Math.max(20 / mark, 10 ** -szDecimals)),
-            slippageBps,
-          }).orders[0]
+          const { p } = (
+            await openPerp(
+              {
+                asset: 'TEST',
+                direction: isLong ? 'long' : 'short',
+                // Clear the minimum without rounding away on a coarse grid.
+                size: String(Math.max(20 / mark, 10 ** -szDecimals)),
+                slippageBps,
+              },
+              stubInfo({
+                markets: [
+                  { name: 'TEST', szDecimals, maxLeverage: 10, markPx },
+                ],
+              }),
+            )
+          ).orders[0]
 
           expect(decimalsOf(p)).toBeLessThanOrEqual(Math.max(0, 6 - szDecimals))
           expect(significantFiguresOf(p)).toBeLessThanOrEqual(5)

--- a/src/hypercore/orders.ts
+++ b/src/hypercore/orders.ts
@@ -1,25 +1,29 @@
 // Builders for the two HyperCore actions an intent usually carries: open a perp
-// position, and close one. Pure — the market data they price against is an
-// argument, read separately with `getPerpMarket` / `getPerpPosition`.
+// position, and close one. Both name the asset by TICKER and resolve everything
+// else themselves, because everything else is Hyperliquid's wire format rather
+// than anything a caller decided: the asset INDEX an order carries, the tick and
+// size grids a price and size must land on, and a limit priced far enough
+// through the book to still cross when the intent delivers ~30s later.
 //
-// What they absorb is Hyperliquid's order arithmetic: the asset index an order
-// carries instead of a ticker, the tick and size grids a price and size must
-// land on, and a limit priced far enough through the book to still cross when
-// the intent delivers ~30s later. Anything past a marketable IOC — a resting
-// limit, a bracket, a trigger — is expressible directly as a `HyperCoreAction`,
-// which is fully typed.
+// Anything past a marketable IOC — a resting limit, a bracket, a trigger — is
+// expressible directly as a `HyperCoreAction`, which is fully typed.
 
-import type { Hex } from 'viem'
+import type { Address, Hex } from 'viem'
 import type {
   HyperCoreOrder,
   HyperCoreOrderAction,
 } from '../clients/orchestrator/public'
 import {
   HyperCoreError,
-  MismatchedPerpAssetError,
+  NoOpenPerpPositionError,
   PerpOrderTooSmallError,
 } from './errors'
-import type { PerpMarket, PerpPosition } from './market'
+import {
+  getPerpMarket,
+  getPerpPosition,
+  type HyperCoreInfoOptions,
+  type PerpMarket,
+} from './market'
 
 /** How far through the mark a marketable limit is placed, when not given. */
 const DEFAULT_SLIPPAGE_BPS = 50
@@ -59,8 +63,8 @@ type PerpOrderSize =
     }
 
 type OpenPerpParams = PerpOrderSize & {
-  /** The market to trade, from {@link getPerpMarket}. */
-  market: PerpMarket
+  /** Ticker as Hyperliquid names it — the coin alone, e.g. `BTC`. */
+  asset: string
   direction: 'long' | 'short'
   /**
    * How far through the mark to place the limit, in basis points. Defaults to
@@ -77,10 +81,10 @@ type OpenPerpParams = PerpOrderSize & {
 }
 
 type ClosePerpParams = {
-  /** The market the position is on, from {@link getPerpMarket}. */
-  market: PerpMarket
-  /** The position to close, from {@link getPerpPosition}. */
-  position: PerpPosition
+  /** Ticker as Hyperliquid names it — the coin alone, e.g. `BTC`. */
+  asset: string
+  /** The account holding the position — the smart account the intent funds. */
+  account: Address
   /** Close only part of the position, in units of the asset. */
   size?: string
   /** How far through the mark to place the limit, in basis points. */
@@ -98,28 +102,38 @@ type ClosePerpParams = {
  * margin — an open needs collateral, and the order is placed only once that
  * collateral has landed.
  *
- * @param params the market, direction, and size to open
+ * Reads the market from Hyperliquid to resolve the asset index and price the
+ * order, so build the action immediately before quoting: the limit comes from a
+ * mark read now and is fixed once the intent is signed.
+ *
+ * @param params the asset, direction, and size to open
+ * @param options where to reach Hyperliquid's info endpoint
  * @returns the action to pass as `hyperCore.action` on a transaction
+ * @throws {UnknownPerpAssetError} if no tradeable market carries that ticker
  * @throws {PerpOrderTooSmallError} if the order is under Hyperliquid's $10 minimum
  * @example
- * const market = await getPerpMarket('BTC')
- *
  * const prepared = await account.prepareTransaction({
  *   sourceChains: [base],
  *   targetChain: hyperCorePerp,
  *   tokenRequests: [{ address: usdc, amount: parseUnits('25', 6) }],
  *   hyperCore: {
- *     action: openPerp({ market, direction: 'long', notionalUsd: 100 }),
+ *     action: await openPerp({
+ *       asset: 'BTC',
+ *       direction: 'long',
+ *       notionalUsd: 100,
+ *     }),
  *   },
  * })
  * const result = await account.submitTransaction(
  *   await account.signTransaction(prepared),
  * )
  * @see {@link closePerp}
- * @see {@link getPerpMarket}
  */
-function openPerp(params: OpenPerpParams): HyperCoreOrderAction {
-  const { market } = params
+async function openPerp(
+  params: OpenPerpParams,
+  options?: HyperCoreInfoOptions,
+): Promise<HyperCoreOrderAction> {
+  const market = await getPerpMarket(params.asset, options)
   const mark = markPrice(market)
   const size =
     params.size === undefined ? params.notionalUsd / mark : Number(params.size)
@@ -137,24 +151,23 @@ function openPerp(params: OpenPerpParams): HyperCoreOrderAction {
 /**
  * Build a HyperCore action that closes a perpetual position.
  *
- * A reduce-only marketable IOC in the direction that flattens the position,
- * sized from the position itself. Closing frees margin rather than consuming
- * it, so it rides a transaction with no `tokenRequests` at all — but still
- * needs a `sourceChains` entry, since HyperCore is a delivery venue and hosts
- * no account of its own.
+ * A reduce-only marketable IOC in the direction that flattens the position and
+ * sized from the position itself, which it reads from Hyperliquid along with
+ * the market. Closing frees margin rather than consuming it, so it rides a
+ * transaction with no `tokenRequests` at all — but still names a `sourceChains`
+ * entry, since HyperCore is a delivery venue and hosts no account of its own.
  *
- * @param params the market and the position to close
+ * @param params the asset and the account whose position to close
+ * @param options where to reach Hyperliquid's info endpoint
  * @returns the action to pass as `hyperCore.action` on a transaction
- * @throws {MismatchedPerpAssetError} if the market and position are different assets
+ * @throws {NoOpenPerpPositionError} if the account holds no position on that asset
  * @example
- * const market = await getPerpMarket('BTC')
- * const position = await getPerpPosition(account.getAddress(), 'BTC')
- * if (!position) return
- *
  * const prepared = await account.prepareTransaction({
  *   sourceChains: [hyperEvm],
  *   targetChain: hyperCorePerp,
- *   hyperCore: { action: closePerp({ market, position }) },
+ *   hyperCore: {
+ *     action: await closePerp({ asset: 'BTC', account: account.getAddress() }),
+ *   },
  * })
  * const result = await account.submitTransaction(
  *   await account.signTransaction(prepared),
@@ -162,17 +175,24 @@ function openPerp(params: OpenPerpParams): HyperCoreOrderAction {
  * @see {@link openPerp}
  * @see {@link getPerpPosition}
  */
-function closePerp(params: ClosePerpParams): HyperCoreOrderAction {
-  const { market, position } = params
-  if (market.asset !== position.asset) {
-    throw new MismatchedPerpAssetError(market.asset, position.asset)
+async function closePerp(
+  params: ClosePerpParams,
+  options?: HyperCoreInfoOptions,
+): Promise<HyperCoreOrderAction> {
+  const [market, position] = await Promise.all([
+    getPerpMarket(params.asset, options),
+    getPerpPosition(params.account, params.asset, options),
+  ])
+  if (!position) {
+    throw new NoOpenPerpPositionError(params.asset, params.account)
   }
+
   const held = Number(position.size)
   const open = Math.abs(held)
   const size = params.size === undefined ? open : Number(params.size)
   if (size > open) {
     throw new HyperCoreError(
-      `Cannot close ${size} ${market.asset} against an open position of ${open}. Hyperliquid rejects a reduce-only order larger than the position it reduces.`,
+      `Cannot close ${size} ${params.asset} against an open position of ${open}. Hyperliquid rejects a reduce-only order larger than the position it reduces.`,
     )
   }
   return orderAction({

--- a/test/types/hypercore.ts
+++ b/test/types/hypercore.ts
@@ -1,7 +1,12 @@
 import { base, hyperEvm } from 'viem/chains'
 import type { WireQuoteRequest } from '../../src/clients/orchestrator/wire'
 import type { PerpMarket, PerpPosition } from '../../src/hypercore/index'
-import { closePerp, openPerp } from '../../src/hypercore/index'
+import {
+  closePerp,
+  getPerpMarkets,
+  getPerpPosition,
+  openPerp,
+} from '../../src/hypercore/index'
 import type {
   HyperCoreAction,
   HyperCoreOrderAction,
@@ -23,34 +28,30 @@ type WireHyperCoreAction = NonNullable<
 const actionMatchesWire: AssignableTo<HyperCoreAction, WireHyperCoreAction> =
   true
 
-const market: PerpMarket = {
-  asset: 'BTC',
-  assetIndex: 0,
-  szDecimals: 5,
-  maxLeverage: 40,
-  markPx: '64250.5',
-}
+const account = '0x1111111111111111111111111111111111111111' as const
 
-const position: PerpPosition = {
+// One await, and the asset is named once — there is no market or position
+// object for a caller to fetch, hold, or pair with the wrong asset.
+const opened: Promise<HyperCoreOrderAction> = openPerp({
   asset: 'BTC',
-  size: '0.0013',
-  entryPx: '63000',
-  leverage: 5,
-}
-
-const opened: HyperCoreOrderAction = openPerp({
-  market,
   direction: 'long',
   notionalUsd: 100,
 })
 
-const closed: HyperCoreOrderAction = closePerp({ market, position })
+const closed: Promise<HyperCoreOrderAction> = closePerp({
+  asset: 'BTC',
+  account,
+})
 
 // Sizing an open is one or the other, never both and never neither.
 // @ts-expect-error — `notionalUsd` and `size` are mutually exclusive
-openPerp({ market, direction: 'long', notionalUsd: 100, size: '0.001' })
+openPerp({ asset: 'BTC', direction: 'long', notionalUsd: 100, size: '0.001' })
 // @ts-expect-error — one of them is required
-openPerp({ market, direction: 'long' })
+openPerp({ asset: 'BTC', direction: 'long' })
+
+// The reads are still reachable for what they are actually for.
+const markets: Promise<PerpMarket[]> = getPerpMarkets()
+const position: Promise<PerpPosition | null> = getPerpPosition(account, 'BTC')
 
 // An action that delivers its own collateral.
 const openTransaction: Transaction = {
@@ -62,7 +63,7 @@ const openTransaction: Transaction = {
       amount: 25000000n,
     },
   ],
-  hyperCore: { action: opened },
+  hyperCore: { action: await opened },
 }
 
 // A close needs none, so it rides a transaction that requests no tokens — but
@@ -70,7 +71,7 @@ const openTransaction: Transaction = {
 const closeTransaction: Transaction = {
   sourceChains: [hyperEvm],
   targetChain: hyperCorePerp,
-  hyperCore: { action: closed },
+  hyperCore: { action: await closed },
 }
 
 // Every action variant is expressible without the builders, and the `type`
@@ -147,6 +148,8 @@ const noFalseAdditionalFlag: HyperCoreAction = {
 
 void actionMatchesWire
 void openTransaction
+void markets
+void position
 void closeTransaction
 void rawActions
 void noFalseAdditionalFlag


### PR DESCRIPTION
Follow-up to #838, on review feedback that the DX was wrong. `@dev` only, never `latest`, so the shape is free to change.

**Before** — two calls, and the thing in between is the wire detail the builders exist to hide:

```ts
const market = await getPerpMarket('BTC')
const action = openPerp({ market, direction: 'long', notionalUsd: 100 })

const position = await getPerpPosition(account, 'BTC')
const close = closePerp({ market, position })   // and a pair you can mismatch
```

**After:**

```ts
const action = await openPerp({ asset: 'BTC', direction: 'long', notionalUsd: 100 })
const close  = await closePerp({ asset: 'BTC', account })
```

### Why the old shape was wrong

I made the builders pure so the mark price stayed visibly a snapshot. That reasoning does not survive contact: the snapshot is taken either way, and moving it one line up makes it no fresher. What it actually bought was a `PerpMarket` object the caller had to fetch, hold and pass back, whose fields — `assetIndex`, `szDecimals` — are precisely the Hyperliquid wire details the module claims to absorb. Purity was my testing convenience, not the caller's problem.

### What it removes

Naming the asset once makes a whole class of error unrepresentable, so `MismatchedPerpAssetError` is deleted rather than documented. `closePerp` reads the position itself and refuses with a new `NoOpenPerpPositionError` when there is nothing to close.

`getPerpMarket`/`getPerpMarkets`/`getPerpPosition`/`getPerpPositions` stay, re-pointed at what they are actually for — which markets exist, what leverage one allows, whether there is a position to close — rather than being a step you are walked through.

### Verified

Re-ran the same checks as #838 against the new shape: all 177 live perp markets priced both ways (354 orders, on-grid and marketable), `closePerp` against a position-less prod account refuses with the named error, and `POST /quotes` on prod with a one-call `openPerp` action returns 200 / `INTENT_EXECUTOR` with the forged agent in `signData`. Quote only; nothing signed or submitted.

RHI-6552

🤖 Generated with [Claude Code](https://claude.com/claude-code)