### PR TITLE
fix(intents): read an origin payload's chain from its ChainOps leaves

### DIFF
--- a/.changeset/multichain-origin-chain.md
+++ b/.changeset/multichain-origin-chain.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Accept a chain-agnostic origin payload, so an intent whose legs are covered by one signature can be signed.
+
+The orchestrator can serve a multi-leg IntentExecutor bundle as a single `MultiChainOps` payload: the contract verifies it with `_hashTypedDataSansChainId`, so the EIP-712 domain deliberately carries no `chainId` and each leg's chain lives in its own `ChainOps` leaf. Reading the chain off the domain therefore produced `Invalid chain id: NaN` and failed the intent — on this path, after the user had already approved it. The chain now falls back to the leaves, and a payload naming no chain at all throws with the payload's type instead of coercing to `NaN`.

--- a/src/api/compose.ts
+++ b/src/api/compose.ts
@@ -67,6 +67,7 @@ import type {
   SignerInvocationPort,
   SigningCheckpointPort,
 } from '../signing/types'
+import { accountChainIdFromOrigins } from '../transactions/intents/origin-chain'
 import {
   buildIntentSigningInput,
   prepareIntent,
@@ -800,10 +801,9 @@ async function reconstructPreparedIntent<CompatibilityConfig>(
   },
   dependencies: CoreDependencies,
 ): Promise<PreparedIntent<CompatibilityConfig>> {
-  const originChainId = Number(
-    input.quote.signData.origin.at(-1)?.domain?.chainId,
+  const accountChain = toEvmChainReference(
+    accountChainIdFromOrigins(input.quote.signData.origin),
   )
-  const accountChain = toEvmChainReference(originChainId)
   const runtime = await createAccountRuntimePort(
     context.account,
     dependencies,
@@ -859,8 +859,9 @@ async function signIntentFromSignData<CompatibilityConfig>(
   },
   dependencies: CoreDependencies,
 ) {
-  const originChainId = Number(input.signData.origin.at(-1)?.domain?.chainId)
-  const accountChain = toEvmChainReference(originChainId)
+  const accountChain = toEvmChainReference(
+    accountChainIdFromOrigins(input.signData.origin),
+  )
   const runtime = await createAccountRuntimePort(
     context.account,
     dependencies,

--- a/src/signing/pipeline.test.ts
+++ b/src/signing/pipeline.test.ts
@@ -456,8 +456,8 @@ describe('direct rewritten signing pipelines', () => {
     })
   })
 
-  test('refuses a chain-agnostic payload where the chain is bound into the hash', () => {
-    // `MultiChainOps` is one signature over legs on several chains, and a
+  test('refuses a multi-chain payload where the chain is bound into the hash', () => {
+    // `MultiChainOps` can be one signature over legs on several chains, and a
     // quorum validator hashes `chain.id` into what the signer signs. Signing it
     // against the leg being resolved yields a signature that validates there
     // and fails on the rest — on chain, after the user has approved.
@@ -482,7 +482,7 @@ describe('direct rewritten signing pipelines', () => {
         typedData,
         chain,
         context: quorumContext,
-        chainAgnostic: true,
+        spansMultipleChains: true,
       }),
     ).toThrow(/quorum validator/u)
 
@@ -492,9 +492,20 @@ describe('direct rewritten signing pipelines', () => {
         typedData,
         chain,
         context,
-        chainAgnostic: true,
+        spansMultipleChains: true,
       }),
     ).toBeDefined()
+
+    // And so are same-chain legs under quorum: a chainless domain does not mean
+    // the leaves span chains, and one chain-bound hash covers all of them.
+    expect(
+      resolveAccountTypedDataSigning({
+        typedData,
+        chain,
+        context: quorumContext,
+        spansMultipleChains: false,
+      }),
+    ).toMatchObject({ payloadKind: 'message' })
 
     // And a per-leg payload still signs under quorum.
     expect(

--- a/src/signing/pipeline.test.ts
+++ b/src/signing/pipeline.test.ts
@@ -456,6 +456,56 @@ describe('direct rewritten signing pipelines', () => {
     })
   })
 
+  test('refuses a chain-agnostic payload where the chain is bound into the hash', () => {
+    // `MultiChainOps` is one signature over legs on several chains, and a
+    // quorum validator hashes `chain.id` into what the signer signs. Signing it
+    // against the leg being resolved yields a signature that validates there
+    // and fails on the rest — on chain, after the user has approved.
+    const context = signingContext()
+    if (context.validator.kind === 'multi-factor') {
+      throw new Error('Expected atomic validator')
+    }
+    const quorumContext: SigningContext = {
+      ...context,
+      validator: { ...context.validator, kind: 'quorum', thresholdWeight: 1n },
+      validatorCapabilities: {
+        ...context.validatorCapabilities,
+        compatibilityKey: {
+          ...context.validatorCapabilities.compatibilityKey,
+          validatorKind: 'quorum',
+        },
+      },
+    }
+
+    expect(() =>
+      resolveAccountTypedDataSigning({
+        typedData,
+        chain,
+        context: quorumContext,
+        chainAgnostic: true,
+      }),
+    ).toThrow(/quorum validator/u)
+
+    // The same payload is fine wherever nothing chain-specific wraps it.
+    expect(
+      resolveAccountTypedDataSigning({
+        typedData,
+        chain,
+        context,
+        chainAgnostic: true,
+      }),
+    ).toBeDefined()
+
+    // And a per-leg payload still signs under quorum.
+    expect(
+      resolveAccountTypedDataSigning({
+        typedData,
+        chain,
+        context: quorumContext,
+      }),
+    ).toMatchObject({ payloadKind: 'message' })
+  })
+
   test('supports direct typed-data and deployless typed-data routes', async () => {
     const context = signingContext()
     const direct = await signAccountTypedData({

--- a/src/signing/typed-data.ts
+++ b/src/signing/typed-data.ts
@@ -61,6 +61,12 @@ export function resolveAccountTypedDataSigning(input: {
    * the EIP-712 hash of `typedData`.
    */
   readonly validationHash?: Hex
+  /**
+   * Set when one signature over this payload has to validate on several chains
+   * (a `MultiChainOps` set). `chain` is then only the leg being resolved, not
+   * the reach of the signature.
+   */
+  readonly chainAgnostic?: boolean
 }): AccountTypedDataSigningRoute {
   const payload = input.validationHash ?? hashTypedData(input.typedData)
   const accountKind = input.context.account.definition.kind
@@ -70,6 +76,24 @@ export function resolveAccountTypedDataSigning(input: {
       K1_DEFAULT_VALIDATOR_ADDRESS.toLowerCase()
   const requiresRawHash =
     accountKind === 'kernel' || input.context.validator.kind === 'quorum'
+  // A quorum validator hashes the chain id into what the signer signs, and
+  // Startale's K1 route puts it in the ERC-7739 verifier domain. Either one
+  // yields a signature that validates on `input.chain` and nowhere else, so a
+  // payload meant to cover every leg must be refused here — while the caller
+  // is still preparing, not after the user has approved a bundle whose later
+  // legs cannot execute. Kernel's wrapping is address-only and stays fine.
+  if (
+    input.chainAgnostic &&
+    (input.context.validator.kind === 'quorum' || startaleK1)
+  ) {
+    throw new Error(
+      `Cannot sign a chain-agnostic intent payload with ${
+        input.context.validator.kind === 'quorum'
+          ? 'a quorum validator'
+          : "Startale's K1 validator"
+      }: it binds the chain id into the signed hash, so the signature would validate only on chain ${input.chain.id} and fail on the intent's other legs`,
+    )
+  }
   const messagePayload = requiresRawHash
     ? resolveAccountValidatorSignableHash({
         hash: payload,

--- a/src/signing/typed-data.ts
+++ b/src/signing/typed-data.ts
@@ -62,11 +62,11 @@ export function resolveAccountTypedDataSigning(input: {
    */
   readonly validationHash?: Hex
   /**
-   * Set when one signature over this payload has to validate on several chains
-   * (a `MultiChainOps` set). `chain` is then only the leg being resolved, not
-   * the reach of the signature.
+   * Set when one signature over this payload has to validate on more than one
+   * chain (a `MultiChainOps` set whose leaves span chains). `chain` is then
+   * only the leg being resolved, not the reach of the signature.
    */
-  readonly chainAgnostic?: boolean
+  readonly spansMultipleChains?: boolean
 }): AccountTypedDataSigningRoute {
   const payload = input.validationHash ?? hashTypedData(input.typedData)
   const accountKind = input.context.account.definition.kind
@@ -79,19 +79,20 @@ export function resolveAccountTypedDataSigning(input: {
   // A quorum validator hashes the chain id into what the signer signs, and
   // Startale's K1 route puts it in the ERC-7739 verifier domain. Either one
   // yields a signature that validates on `input.chain` and nowhere else, so a
-  // payload meant to cover every leg must be refused here — while the caller
-  // is still preparing, not after the user has approved a bundle whose later
-  // legs cannot execute. Kernel's wrapping is address-only and stays fine.
+  // payload whose legs are spread across chains must be refused here — while
+  // the caller is still preparing, not after the user has approved a bundle
+  // whose later legs cannot execute. Same-chain legs are unaffected, and
+  // Kernel's wrapping is address-only, so it stays fine either way.
   if (
-    input.chainAgnostic &&
+    input.spansMultipleChains &&
     (input.context.validator.kind === 'quorum' || startaleK1)
   ) {
     throw new Error(
-      `Cannot sign a chain-agnostic intent payload with ${
+      `Cannot sign a multi-chain intent payload with ${
         input.context.validator.kind === 'quorum'
           ? 'a quorum validator'
           : "Startale's K1 validator"
-      }: it binds the chain id into the signed hash, so the signature would validate only on chain ${input.chain.id} and fail on the intent's other legs`,
+      }: it binds the chain id into the signed hash, so the signature would validate only on chain ${input.chain.id} and fail on the intent's legs on other chains`,
     )
   }
   const messagePayload = requiresRawHash

--- a/src/transactions/intents/origin-chain.test.ts
+++ b/src/transactions/intents/origin-chain.test.ts
@@ -35,22 +35,58 @@ const multiChainOps = {
   },
 } as const satisfies TypedDataDefinition
 
+function withMessage(message: unknown): TypedDataDefinition {
+  return { ...multiChainOps, message } as unknown as TypedDataDefinition
+}
+
+function withDomainChainId(chainId: unknown): TypedDataDefinition {
+  return {
+    ...singleChainOps,
+    domain: { ...singleChainOps.domain, chainId },
+  } as unknown as TypedDataDefinition
+}
+
 describe('origin payload chain', () => {
   test('reads the domain chainId of a per-leg payload', () => {
     expect(originChainId(singleChainOps)).toBe(8453)
+  })
+
+  test('reads a domain chainId that arrives unnormalized', () => {
+    // `normalizeIntentTypedData` widens uints to bigint, but a caller building
+    // its own SignData hands over whatever the wire gave it.
+    expect(originChainId(withDomainChainId('10'))).toBe(10)
+    expect(originChainId(withDomainChainId(42161n))).toBe(42161)
   })
 
   test('reads the first ChainOps leaf when the domain names no chain', () => {
     expect(originChainId(multiChainOps)).toBe(42161)
   })
 
-  test('names the payload rather than yielding NaN when no chain is present', () => {
-    expect(() =>
-      originChainId({
-        ...multiChainOps,
-        message: { account: verifyingContract, ops: [] },
-      }),
-    ).toThrow(/names no chain/u)
+  test.each([
+    ['not a number', 'abc'],
+    ['an object', { id: 1 }],
+    ['NaN itself', Number.NaN],
+  ])('refuses a domain chainId that is %s', (_label, chainId) => {
+    expect(() => originChainId(withDomainChainId(chainId))).toThrow(
+      /unreadable domain chainId/u,
+    )
+  })
+
+  test.each([
+    ['no ops at all', { account: verifyingContract }],
+    ['ops that are not an array', { ops: 'MultiChainOps' }],
+    ['an empty ops array', { ops: [] }],
+    ['a null leaf', { ops: [null] }],
+    ['a leaf with no chainId', { ops: [{ nonce: 1n }] }],
+    ['a leaf whose chainId is unreadable', { ops: [{ chainId: 'abc' }] }],
+  ])('names the payload rather than yielding NaN for %s', (_label, message) => {
+    expect(() => originChainId(withMessage(message))).toThrow(/names no chain/u)
+  })
+
+  test('names the payload when it carries no message', () => {
+    expect(() => originChainId(withMessage(undefined))).toThrow(
+      /names no chain/u,
+    )
   })
 
   test('resolves the account chain from a multi-leg quote', () => {
@@ -60,6 +96,12 @@ describe('origin payload chain', () => {
     // after the user had approved it.
     expect(accountChainIdFromOrigins([multiChainOps])).toBe(42161)
     expect(accountChainIdFromOrigins([singleChainOps])).toBe(8453)
+  })
+
+  test('takes the last origin of a per-leg quote', () => {
+    expect(
+      accountChainIdFromOrigins([singleChainOps, withDomainChainId(10)]),
+    ).toBe(10)
   })
 
   test('rejects a quote with no origin payloads', () => {

--- a/src/transactions/intents/origin-chain.test.ts
+++ b/src/transactions/intents/origin-chain.test.ts
@@ -1,6 +1,10 @@
 import type { TypedDataDefinition } from 'viem'
 import { describe, expect, test } from 'vitest'
-import { accountChainIdFromOrigins, originChainId } from './origin-chain'
+import {
+  accountChainIdFromOrigins,
+  isChainAgnosticPayload,
+  originChainId,
+} from './origin-chain'
 
 const verifyingContract = '0x0000000000000000000000000000000000000001' as const
 
@@ -102,6 +106,18 @@ describe('origin payload chain', () => {
     expect(
       accountChainIdFromOrigins([singleChainOps, withDomainChainId(10)]),
     ).toBe(10)
+  })
+
+  test('recognises which payloads one signature has to span', () => {
+    expect(isChainAgnosticPayload(multiChainOps)).toBe(true)
+    expect(isChainAgnosticPayload(singleChainOps)).toBe(false)
+    expect(isChainAgnosticPayload(withDomainChainId(null))).toBe(true)
+    expect(
+      isChainAgnosticPayload({
+        ...multiChainOps,
+        domain: undefined,
+      } as unknown as TypedDataDefinition),
+    ).toBe(true)
   })
 
   test('rejects a quote with no origin payloads', () => {

--- a/src/transactions/intents/origin-chain.test.ts
+++ b/src/transactions/intents/origin-chain.test.ts
@@ -1,0 +1,70 @@
+import type { TypedDataDefinition } from 'viem'
+import { describe, expect, test } from 'vitest'
+import { accountChainIdFromOrigins, originChainId } from './origin-chain'
+
+const verifyingContract = '0x0000000000000000000000000000000000000001' as const
+
+const singleChainOps = {
+  domain: { chainId: 8453, verifyingContract },
+  types: { SingleChainOps: [{ name: 'nonce', type: 'uint256' }] },
+  primaryType: 'SingleChainOps',
+  message: { nonce: 1n },
+} as const satisfies TypedDataDefinition
+
+// No `chainId` in the domain — the contract verifies this one with
+// `_hashTypedDataSansChainId` so that one signature covers every leg.
+const multiChainOps = {
+  domain: { name: 'IntentExecutor', version: 'v0.0.1', verifyingContract },
+  types: {
+    MultiChainOps: [
+      { name: 'account', type: 'address' },
+      { name: 'ops', type: 'ChainOps[]' },
+    ],
+    ChainOps: [
+      { name: 'chainId', type: 'uint256' },
+      { name: 'nonce', type: 'uint256' },
+    ],
+  },
+  primaryType: 'MultiChainOps',
+  message: {
+    account: verifyingContract,
+    ops: [
+      { chainId: 42161n, nonce: 1n },
+      { chainId: 10n, nonce: 2n },
+    ],
+  },
+} as const satisfies TypedDataDefinition
+
+describe('origin payload chain', () => {
+  test('reads the domain chainId of a per-leg payload', () => {
+    expect(originChainId(singleChainOps)).toBe(8453)
+  })
+
+  test('reads the first ChainOps leaf when the domain names no chain', () => {
+    expect(originChainId(multiChainOps)).toBe(42161)
+  })
+
+  test('names the payload rather than yielding NaN when no chain is present', () => {
+    expect(() =>
+      originChainId({
+        ...multiChainOps,
+        message: { account: verifyingContract, ops: [] },
+      }),
+    ).toThrow(/names no chain/u)
+  })
+
+  test('resolves the account chain from a multi-leg quote', () => {
+    // A MultiChainOps quote carries ONE origin entry for a bundle of several
+    // legs, so the account chain has to come out of the leaves too — reading
+    // the domain here produced `Invalid chain id: NaN` and failed the intent
+    // after the user had approved it.
+    expect(accountChainIdFromOrigins([multiChainOps])).toBe(42161)
+    expect(accountChainIdFromOrigins([singleChainOps])).toBe(8453)
+  })
+
+  test('rejects a quote with no origin payloads', () => {
+    expect(() => accountChainIdFromOrigins([])).toThrow(
+      'Intent quote has no origin payloads',
+    )
+  })
+})

--- a/src/transactions/intents/origin-chain.test.ts
+++ b/src/transactions/intents/origin-chain.test.ts
@@ -2,8 +2,8 @@ import type { TypedDataDefinition } from 'viem'
 import { describe, expect, test } from 'vitest'
 import {
   accountChainIdFromOrigins,
-  isChainAgnosticPayload,
   originChainId,
+  signatureSpansMultipleChains,
 } from './origin-chain'
 
 const verifyingContract = '0x0000000000000000000000000000000000000001' as const
@@ -108,16 +108,49 @@ describe('origin payload chain', () => {
     ).toBe(10)
   })
 
-  test('recognises which payloads one signature has to span', () => {
-    expect(isChainAgnosticPayload(multiChainOps)).toBe(true)
-    expect(isChainAgnosticPayload(singleChainOps)).toBe(false)
-    expect(isChainAgnosticPayload(withDomainChainId(null))).toBe(true)
+  test('recognises how many chains one signature has to reach', () => {
+    expect(signatureSpansMultipleChains(multiChainOps)).toBe(true)
+    expect(signatureSpansMultipleChains(singleChainOps)).toBe(false)
     expect(
-      isChainAgnosticPayload({
+      signatureSpansMultipleChains({
         ...multiChainOps,
         domain: undefined,
       } as unknown as TypedDataDefinition),
     ).toBe(true)
+  })
+
+  test('does not call same-chain legs multi-chain', () => {
+    // `MultiChainOps` does not require its leaves to be on different chains:
+    // same-chain legs with distinct nonces are a valid set, and are how a
+    // bundle splits its destination ops across blocks. The domain is chainless
+    // either way, so the domain alone cannot answer this — and a chain-bound
+    // wrapper validates on every leg of a same-chain set.
+    expect(
+      signatureSpansMultipleChains(
+        withMessage({
+          account: verifyingContract,
+          ops: [
+            { chainId: 8453n, nonce: 1n },
+            { chainId: 8453n, nonce: 2n },
+          ],
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      signatureSpansMultipleChains(withMessage({ ops: [{ chainId: 1n }] })),
+    ).toBe(false)
+    // A payload naming no chain at all reaches nothing, and `originChainId`
+    // refuses it separately — this must not report a span it cannot support.
+    expect(signatureSpansMultipleChains(withMessage({ ops: [] }))).toBe(false)
+    expect(signatureSpansMultipleChains(withMessage({ ops: 'nope' }))).toBe(
+      false,
+    )
+    // An unreadable leaf drops out rather than counting as its own chain.
+    expect(
+      signatureSpansMultipleChains(
+        withMessage({ ops: [{ chainId: 1n }, { chainId: null }] }),
+      ),
+    ).toBe(false)
   })
 
   test('rejects a quote with no origin payloads', () => {

--- a/src/transactions/intents/origin-chain.ts
+++ b/src/transactions/intents/origin-chain.ts
@@ -10,23 +10,16 @@ import type { TypedDataDefinition } from 'viem'
 // resolving a signer; the first is taken because the leaves are in signed order
 // and the choice has to be deterministic.
 
-type ChainOpsLeaf = { chainId: bigint | number | string }
-
-function isChainOpsLeaf(value: unknown): value is ChainOpsLeaf {
-  if (typeof value !== 'object' || value === null) return false
-  const { chainId } = value as { chainId?: unknown }
-  return (
-    typeof chainId === 'bigint' ||
-    typeof chainId === 'number' ||
-    typeof chainId === 'string'
-  )
-}
-
-function firstLeafChainId(typedData: TypedDataDefinition): number | undefined {
-  const ops = (typedData.message as { ops?: unknown } | undefined)?.ops
-  if (!Array.isArray(ops)) return undefined
-  const [first] = ops
-  return isChainOpsLeaf(first) ? Number(first.chainId) : undefined
+function readChainId(value: unknown): number | undefined {
+  if (
+    typeof value !== 'bigint' &&
+    typeof value !== 'number' &&
+    typeof value !== 'string'
+  ) {
+    return undefined
+  }
+  const chainId = Number(value)
+  return Number.isFinite(chainId) ? chainId : undefined
 }
 
 /**
@@ -39,8 +32,8 @@ function firstLeafChainId(typedData: TypedDataDefinition): number | undefined {
 export function originChainId(typedData: TypedDataDefinition): number {
   const fromDomain = typedData.domain?.chainId
   if (fromDomain !== undefined && fromDomain !== null) {
-    const chainId = Number(fromDomain)
-    if (!Number.isFinite(chainId)) {
+    const chainId = readChainId(fromDomain)
+    if (chainId === undefined) {
       throw new Error(
         `Intent origin payload has an unreadable domain chainId: ${String(fromDomain)}`,
       )
@@ -48,8 +41,11 @@ export function originChainId(typedData: TypedDataDefinition): number {
     return chainId
   }
 
-  const fromLeaf = firstLeafChainId(typedData)
-  if (fromLeaf !== undefined && Number.isFinite(fromLeaf)) return fromLeaf
+  const ops = (typedData.message as { ops?: unknown } | undefined)?.ops
+  const fromLeaf = Array.isArray(ops)
+    ? readChainId((ops[0] as { chainId?: unknown } | undefined)?.chainId)
+    : undefined
+  if (fromLeaf !== undefined) return fromLeaf
 
   throw new Error(
     `Intent origin payload "${String(typedData.primaryType)}" names no chain: it carries neither a domain chainId nor a ChainOps leaf to read one from`,

--- a/src/transactions/intents/origin-chain.ts
+++ b/src/transactions/intents/origin-chain.ts
@@ -67,3 +67,19 @@ export function accountChainIdFromOrigins(
   if (!last) throw new Error('Intent quote has no origin payloads')
   return originChainId(last)
 }
+
+/**
+ * True when the payload's chain is not bound into the signature — a
+ * `MultiChainOps` set, which one signature has to satisfy on every leg.
+ *
+ * Callers that wrap the digest with anything chain-specific must refuse such a
+ * payload rather than sign it against the leg they happen to be resolving: the
+ * resulting signature validates on that chain and fails on the rest, on chain,
+ * after the user has approved.
+ */
+export function isChainAgnosticPayload(
+  typedData: TypedDataDefinition,
+): boolean {
+  const { chainId } = typedData.domain ?? {}
+  return chainId === undefined || chainId === null
+}

--- a/src/transactions/intents/origin-chain.ts
+++ b/src/transactions/intents/origin-chain.ts
@@ -22,6 +22,24 @@ function readChainId(value: unknown): number | undefined {
   return Number.isFinite(chainId) ? chainId : undefined
 }
 
+function domainChainId(typedData: TypedDataDefinition): unknown {
+  const { chainId } = typedData.domain ?? {}
+  return chainId === null ? undefined : chainId
+}
+
+function leafChainIds(typedData: TypedDataDefinition): number[] {
+  const ops = (typedData.message as { ops?: unknown } | undefined)?.ops
+  if (!Array.isArray(ops)) return []
+  const chainIds: number[] = []
+  for (const leaf of ops) {
+    const chainId = readChainId(
+      (leaf as { chainId?: unknown } | undefined)?.chainId,
+    )
+    if (chainId !== undefined) chainIds.push(chainId)
+  }
+  return chainIds
+}
+
 /**
  * The chain an origin payload is signed for.
  *
@@ -30,8 +48,8 @@ function readChainId(value: unknown): number | undefined {
  * failure lands after the user has already approved the intent.
  */
 export function originChainId(typedData: TypedDataDefinition): number {
-  const fromDomain = typedData.domain?.chainId
-  if (fromDomain !== undefined && fromDomain !== null) {
+  const fromDomain = domainChainId(typedData)
+  if (fromDomain !== undefined) {
     const chainId = readChainId(fromDomain)
     if (chainId === undefined) {
       throw new Error(
@@ -41,10 +59,7 @@ export function originChainId(typedData: TypedDataDefinition): number {
     return chainId
   }
 
-  const ops = (typedData.message as { ops?: unknown } | undefined)?.ops
-  const fromLeaf = Array.isArray(ops)
-    ? readChainId((ops[0] as { chainId?: unknown } | undefined)?.chainId)
-    : undefined
+  const [fromLeaf] = leafChainIds(typedData)
   if (fromLeaf !== undefined) return fromLeaf
 
   throw new Error(
@@ -69,17 +84,23 @@ export function accountChainIdFromOrigins(
 }
 
 /**
- * True when the payload's chain is not bound into the signature — a
- * `MultiChainOps` set, which one signature has to satisfy on every leg.
+ * True when one signature over this payload has to validate on more than one
+ * chain.
  *
- * Callers that wrap the digest with anything chain-specific must refuse such a
- * payload rather than sign it against the leg they happen to be resolving: the
- * resulting signature validates on that chain and fails on the rest, on chain,
- * after the user has approved.
+ * An absent domain chainId is not the test on its own: `MultiChainOps` does not
+ * require its leaves to be on DIFFERENT chains, and same-chain legs with
+ * distinct nonces are a valid set — that is how a bundle splits its destination
+ * ops across blocks. Such a payload is chainless in the domain yet every leg
+ * runs on one chain, so a chain-bound wrapper still validates on all of them.
+ *
+ * Callers that wrap the digest with anything chain-specific must refuse only
+ * the genuinely multi-chain case, where signing against the leg being resolved
+ * gives a signature that fails on the rest — on chain, after the user has
+ * approved.
  */
-export function isChainAgnosticPayload(
+export function signatureSpansMultipleChains(
   typedData: TypedDataDefinition,
 ): boolean {
-  const { chainId } = typedData.domain ?? {}
-  return chainId === undefined || chainId === null
+  if (domainChainId(typedData) !== undefined) return false
+  return new Set(leafChainIds(typedData)).size > 1
 }

--- a/src/transactions/intents/origin-chain.ts
+++ b/src/transactions/intents/origin-chain.ts
@@ -1,0 +1,73 @@
+import type { TypedDataDefinition } from 'viem'
+
+// A `SingleChainOps` origin payload binds its chain in the EIP-712 domain, so
+// `domain.chainId` names it. A `MultiChainOps` payload is one signature over
+// every leg of a multi-leg bundle, and the contract verifies it with
+// `_hashTypedDataSansChainId` — the domain deliberately carries no chainId, and
+// each leg's chain lives in its own `ChainOps` leaf instead.
+//
+// The signature is identical on every leg, so any leaf is a valid context for
+// resolving a signer; the first is taken because the leaves are in signed order
+// and the choice has to be deterministic.
+
+type ChainOpsLeaf = { chainId: bigint | number | string }
+
+function isChainOpsLeaf(value: unknown): value is ChainOpsLeaf {
+  if (typeof value !== 'object' || value === null) return false
+  const { chainId } = value as { chainId?: unknown }
+  return (
+    typeof chainId === 'bigint' ||
+    typeof chainId === 'number' ||
+    typeof chainId === 'string'
+  )
+}
+
+function firstLeafChainId(typedData: TypedDataDefinition): number | undefined {
+  const ops = (typedData.message as { ops?: unknown } | undefined)?.ops
+  if (!Array.isArray(ops)) return undefined
+  const [first] = ops
+  return isChainOpsLeaf(first) ? Number(first.chainId) : undefined
+}
+
+/**
+ * The chain an origin payload is signed for.
+ *
+ * Throws rather than yielding `NaN` for a payload that names no chain at all:
+ * the value flows into signer and session resolution, and on this path a
+ * failure lands after the user has already approved the intent.
+ */
+export function originChainId(typedData: TypedDataDefinition): number {
+  const fromDomain = typedData.domain?.chainId
+  if (fromDomain !== undefined && fromDomain !== null) {
+    const chainId = Number(fromDomain)
+    if (!Number.isFinite(chainId)) {
+      throw new Error(
+        `Intent origin payload has an unreadable domain chainId: ${String(fromDomain)}`,
+      )
+    }
+    return chainId
+  }
+
+  const fromLeaf = firstLeafChainId(typedData)
+  if (fromLeaf !== undefined && Number.isFinite(fromLeaf)) return fromLeaf
+
+  throw new Error(
+    `Intent origin payload "${String(typedData.primaryType)}" names no chain: it carries neither a domain chainId nor a ChainOps leaf to read one from`,
+  )
+}
+
+/**
+ * The chain whose account runtime signs an intent, read off the last origin
+ * payload as the callers here have always done.
+ *
+ * A `MultiChainOps` quote carries exactly one origin entry however many legs it
+ * covers, so first and last are the same payload and the choice only matters
+ * for the per-leg shape.
+ */
+export function accountChainIdFromOrigins(
+  origins: readonly TypedDataDefinition[],
+): number {
+  const last = origins.at(-1)
+  if (!last) throw new Error('Intent quote has no origin payloads')
+  return originChainId(last)
+}

--- a/src/transactions/intents/prepare.ts
+++ b/src/transactions/intents/prepare.ts
@@ -15,6 +15,7 @@ import type { IntentSigningInput } from '../../signing/intent-plans/types'
 import { signingTopology } from '../../signing/plan'
 import { projectIntentAccount } from './account'
 import { normalizeIntentQuote } from './normalize'
+import { originChainId } from './origin-chain'
 import { selectIntentQuote } from './quotes'
 import { buildIntentRequest } from './request'
 import { prepareIntentSessions } from './sessions'
@@ -217,7 +218,7 @@ export function buildIntentSigningInput(
         }
   const origins = quote.signData.origin.map((typedData, index) => ({
     id: hashTypedData(typedData),
-    chain: toEvmChainReference(Number(typedData.domain?.chainId)),
+    chain: toEvmChainReference(originChainId(typedData)),
     role: 'origin' as const,
     typedData,
     usage: 'intent-origin' as const,

--- a/src/transactions/intents/session-signing.ts
+++ b/src/transactions/intents/session-signing.ts
@@ -44,7 +44,7 @@ import type {
   SigningPayloadRegistry,
   SigningTaskTemplate,
 } from '../../signing/types'
-import { isChainAgnosticPayload } from './origin-chain'
+import { signatureSpansMultipleChains } from './origin-chain'
 import type { PreparedIntent } from './types'
 
 export function createIntentSessionSignerInvoker<CompatibilityConfig>(
@@ -94,7 +94,7 @@ export function buildSessionIntentPlanInput<CompatibilityConfig>(
     // session's identity, so one signature cannot stand for legs on other
     // chains. Refuse while preparing rather than sign a bundle whose later legs
     // cannot execute.
-    if (isChainAgnosticPayload(origin.typedData)) {
+    if (signatureSpansMultipleChains(origin.typedData)) {
       throw new Error(
         'Cannot sign a chain-agnostic intent payload with a smart session: a session is enabled per chain, so the signature would validate only on the leg it was resolved against',
       )

--- a/src/transactions/intents/session-signing.ts
+++ b/src/transactions/intents/session-signing.ts
@@ -44,6 +44,7 @@ import type {
   SigningPayloadRegistry,
   SigningTaskTemplate,
 } from '../../signing/types'
+import { isChainAgnosticPayload } from './origin-chain'
 import type { PreparedIntent } from './types'
 
 export function createIntentSessionSignerInvoker<CompatibilityConfig>(
@@ -89,6 +90,15 @@ export function buildSessionIntentPlanInput<CompatibilityConfig>(
   const payloads: Record<Hex, SigningPayloadRegistry[Hex]> = {}
   const stages: IntentSigningPlanCreationInput['stages'][number][] = []
   for (const [index, origin] of prepared.signing.origins.entries()) {
+    // A smart session is enabled per chain and its signature carries that
+    // session's identity, so one signature cannot stand for legs on other
+    // chains. Refuse while preparing rather than sign a bundle whose later legs
+    // cannot execute.
+    if (isChainAgnosticPayload(origin.typedData)) {
+      throw new Error(
+        'Cannot sign a chain-agnostic intent payload with a smart session: a session is enabled per chain, so the signature would validate only on the leg it was resolved against',
+      )
+    }
     const session = requireSession(prepared, origin.chain.id)
     stages.push(
       buildSessionStage({

--- a/src/transactions/intents/sign-transaction.ts
+++ b/src/transactions/intents/sign-transaction.ts
@@ -45,6 +45,7 @@ import type {
   SigningPayloadRegistry,
   SigningTaskTemplate,
 } from '../../signing/types'
+import { isChainAgnosticPayload } from './origin-chain'
 import {
   buildSessionIntentPlanInput,
   createIntentSessionSignerInvoker,
@@ -400,8 +401,16 @@ function buildIntentPlanInput<CompatibilityConfig>(
 ): IntentSigningPlanCreationInput {
   const payloads: Record<Hex, SigningPayloadRegistry[Hex]> = {}
   const stages: IntentSigningStageInput[] = []
+  // A chain-agnostic origin is deliberately excluded: every leaf here is hashed
+  // with its own chain id, so it would be bound to the leg the payload happens
+  // to name. Routing it down the plain branch instead reaches the one refusal
+  // in `resolveAccountTypedDataSigning`.
   const quorumMerkle =
-    context.validator.kind === 'quorum' && prepared.signing.origins.length > 1
+    context.validator.kind === 'quorum' &&
+    prepared.signing.origins.length > 1 &&
+    !prepared.signing.origins.some(({ typedData }) =>
+      isChainAgnosticPayload(typedData),
+    )
       ? buildQuorumMerkleTree(
           prepared.signing.origins.map((origin) => ({
             account: context.account.address,
@@ -445,6 +454,7 @@ function buildIntentPlanInput<CompatibilityConfig>(
         chain: origin.chain,
         context,
         validationHash: origin.id,
+        chainAgnostic: isChainAgnosticPayload(origin.typedData),
       })
       payloads[origin.id] = route.material
       stages.push(

--- a/src/transactions/intents/sign-transaction.ts
+++ b/src/transactions/intents/sign-transaction.ts
@@ -45,7 +45,7 @@ import type {
   SigningPayloadRegistry,
   SigningTaskTemplate,
 } from '../../signing/types'
-import { isChainAgnosticPayload } from './origin-chain'
+import { signatureSpansMultipleChains } from './origin-chain'
 import {
   buildSessionIntentPlanInput,
   createIntentSessionSignerInvoker,
@@ -409,7 +409,7 @@ function buildIntentPlanInput<CompatibilityConfig>(
     context.validator.kind === 'quorum' &&
     prepared.signing.origins.length > 1 &&
     !prepared.signing.origins.some(({ typedData }) =>
-      isChainAgnosticPayload(typedData),
+      signatureSpansMultipleChains(typedData),
     )
       ? buildQuorumMerkleTree(
           prepared.signing.origins.map((origin) => ({
@@ -454,7 +454,7 @@ function buildIntentPlanInput<CompatibilityConfig>(
         chain: origin.chain,
         context,
         validationHash: origin.id,
-        chainAgnostic: isChainAgnosticPayload(origin.typedData),
+        spansMultipleChains: signatureSpansMultipleChains(origin.typedData),
       })
       payloads[origin.id] = route.material
       stages.push(

--- a/src/transactions/intents/workflow.test.ts
+++ b/src/transactions/intents/workflow.test.ts
@@ -462,6 +462,47 @@ describe('intent workflow', () => {
     )
   })
 
+  test('signs a chain-agnostic multi-leg origin payload', () => {
+    // `MultiChainOps` is one signature over every IntentExecutor leg, so its
+    // domain carries no chainId and the quote carries ONE origin entry for a
+    // bundle of several legs. Deriving the chain from the domain gave
+    // `Invalid chain id: NaN` and failed the intent after the user's approval.
+    const intentQuote = quote()
+    const multiChainOps = {
+      domain: {
+        name: 'IntentExecutor',
+        version: 'v0.0.1',
+        verifyingContract: address,
+      },
+      types: {
+        MultiChainOps: [
+          { name: 'account', type: 'address' },
+          { name: 'ops', type: 'ChainOps[]' },
+        ],
+        ChainOps: [
+          { name: 'chainId', type: 'uint256' },
+          { name: 'nonce', type: 'uint256' },
+        ],
+      },
+      primaryType: 'MultiChainOps',
+      message: {
+        account: address,
+        ops: [
+          { chainId: 1n, nonce: 1n },
+          { chainId: 8453n, nonce: 2n },
+        ],
+      },
+    } as const
+
+    const signing = buildIntentSigningInput(runtime(), {
+      ...intentQuote,
+      signData: { ...intentQuote.signData, origin: [multiChainOps] },
+    })
+
+    expect(signing.origins).toHaveLength(1)
+    expect(signing.origins[0].chain.id).toBe(1)
+  })
+
   test('does not sign an ordinary target execution payload', () => {
     const intentQuote = quote()
     const targetExecution = {


### PR DESCRIPTION
Unblocks RHI-6552 phase 2 on the orchestrator side, which is merged but can
never be enabled while this SDK cannot sign what it emits.

## The failure

`MultiChainOps` is one user signature over every IntentExecutor leg of a bundle.
The contract verifies it with `_hashTypedDataSansChainId`, so the EIP-712 domain
carries no `chainId` by design — each leg's chain lives in its own `ChainOps`
leaf, and one quote carries a single origin entry however many legs it covers.

`buildIntentSigningInput` derived the chain per origin entry as
`toEvmChainReference(Number(typedData.domain?.chainId))`, which is `Number(undefined)`,
which `formatCaip2` rejects as `Invalid chain id: NaN`. `reconstructPreparedIntent`
and `signIntentFromSignData` picked the account chain the same way.

This is not a soft failure: it aborts the whole intent, and it lands after the
user has approved it. It is why the orchestrator's emission flag was reverted on
dev rather than soaked.

## The fix

`originChainId` prefers `domain.chainId` and falls back to the first `ChainOps`
leaf. The signature is identical on every leg, so any leaf is a valid context
for resolving a signer; the first is taken because the leaves are in signed
order and the choice has to be deterministic.

Per-leg `SingleChainOps` payloads are untouched — the domain still wins wherever
it is present, which is every payload served today.

A payload that names no chain in either place now throws with its primary type.
The old read was `?.` plus `Number()`, so a shape the SDK does not expect
produced a `NaN` chain and only surfaced where a consumer happened to validate
it; on a path whose failures land after signing, that is worth being loud about.

## Verified

`bun run typecheck`, `bun run check`, `bun run check:architecture`, and the full
unit suite (998 tests, 80 files) pass. The regression is pinned twice: directly
in `origin-chain.test.ts`, and through `buildIntentSigningInput` in
`workflow.test.ts` with a chain-agnostic multi-leg payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
