### PR TITLE
fix(build): give the hypercore entry point its size gate

### DIFF
--- a/.size-limit.ts
+++ b/.size-limit.ts
@@ -68,6 +68,13 @@ const limits = [
     ignore: viem,
   },
   {
+    name: '@rhinestone/sdk/hypercore',
+    path: `${packageRoot}/hypercore/index.js`,
+    limit: '2 kB',
+    import: '*',
+    ignore: viem,
+  },
+  {
     name: '@rhinestone/sdk/errors',
     path: `${packageRoot}/errors/index.js`,
     limit: '20 kB',


### PR DESCRIPTION
`@rhinestone/sdk/hypercore` (#838) went into the exports map without a matching
`.size-limit.ts` entry. `test/contract/package.ctest.ts` asserts those two lists
agree name-for-name and in order, so the release PR fails
`release-package-contract` — which is the only job that runs the packed contract
suite, hence the delay in seeing it.

2 kB against a measured 734 B. The entries either side use 1–2 kB for comparable
surfaces; the module is thin wrappers over Hyperliquid's info endpoint with viem
ignored, so the gate is sized to catch an accidental heavy import rather than to
leave room for one.

[skip-linear]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
