### PR TITLE
feat(smart-sessions): let a swap scope authorise several sell tokens

### DIFF
--- a/.changeset/rhi-6643-multi-sell-swap-scope.md
+++ b/.changeset/rhi-6643-multi-sell-swap-scope.md
@@ -2,4 +2,6 @@
 '@rhinestone/sdk': minor
 ---
 
-`swap.sell` accepts `tokens` as well as `token`, so one session can authorise spending any of several tokens. The sell pins become an OR across the list, evaluated on-chain by ArgPolicy. A single `token` is unchanged — same rules, same policy type, same digest — so sessions already signed against it keep working.
+`swap.sell` accepts `tokens` as well as `token`, so one session can authorise spending any of several tokens — for an account that may receive whichever the sender chooses. Each token gets its own approve permission, and the swap actions accept any of them.
+
+Passing a single `token` is unchanged: same permissions, same actions, same session digest, so sessions already signed against it keep working. An empty `tokens` list, a repeated token, or a sell token that is also the buy token are rejected.

--- a/.changeset/rhi-6643-multi-sell-swap-scope.md
+++ b/.changeset/rhi-6643-multi-sell-swap-scope.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+`swap.sell` accepts `tokens` as well as `token`, so one session can authorise spending any of several tokens. The sell pins become an OR across the list, evaluated on-chain by ArgPolicy. A single `token` is unchanged — same rules, same policy type, same digest — so sessions already signed against it keep working.

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -548,9 +548,8 @@ type SpendingLimitField<TFn extends AbiFunction> =
     ? { spendingLimit?: { token: Address; amount: bigint } }
     : { spendingLimit?: never }
 
-type ValueLimitField<TFn extends AbiFunction> = IsPayable<TFn> extends true
-  ? { valueLimit?: bigint }
-  : { valueLimit?: never }
+type ValueLimitField<TFn extends AbiFunction> =
+  IsPayable<TFn> extends true ? { valueLimit?: bigint } : { valueLimit?: never }
 
 type PermissionFunctionConfig<TFn extends AbiFunction> = {
   /** `valueLimitPerUse` embedded in universal/arg-policy `ActionConfig`. */
@@ -686,17 +685,27 @@ type SessionSigning =
  * })
  * ```
  */
+/**
+ * Cumulative cap on total sell-token spend across the whole session — enforced
+ * both as a spending-limit on the approve and as an accumulating bound on each
+ * swap's own amount, so a pre-existing allowance cannot be used to exceed it.
+ * Omit for no cap.
+ */
+type SwapSellCap = { maxTotal?: bigint }
+
 interface SwapScope<TChainId extends number = number> {
-  sell: {
-    token: Address
-    /**
-     * Cumulative cap on total sell-token spend across the whole session —
-     * enforced both as a spending-limit on the approve and as an accumulating
-     * bound on each swap's own amount, so a pre-existing allowance cannot be
-     * used to exceed it. Omit for no cap.
-     */
-    maxTotal?: bigint
-  }
+  /**
+   * The token this session may spend, or `tokens` for several — one session
+   * then serves an account that may receive any of a set, which is the case
+   * when the sender chooses what arrives.
+   *
+   * A single `token` is not `tokens` of length one: it keeps the rule shape and
+   * policy type it has always produced, so sessions already signed against it
+   * are unaffected.
+   */
+  sell:
+    | ({ token: Address; tokens?: never } & SwapSellCap)
+    | ({ tokens: readonly Address[]; token?: never } & SwapSellCap)
   buy: { token: Address }
   /**
    * Swap output recipient, normally the account itself. Pinned on-chain as an
@@ -1201,6 +1210,7 @@ export type {
   CallInput,
   CallResolveContext,
   ChainSessionConfig,
+  ClosePerpRequest,
   CrossChainPermissionInput,
   CrossChainPermit,
   CrossChainSettlementLayer,
@@ -1210,6 +1220,8 @@ export type {
   FromLeg,
   GuardiansSignerSet,
   HcaAccount,
+  HyperCoreOptions,
+  HyperliquidConfig,
   JwtAuth,
   KernelAccount,
   LazyCallInput,
@@ -1219,6 +1231,7 @@ export type {
   NexusAccount,
   NonEvmTokenRequest,
   NonEvmTokenRequests,
+  OpenPerpRequest,
   OwnableValidatorConfig,
   OwnerSet,
   ParamConstraint,
@@ -1260,10 +1273,6 @@ export type {
   SwapQuoter,
   SwapQuoterFilter,
   SwapScope,
-  ClosePerpRequest,
-  HyperCoreOptions,
-  HyperliquidConfig,
-  OpenPerpRequest,
   TokenRequest,
   TokenRequests,
   TokenSymbol,

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -720,6 +720,12 @@ interface SwapScope<TChainId extends number = number> {
    * A single `token` is not `tokens` of length one: it keeps the rule shape and
    * policy type it has always produced, so sessions already signed against it
    * are unaffected.
+   *
+   * Several tokens are authorised as alternatives, so the rules grow with
+   * tokens x named venues and the policy has a hard ceiling of 128. Three
+   * tokens across two named aggregators encodes; four does not, and fails when
+   * the session is built rather than silently dropping anything. Name fewer
+   * venues if you need more tokens.
    */
   sell:
     | ({ token: Address; tokens?: never } & SwapSellCap)

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -548,8 +548,9 @@ type SpendingLimitField<TFn extends AbiFunction> =
     ? { spendingLimit?: { token: Address; amount: bigint } }
     : { spendingLimit?: never }
 
-type ValueLimitField<TFn extends AbiFunction> =
-  IsPayable<TFn> extends true ? { valueLimit?: bigint } : { valueLimit?: never }
+type ValueLimitField<TFn extends AbiFunction> = IsPayable<TFn> extends true
+  ? { valueLimit?: bigint }
+  : { valueLimit?: never }
 
 type PermissionFunctionConfig<TFn extends AbiFunction> = {
   /** `valueLimitPerUse` embedded in universal/arg-policy `ActionConfig`. */

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -686,10 +686,27 @@ type SessionSigning =
  * ```
  */
 /**
- * Cumulative cap on total sell-token spend across the whole session — enforced
- * both as a spending-limit on the approve and as an accumulating bound on each
- * swap's own amount, so a pre-existing allowance cannot be used to exceed it.
+ * Cumulative cap on sell-token spend, enforced on two surfaces so a
+ * pre-existing allowance cannot be used to exceed it: as a spending-limit on
+ * the approve, and as an accumulating bound on each swap's own sell amount.
  * Omit for no cap.
+ *
+ * With a single `sell.token` it is what it reads as: one lifetime cap on that
+ * token. With `sell.tokens` it is a cap PER SURFACE, not one budget shared
+ * across everything, because neither surface can express a shared counter:
+ *
+ * - approve — one permission per token, each carrying its own `maxTotal`
+ *   spending limit. A permission's `address` IS the token, so N tokens are N
+ *   counters, and the approve surface therefore admits up to N × `maxTotal`.
+ * - swap — one accumulating counter per authorised call shape, shared by every
+ *   token (with several sell tokens the token pins sit in one action's
+ *   alternatives). Distinct venues are distinct actions, so each carries its
+ *   own counter.
+ *
+ * So `maxTotal` bounds any one token's approvals and any one call shape's swap
+ * volume; it is not a single ceiling on the session's total spend. Size it as
+ * the per-token bound you are willing to grant, and treat the aggregate as
+ * that times the number of tokens.
  */
 type SwapSellCap = { maxTotal?: bigint }
 
@@ -705,7 +722,10 @@ interface SwapScope<TChainId extends number = number> {
    */
   sell:
     | ({ token: Address; tokens?: never } & SwapSellCap)
-    | ({ tokens: readonly [Address, ...Address[]]; token?: never } & SwapSellCap)
+    | ({
+        tokens: readonly [Address, ...Address[]]
+        token?: never
+      } & SwapSellCap)
   buy: { token: Address }
   /**
    * Swap output recipient, normally the account itself. Pinned on-chain as an

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -705,7 +705,7 @@ interface SwapScope<TChainId extends number = number> {
    */
   sell:
     | ({ token: Address; tokens?: never } & SwapSellCap)
-    | ({ tokens: readonly Address[]; token?: never } & SwapSellCap)
+    | ({ tokens: readonly [Address, ...Address[]]; token?: never } & SwapSellCap)
   buy: { token: Address }
   /**
    * Swap output recipient, normally the account itself. Pinned on-chain as an

--- a/src/modules/validators/smart-sessions/swap/fynd.ts
+++ b/src/modules/validators/smart-sessions/swap/fynd.ts
@@ -2,7 +2,12 @@ import { type Abi, type Address, toFunctionSelector } from 'viem'
 import { namedParamOffsets } from '../../permissions'
 import type { FyndVenue, UniversalActionPolicyParamRule } from '../types'
 import type { VenueContext, VenueScoping } from './rules'
-import { cumulativeCap, pin, swapAction } from './rules'
+import {
+  cumulativeCap,
+  pin,
+  sellPinsGoInAlternatives,
+  swapAction,
+} from './rules'
 
 /**
  * fynd — Rhinestone's self-hosted Tycho aggregator.
@@ -103,16 +108,23 @@ export function scopeFynd(ctx: VenueContext): VenueScoping {
         `Supported: ${FYND_CHAIN_IDS.join(', ')}.`,
     )
   }
+  const multiSell = sellPinsGoInAlternatives(ctx)
   const rules: UniversalActionPolicyParamRule[] = [
-    pin(OFFSETS.tokenIn, ctx.sellToken),
+    // One token keeps its pin here, which is what preserves the historical
+    // rule order, policy type and digest.
+    ...(multiSell ? [] : [pin(OFFSETS.tokenIn, ctx.sellTokens[0])]),
     pin(OFFSETS.tokenOut, ctx.buyToken),
     pin(OFFSETS.receiver, ctx.recipient),
   ]
   if (ctx.cap !== undefined) {
     rules.push(cumulativeCap(OFFSETS.amountIn, ctx.cap))
   }
+  // Several tokens become an OR over the one word that differs between them.
+  const sellAlternatives = multiSell
+    ? ctx.sellTokens.map((token) => [pin(OFFSETS.tokenIn, token)])
+    : []
   return {
     approveSpenders: [router],
-    actions: [swapAction(router, FYND_SWAP_SELECTOR, rules)],
+    actions: [swapAction(router, FYND_SWAP_SELECTOR, rules, sellAlternatives)],
   }
 }

--- a/src/modules/validators/smart-sessions/swap/rhinestone.ts
+++ b/src/modules/validators/smart-sessions/swap/rhinestone.ts
@@ -315,14 +315,6 @@ export function scopeRhinestone(
         `Supported: ${FYND_CHAIN_IDS.join(', ')}.`,
     )
   }
-  // Which router the pinned tail must call. Undefined route = unconstrained.
-  const routeAggregator =
-    venue.route === 'zeroEx'
-      ? ZEROX_ALLOWANCE_HOLDER
-      : venue.route === 'fynd'
-        ? FYND_ROUTERS[ctx.chainId as FyndChainId]
-        : undefined
-
   const multiSell = sellPinsGoInAlternatives(ctx)
 
   /** Route pins for one (sell token, aggregator) pair. */

--- a/src/modules/validators/smart-sessions/swap/rhinestone.ts
+++ b/src/modules/validators/smart-sessions/swap/rhinestone.ts
@@ -7,7 +7,14 @@ import type {
 } from '../types'
 import { FYND_CHAIN_IDS, FYND_ROUTERS, type FyndChainId } from './fynd'
 import type { VenueContext, VenueScoping } from './rules'
-import { cumulativeCap, pin, pinValue, pinWord, swapAction } from './rules'
+import {
+  cumulativeCap,
+  pin,
+  pinValue,
+  pinWord,
+  sellPinsGoInAlternatives,
+  swapAction,
+} from './rules'
 import { ZEROX_ALLOWANCE_HOLDER, ZEROX_CHAIN_IDS } from './zero-ex'
 
 /**
@@ -316,44 +323,82 @@ export function scopeRhinestone(
         ? FYND_ROUTERS[ctx.chainId as FyndChainId]
         : undefined
 
+  const multiSell = sellPinsGoInAlternatives(ctx)
+
+  /** Route pins for one (sell token, aggregator) pair. */
+  const routeRulesFor = (
+    sellToken: Address,
+    route: 'zeroEx' | 'fynd',
+  ): UniversalActionPolicyParamRule[] =>
+    routeRules(
+      sellToken,
+      route === 'zeroEx'
+        ? ZEROX_ALLOWANCE_HOLDER
+        : FYND_ROUTERS[ctx.chainId as FyndChainId],
+      route === 'zeroEx' ? venue.settler : undefined,
+      route === 'fynd' ? { buyToken: ctx.buyToken, swapper } : undefined,
+    )
+
   const rulesFor = (
     offsets: Record<string, bigint>,
     sellAmountParam: string,
   ): UniversalActionPolicyParamRule[] => {
     const rules = [
-      pin(offsets.tokenIn, ctx.sellToken),
+      // With one token the pin stays here, which is what keeps the rule order,
+      // the chosen policy type and the digest identical to what callers have
+      // already signed. With several it moves into the OR below, because the
+      // wrapped route mentions the sell token at more than one offset and a
+      // branch has to agree with itself.
+      ...(multiSell ? [] : [pin(offsets.tokenIn, ctx.sellTokens[0])]),
       pin(offsets.tokenOut, ctx.buyToken),
       pin(offsets.recipient, ctx.recipient),
     ]
     if (ctx.cap !== undefined) {
       rules.push(cumulativeCap(offsets[sellAmountParam], ctx.cap))
     }
-    if (venue.routes === undefined && routeAggregator !== undefined) {
-      rules.push(
-        ...routeRules(
-          ctx.sellToken,
-          routeAggregator,
-          venue.route === 'zeroEx' ? venue.settler : undefined,
-          venue.route === 'fynd'
-            ? { buyToken: ctx.buyToken, swapper }
-            : undefined,
-        ),
-      )
+    if (
+      !multiSell &&
+      venue.routes === undefined &&
+      routeAggregator !== undefined
+    ) {
+      rules.push(...routeRulesFor(ctx.sellTokens[0], venue.route as 'zeroEx'))
     }
     return rules
   }
 
-  /** One rule set per authorised aggregator; the policy requires any one. */
-  const routeAlternatives = (venue.routes ?? []).map((route) =>
-    routeRules(
-      ctx.sellToken,
-      route === 'zeroEx'
-        ? ZEROX_ALLOWANCE_HOLDER
-        : FYND_ROUTERS[ctx.chainId as FyndChainId],
-      route === 'zeroEx' ? venue.settler : undefined,
-      route === 'fynd' ? { buyToken: ctx.buyToken, swapper } : undefined,
-    ),
-  )
+  /**
+   * The OR branches. Each must be self-consistent: every offset that names the
+   * sell token has to name the SAME one, so a branch is a (token, route) pair
+   * rather than a token pin and a route pin chosen independently.
+   *
+   * Single token, several routes -> today's per-route alternatives, unchanged.
+   * Several tokens -> the cross product, which is what lets one session serve
+   * an account that may receive any of a set of tokens.
+   */
+  const alternativesFor = (
+    offsets: Record<string, bigint>,
+  ): UniversalActionPolicyParamRule[][] => {
+    const routes: ('zeroEx' | 'fynd' | undefined)[] =
+      venue.routes !== undefined
+        ? [...venue.routes]
+        : [venue.route === undefined ? undefined : venue.route]
+
+    if (!multiSell) {
+      // Unchanged: no branches at all unless several routes were named.
+      return venue.routes === undefined
+        ? []
+        : routes.map((route) =>
+            routeRulesFor(ctx.sellTokens[0], route as 'zeroEx'),
+          )
+    }
+
+    return ctx.sellTokens.flatMap((token) =>
+      routes.map((route) => [
+        pin(offsets.tokenIn, token),
+        ...(route === undefined ? [] : routeRulesFor(token, route)),
+      ]),
+    )
+  }
 
   return {
     // The account approves the proxy, never the Swapper and never a router —
@@ -364,13 +409,13 @@ export function scopeRhinestone(
         swapper,
         SWAP_EXACT_IN_SELECTOR,
         rulesFor(EXACT_IN, 'amountIn'),
-        routeAlternatives,
+        alternativesFor(EXACT_IN),
       ),
       swapAction(
         swapper,
         SWAP_EXACT_OUT_SELECTOR,
         rulesFor(EXACT_OUT, 'amountInMax'),
-        routeAlternatives,
+        alternativesFor(EXACT_OUT),
       ),
     ],
   }

--- a/src/modules/validators/smart-sessions/swap/rhinestone.ts
+++ b/src/modules/validators/smart-sessions/swap/rhinestone.ts
@@ -356,12 +356,10 @@ export function scopeRhinestone(
     if (ctx.cap !== undefined) {
       rules.push(cumulativeCap(offsets[sellAmountParam], ctx.cap))
     }
-    if (
-      !multiSell &&
-      venue.routes === undefined &&
-      routeAggregator !== undefined
-    ) {
-      rules.push(...routeRulesFor(ctx.sellTokens[0], venue.route as 'zeroEx'))
+    // Narrowed on `venue.route` itself rather than on `routeAggregator`, so
+    // the type follows the check instead of being asserted past it.
+    if (!multiSell && venue.routes === undefined && venue.route !== undefined) {
+      rules.push(...routeRulesFor(ctx.sellTokens[0], venue.route))
     }
     return rules
   }
@@ -387,8 +385,10 @@ export function scopeRhinestone(
       // Unchanged: no branches at all unless several routes were named.
       return venue.routes === undefined
         ? []
-        : routes.map((route) =>
-            routeRulesFor(ctx.sellTokens[0], route as 'zeroEx'),
+        : routes.flatMap((route) =>
+            route === undefined
+              ? []
+              : [routeRulesFor(ctx.sellTokens[0], route)],
           )
     }
 

--- a/src/modules/validators/smart-sessions/swap/rhinestone.ts
+++ b/src/modules/validators/smart-sessions/swap/rhinestone.ts
@@ -315,6 +315,18 @@ export function scopeRhinestone(
         `Supported: ${FYND_CHAIN_IDS.join(', ')}.`,
     )
   }
+  // An empty list authorises nothing, the same as `swap.via: []`, and it is
+  // worse than useless here: with several sell tokens the tokenIn pin has
+  // already moved out of the shared rules and into the branches, so an empty
+  // cross product leaves the sell token UNPINNED and the session able to sell
+  // anything the proxy is approved for.
+  if (venue.routes !== undefined && venue.routes.length === 0) {
+    throw new Error(
+      'rhinestoneSwap routes must list at least one aggregator — an empty ' +
+        'list would authorise nothing. Omit `routes` to leave the tail open.',
+    )
+  }
+
   const multiSell = sellPinsGoInAlternatives(ctx)
 
   /** Route pins for one (sell token, aggregator) pair. */
@@ -392,6 +404,22 @@ export function scopeRhinestone(
     )
   }
 
+  // The invariant behind moving the pin: whenever it leaves the shared rules,
+  // the branches must put it back. Checked rather than assumed — an empty
+  // alternatives list silently unpins the sell token, and the resulting scope
+  // looks well-formed.
+  const assertSellTokenPinned = (
+    alternatives: UniversalActionPolicyParamRule[][],
+  ): UniversalActionPolicyParamRule[][] => {
+    if (multiSell && alternatives.length === 0) {
+      throw new Error(
+        'internal: several sell tokens but no alternatives to pin them in — ' +
+          'the sell token would be unconstrained',
+      )
+    }
+    return alternatives
+  }
+
   return {
     // The account approves the proxy, never the Swapper and never a router —
     // one fixed spender per chain, whichever aggregator ends up filling.
@@ -401,13 +429,13 @@ export function scopeRhinestone(
         swapper,
         SWAP_EXACT_IN_SELECTOR,
         rulesFor(EXACT_IN, 'amountIn'),
-        alternativesFor(EXACT_IN),
+        assertSellTokenPinned(alternativesFor(EXACT_IN)),
       ),
       swapAction(
         swapper,
         SWAP_EXACT_OUT_SELECTOR,
         rulesFor(EXACT_OUT, 'amountInMax'),
-        alternativesFor(EXACT_OUT),
+        assertSellTokenPinned(alternativesFor(EXACT_OUT)),
       ),
     ],
   }

--- a/src/modules/validators/smart-sessions/swap/rules.ts
+++ b/src/modules/validators/smart-sessions/swap/rules.ts
@@ -162,9 +162,28 @@ export interface VenueContext {
   readonly chainId: number
   /** Selects the Swapper/proxy deployment pair. */
   readonly environment: 'production' | 'development'
-  readonly sellToken: Address
+  /**
+   * Every token this session may spend, in the caller's order. Length 1 is the
+   * historical single-token case and MUST keep producing the historical rule
+   * shape — see `sellPinsGoInAlternatives`.
+   */
+  readonly sellTokens: readonly Address[]
   readonly buyToken: Address
   readonly recipient: Address
   /** Cumulative sell-token cap, or undefined for no cap. */
   readonly cap: bigint | undefined
+}
+
+/**
+ * Whether the sell-token pins belong in the action's OR branches rather than
+ * its shared rules.
+ *
+ * Only when there is more than one. With a single token the pin stays where it
+ * has always been, which keeps the rule list, the chosen policy type and
+ * therefore the session digest byte-identical to what callers have already
+ * signed. Moving it unconditionally would be a HashMismatch for every existing
+ * swap session.
+ */
+export function sellPinsGoInAlternatives(ctx: VenueContext): boolean {
+  return ctx.sellTokens.length > 1
 }

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -33,6 +33,7 @@ import {
 
 const USDT0: Address = '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb'
 const USDC: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const DAI: Address = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 const ACCOUNT: Address = '0x1111111111111111111111111111111111111111'
 const SETTLER: Address = '0x7F2194E8d4D5B5F889b17aeCe891F89Da74F5384'
 const PLASMA = 9745
@@ -280,6 +281,66 @@ describe('resolveSwapScope — the cumulative cap', () => {
       PLASMA,
     )
     expect(ruleAt(rulesOf(actions[0]), 0n)?.usageLimit).toBe(0n)
+  })
+})
+
+describe('several sell tokens on a direct aggregator call', () => {
+  // The tokenIn pin is the one word that differs between sell tokens, so it
+  // moves into the action's OR alternatives. Asserted on the DIRECT router
+  // call, where the offset is the aggregator's own tokenIn — the Swapper-wrapped
+  // shape is covered above.
+  test('fynd: both sell tokens are authorised at the router tokenIn slot', () => {
+    const { actions } = resolveSwapScope(
+      scope({ sell: { tokens: [USDT0, DAI] }, via: [fynd()] }),
+      PLASMA,
+    )
+    const direct = actions.find(
+      (a) => a.target.toLowerCase() === TYCHO_PLASMA,
+    ) as ScopedAction
+    const pinned = rulesOf(direct)
+      .filter((r) => r.calldataOffset === 32n)
+      .map((r) => String(r.referenceValue).toLowerCase())
+
+    expect(pinned).toContain(USDT0.toLowerCase())
+    expect(pinned).toContain(DAI.toLowerCase())
+    // tokenOut and receiver stay in the AND part: they do not vary per token.
+    expect(ruleAt(rulesOf(direct), 64n)?.referenceValue).toBe(USDC)
+  })
+
+  test('zeroEx: both sell tokens are authorised at the AllowanceHolder token slot', () => {
+    const { actions } = resolveSwapScope(
+      scope({
+        sell: { tokens: [USDT0, DAI] },
+        via: [zeroEx({ settler: SETTLER })],
+      }),
+      PLASMA,
+    )
+    const direct = actions.find(
+      (a) =>
+        a.target.toLowerCase() === ZEROX_ALLOWANCE_HOLDER.toLowerCase() &&
+        a.selector === ALLOWANCE_HOLDER_EXEC_SELECTOR,
+    ) as ScopedAction
+    // exec(operator, token, amount, target, data): token is the second word.
+    const pinned = rulesOf(direct)
+      .filter((r) => r.calldataOffset === 32n)
+      .map((r) => String(r.referenceValue).toLowerCase())
+
+    expect(pinned).toContain(USDT0.toLowerCase())
+    expect(pinned).toContain(DAI.toLowerCase())
+  })
+
+  // Neither a pinned Settler nor anySettler leaves the operator, target and
+  // amount all unbounded on the AllowanceHolder path. The union forbids it;
+  // a plain-JS caller reaches it.
+  test('zeroEx: refuses a venue with neither a settler nor anySettler', () => {
+    expect(() =>
+      resolveSwapScope(
+        scope({
+          via: [{ route: 'zeroEx' } as unknown as ReturnType<typeof zeroEx>],
+        }),
+        PLASMA,
+      ),
+    ).toThrow(/pinned settler or anySettler/)
   })
 })
 
@@ -837,8 +898,6 @@ describe('venue maxSpend', () => {
 })
 
 describe('resolveSwapScope — several sell tokens', () => {
-  const DAI: Address = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
-
   const scopeFor = (sell: SwapScopeInput['sell']) =>
     resolveSwapScope(
       { sell, buy: { token: USDT0 }, to: ACCOUNT, via: [rhinestoneSwap()] },

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -906,6 +906,24 @@ describe('resolveSwapScope — several sell tokens', () => {
     ).toThrow(/at least one token/)
   })
 
+  // Unreachable for a TypeScript caller (the union forbids it) but reachable
+  // from a deserialized scope, and either resolution silently changes what the
+  // session may spend.
+  test('refuses a scope naming both token and tokens', () => {
+    expect(() =>
+      scopeFor({
+        token: USDC,
+        tokens: [USDC, USDT0],
+      } as unknown as { tokens: [Address, ...Address[]] }),
+    ).toThrow(/mutually exclusive/)
+  })
+
+  test('refuses a scope naming neither', () => {
+    expect(() =>
+      scopeFor({} as unknown as { tokens: [Address, ...Address[]] }),
+    ).toThrow(/must name a token/)
+  })
+
   test('refuses a repeated token', () => {
     expect(() => scopeFor({ tokens: [USDC, USDC] })).toThrow(/repeats/)
   })

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -835,3 +835,77 @@ describe('venue maxSpend', () => {
     expect(ruleAt(rulesOf(actions[0]), 32n)?.usageLimit).toBe(7n)
   })
 })
+
+describe('resolveSwapScope — several sell tokens', () => {
+  const DAI: Address = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+
+  const scopeFor = (sell: SwapScopeInput['sell']) =>
+    resolveSwapScope(
+      { sell, buy: { token: USDT0 }, to: ACCOUNT, via: [rhinestoneSwap()] },
+      PLASMA,
+    )
+
+  // The reason this feature exists: a deposit address takes whatever the
+  // depositor sends, so a session pinned to one sell token refuses every other.
+  test('authorises each token with its own approve action', () => {
+    const scoped = scopeFor({ tokens: [USDC, DAI] })
+
+    const approveAddresses = scoped.permissions.map((p) =>
+      (p.address as Address).toLowerCase(),
+    )
+
+    expect(approveAddresses).toEqual([USDC.toLowerCase(), DAI.toLowerCase()])
+  })
+
+  // One on-chain action id cannot carry two policies, so the swap entrypoints
+  // stay single actions and the tokens become OR branches inside them.
+  test('keeps one action per swap entrypoint, not one per token', () => {
+    const one = scopeFor({ token: USDC })
+    const two = scopeFor({ tokens: [USDC, DAI] })
+
+    const entrypoints = (r: typeof one) =>
+      r.actions.filter((a) => 'target' in a && a.target === SWAPPER_PLASMA)
+        .length
+
+    expect(entrypoints(two)).toBe(entrypoints(one))
+  })
+
+  // ArgPolicy is the one whose on-chain evaluator handles OR nodes;
+  // UniversalActionPolicy compares a word against a single constant, so it
+  // cannot express "either of these tokens".
+  test('uses the policy that can evaluate an OR', () => {
+    const two = scopeFor({ tokens: [USDC, DAI] })
+
+    const swapAction = two.actions.find(
+      (a) => 'target' in a && a.target === SWAPPER_PLASMA,
+    )
+
+    expect(swapAction?.policies?.[0]?.type).toBe('arg-policy')
+  })
+
+  // A single token is not a list of one: it must keep the exact shape and
+  // policy type it has always produced, or every already-signed swap session
+  // becomes a HashMismatch.
+  test('leaves the single-token shape untouched', () => {
+    const one = scopeFor({ token: USDC })
+
+    const swapAction = one.actions.find(
+      (a) => 'target' in a && a.target === SWAPPER_PLASMA,
+    )
+
+    expect(swapAction?.policies?.[0]?.type).toBe('universal-action')
+    expect(one.permissions).toHaveLength(1)
+  })
+
+  test('refuses an empty token list rather than authorising nothing', () => {
+    expect(() => scopeFor({ tokens: [] })).toThrow(/at least one token/)
+  })
+
+  test('refuses a repeated token', () => {
+    expect(() => scopeFor({ tokens: [USDC, USDC] })).toThrow(/repeats/)
+  })
+
+  test('refuses a sell token that is also the buy token', () => {
+    expect(() => scopeFor({ tokens: [USDC, USDT0] })).toThrow(/same address/)
+  })
+})

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -897,8 +897,13 @@ describe('resolveSwapScope — several sell tokens', () => {
     expect(one.permissions).toHaveLength(1)
   })
 
+  // The type makes this unreachable for a TypeScript caller (`tokens` is a
+  // non-empty tuple), so the cast is the only way to reach the runtime guard —
+  // which still has to hold for JavaScript callers.
   test('refuses an empty token list rather than authorising nothing', () => {
-    expect(() => scopeFor({ tokens: [] })).toThrow(/at least one token/)
+    expect(() =>
+      scopeFor({ tokens: [] as unknown as [Address, ...Address[]] }),
+    ).toThrow(/at least one token/)
   })
 
   test('refuses a repeated token', () => {

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -63,6 +63,53 @@ function flatten(
   throw new Error(`unexpected node in a swap policy: ${expression.type}`)
 }
 
+/**
+ * The OR branches of a swap policy, as separate rule lists.
+ *
+ * `flatten` deliberately loses which branch a rule belongs to, which is enough
+ * to assert a slot is pinned at all — and NOT enough to catch the failure that
+ * matters here: a constraint that should bind every branch ending up inside
+ * one, or a branch mixing two sell tokens. Those need the tree.
+ */
+function branchesOf(action: ScopedAction): {
+  shared: UniversalActionPolicyParamRule[]
+  branches: UniversalActionPolicyParamRule[][]
+} {
+  const policy = action.policies?.[0]
+  if (policy?.type !== 'arg-policy') {
+    return { shared: rulesOf(action), branches: [] }
+  }
+  const shared: UniversalActionPolicyParamRule[] = []
+  const branches: UniversalActionPolicyParamRule[][] = []
+  const collectOr = (node: ArgPolicyExpression): void => {
+    if (node.type === 'or') {
+      collectOr(node.left)
+      collectOr(node.right)
+      return
+    }
+    branches.push(flatten(node))
+  }
+  const walk = (node: ArgPolicyExpression): void => {
+    if (node.type === 'or') {
+      collectOr(node)
+      return
+    }
+    if (node.type === 'and') {
+      walk(node.left)
+      walk(node.right)
+      return
+    }
+    // A `not` node carries no rule of its own; swap policies never build
+    // one, and treating it as a rule would silently invert an assertion.
+    if (node.type !== 'rule') {
+      throw new Error(`unexpected node in a swap policy: ${node.type}`)
+    }
+    shared.push(node.rule)
+  }
+  walk(policy.expression)
+  return { shared, branches }
+}
+
 function rulesOf(action: ScopedAction): UniversalActionPolicyParamRule[] {
   const policy = action.policies?.[0]
   if (policy?.type === 'universal-action') return [...policy.rules]
@@ -927,6 +974,53 @@ describe('resolveSwapScope — several sell tokens', () => {
         .length
 
     expect(entrypoints(two)).toBe(entrypoints(one))
+  })
+
+  // The property the whole multi-sell shape rests on, and the one `flatten`
+  // cannot see: what binds EVERY branch must sit outside the OR, and each
+  // branch must name one token at every offset that mentions a sell token. A
+  // constraint trapped inside a branch is satisfiable by picking another.
+  test('keeps the shared constraints outside the OR, one token per branch', () => {
+    const two = scopeFor({ tokens: [USDC, DAI] })
+
+    const swapAction = two.actions.find(
+      (a) => 'target' in a && a.target === SWAPPER_PLASMA,
+    ) as ScopedAction
+    const { shared, branches } = branchesOf(swapAction)
+
+    // Buy token (64) and recipient (160) bind every branch, so they sit
+    // outside the OR rather than being repeated inside it.
+    const sharedOffsets = shared.map((r) => r.calldataOffset)
+    expect(sharedOffsets).toContain(64n)
+    expect(sharedOffsets).toContain(160n)
+    expect(branches.length).toBeGreaterThan(1)
+
+    // And no branch may name two different sell tokens at its own offsets.
+    for (const branch of branches) {
+      const named = new Set(
+        branch
+          .map((r) => String(r.referenceValue).toLowerCase())
+          .filter((v) => v === USDC.toLowerCase() || v === DAI.toLowerCase()),
+      )
+      expect(named.size).toBeLessThanOrEqual(1)
+    }
+  })
+
+  // The regression this pairs with: with the pin moved into the branches, an
+  // empty branch list leaves the sell token unconstrained — the session could
+  // sell anything the proxy is approved for. Refused instead.
+  test('refuses a routed venue with no routes rather than unpinning the token', () => {
+    expect(() =>
+      resolveSwapScope(
+        {
+          sell: { tokens: [USDC, DAI] },
+          buy: { token: USDT0 },
+          to: ACCOUNT,
+          via: [{ id: 'rhinestone', routes: [] } as never],
+        },
+        PLASMA,
+      ),
+    ).toThrow(/at least one aggregator/)
   })
 
   // ArgPolicy is the one whose on-chain evaluator handles OR nodes;

--- a/src/modules/validators/smart-sessions/swap/scope.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.ts
@@ -64,11 +64,13 @@ const erc20ApproveAbi = [
 ] as const satisfies Abi
 
 /**
- * One approve permission covering every venue's spender.
+ * The approve permission for ONE sell token, covering every venue's spender.
  *
- * Merged rather than one-per-venue because all venues pull the same sell token;
- * a single action with a spender allowlist is cheaper to install and keeps the
- * spending-limit a single shared counter instead of one budget per venue.
+ * One per token, not one per venue: every venue pulls the same token, so a
+ * single action with a spender allowlist is cheaper to install and keeps the
+ * spending limit a shared counter rather than a budget per venue. Several sell
+ * tokens mean several of these — the permission's `address` IS the token, so it
+ * cannot be merged further.
  */
 function approvePermission(
   sellToken: Address,

--- a/src/modules/validators/smart-sessions/swap/scope.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.ts
@@ -127,9 +127,23 @@ export function resolveSwapScope(
   // One shape from here down. `token` and `tokens` are the same thing to
   // everything downstream except rule placement, which `sellPinsGoInAlternatives`
   // decides from the length.
-  const sellTokens: readonly Address[] = scope.sell.tokens ?? [
-    scope.sell.token as Address,
-  ]
+  //
+  // Both present is refused rather than resolved. The type makes it impossible
+  // for a TypeScript caller, but a deserialized scope can carry both, and
+  // preferring either one silently widens or narrows what the session may
+  // spend. Neither present is refused for the same reason: it would otherwise
+  // reach the checks below as `[undefined]`.
+  const { token, tokens } = scope.sell
+  if (token !== undefined && tokens !== undefined) {
+    throw new Error(
+      'swap.sell names both token and tokens — they are mutually exclusive, so ' +
+        'which tokens the session may spend is ambiguous. Pass one.',
+    )
+  }
+  if (token === undefined && tokens === undefined) {
+    throw new Error('swap.sell must name a token or a non-empty tokens list')
+  }
+  const sellTokens: readonly Address[] = tokens ?? [token as Address]
   if (sellTokens.length === 0) {
     throw new Error(
       'swap.sell.tokens must name at least one token — an empty list would authorise nothing',

--- a/src/modules/validators/smart-sessions/swap/scope.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.ts
@@ -71,7 +71,8 @@ const erc20ApproveAbi = [
  * spending-limit a single shared counter instead of one budget per venue.
  */
 function approvePermission(
-  scope: SwapScopeInput,
+  sellToken: Address,
+  maxTotal: bigint | undefined,
   scopings: VenueScoping[],
 ): Permission {
   const spenders = [
@@ -81,14 +82,14 @@ function approvePermission(
   ].map((s) => s as Address)
   return {
     abi: erc20ApproveAbi as unknown as Abi,
-    address: scope.sell.token,
+    address: sellToken,
     functions: {
       approve: {
-        ...(scope.sell.maxTotal !== undefined
+        ...(maxTotal !== undefined
           ? {
               spendingLimit: {
-                token: scope.sell.token,
-                amount: scope.sell.maxTotal,
+                token: sellToken,
+                amount: maxTotal,
               },
             }
           : {}),
@@ -121,16 +122,36 @@ export function resolveSwapScope(
       'swap.via must list at least one venue — an empty list would authorise nothing',
     )
   }
-  if (scope.sell.token.toLowerCase() === scope.buy.token.toLowerCase()) {
+  // One shape from here down. `token` and `tokens` are the same thing to
+  // everything downstream except rule placement, which `sellPinsGoInAlternatives`
+  // decides from the length.
+  const sellTokens: readonly Address[] = scope.sell.tokens ?? [
+    scope.sell.token as Address,
+  ]
+  if (sellTokens.length === 0) {
     throw new Error(
-      `swap.sell.token and swap.buy.token are the same address (${scope.sell.token})`,
+      'swap.sell.tokens must name at least one token — an empty list would authorise nothing',
+    )
+  }
+  const duplicate = sellTokens
+    .map((t) => t.toLowerCase())
+    .find((t, i, all) => all.indexOf(t) !== i)
+  if (duplicate) {
+    throw new Error(`swap.sell.tokens repeats ${duplicate}`)
+  }
+  const sameAsBuy = sellTokens.find(
+    (t) => t.toLowerCase() === scope.buy.token.toLowerCase(),
+  )
+  if (sameAsBuy) {
+    throw new Error(
+      `swap.sell and swap.buy.token are the same address (${sameAsBuy})`,
     )
   }
 
   const ctxFor = (venue: { maxSpend?: bigint }) => ({
     chainId,
     environment,
-    sellToken: scope.sell.token,
+    sellTokens,
     buyToken: scope.buy.token,
     recipient: scope.to,
     // A venue-level cap wins over the scope-level one: `anySettler` demands its
@@ -209,7 +230,12 @@ export function resolveSwapScope(
   })
 
   return {
-    permissions: [approvePermission(scope, scopings)],
+    // One permission per sell token: distinct addresses are distinct on-chain
+    // action ids, so they carry their own policies without conflicting. A single
+    // merged permission cannot express two tokens — its `address` IS the token.
+    permissions: sellTokens.map((token) =>
+      approvePermission(token, scope.sell.maxTotal, scopings),
+    ),
     actions: dedupeActions(scopings.flatMap((s) => [...s.actions])),
   }
 }

--- a/src/modules/validators/smart-sessions/swap/zero-ex.ts
+++ b/src/modules/validators/smart-sessions/swap/zero-ex.ts
@@ -2,7 +2,13 @@ import { type Abi, type Address, toFunctionSelector } from 'viem'
 import { namedParamOffsets } from '../../permissions'
 import type { UniversalActionPolicyParamRule, ZeroExVenue } from '../types'
 import type { VenueContext, VenueScoping } from './rules'
-import { cumulativeCap, pin, pinValue, swapAction } from './rules'
+import {
+  cumulativeCap,
+  pin,
+  pinValue,
+  sellPinsGoInAlternatives,
+  swapAction,
+} from './rules'
 
 /**
  * 0x — Swap API v2, AllowanceHolder flow.
@@ -217,8 +223,10 @@ export function scopeZeroEx(
   }
   // Pinned from the scope, never from venue options — the sell token is a
   // scope-level guarantee and must not depend on the caller restating it.
+  const multiSell = sellPinsGoInAlternatives(ctx)
   const rules: UniversalActionPolicyParamRule[] = [
-    pin(EXEC.token, ctx.sellToken),
+    // One token keeps its pin here, preserving the historical digest.
+    ...(multiSell ? [] : [pin(EXEC.token, ctx.sellTokens[0])]),
   ]
   if (venue.settler !== undefined) {
     rules.push(pin(EXEC.operator, venue.settler))
@@ -231,10 +239,18 @@ export function scopeZeroEx(
   if (ctx.cap !== undefined) {
     rules.push(cumulativeCap(EXEC.amount, ctx.cap))
   }
+  const sellAlternatives = multiSell
+    ? ctx.sellTokens.map((token) => [pin(EXEC.token, token)])
+    : []
   return {
     approveSpenders: [ZEROX_ALLOWANCE_HOLDER],
     actions: [
-      swapAction(ZEROX_ALLOWANCE_HOLDER, ALLOWANCE_HOLDER_EXEC_SELECTOR, rules),
+      swapAction(
+        ZEROX_ALLOWANCE_HOLDER,
+        ALLOWANCE_HOLDER_EXEC_SELECTOR,
+        rules,
+        sellAlternatives,
+      ),
     ],
   }
 }

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -122,7 +122,27 @@ export type SwapVenue = RhinestoneSwapVenue | ZeroExVenue | FyndVenue
 
 /** Loose (chain-unaware) swap scope. The public config type narrows `via` by chain. */
 export interface SwapScopeInput {
-  readonly sell: { readonly token: Address; readonly maxTotal?: bigint }
+  /**
+   * The token(s) this session may spend. `tokens` authorises several — the sell
+   * pins become an OR across them, so one session serves an account that can
+   * receive any of a set (a deposit address, for instance, where the depositor
+   * chooses what arrives).
+   *
+   * A single `token` is NOT `tokens` of length one: it keeps the exact rule
+   * shape and policy type it has always produced, so the digest of every
+   * session already signed against it is unchanged.
+   */
+  readonly sell:
+    | {
+        readonly token: Address
+        readonly tokens?: never
+        readonly maxTotal?: bigint
+      }
+    | {
+        readonly tokens: readonly Address[]
+        readonly token?: never
+        readonly maxTotal?: bigint
+      }
   readonly buy: { readonly token: Address }
   /** Swap output recipient — pinned, so a compromised key cannot redirect output. */
   readonly to: Address

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -139,7 +139,7 @@ export interface SwapScopeInput {
         readonly maxTotal?: bigint
       }
     | {
-        readonly tokens: readonly Address[]
+        readonly tokens: readonly [Address, ...Address[]]
         readonly token?: never
         readonly maxTotal?: bigint
       }


### PR DESCRIPTION
## What

`swap.sell` accepts `tokens` as well as `token`:

```ts
swap: { sell: { tokens: [USDC, USDT, DAI], maxTotal }, buy: { token: WETH }, to, via }
```

The sell pins become an OR across the list, so one session serves an account that may receive **any** of a set rather than exactly one.

## Why

This is the deposit service's case (RHI-6643), and it is not an edge case. An account record pins only the *destination* — there is no source token on it — and single accounts in production have completed deposits in **9, 8 and 8 distinct source tokens**. A session pinned to one sell token refuses every other, so scoping such an account was simply impossible before this.

## Construction

**One approve permission per token.** Distinct addresses are distinct on-chain action ids, so each carries its own policy without conflicting. A merged permission cannot express two tokens — its `address` *is* the token.

**The swap entrypoints stay one action each.** A single action id cannot carry two policies, so the tokens become OR branches *inside* the action, via `swapAction`'s existing `alternatives` — which builds `and(shared, or(branch…))` and is already evaluated on-chain by `ArgPolicyTreeLibV2`. No new contract, no new policy.

**A branch is a (token, route) pair**, not a token pin and a route pin chosen independently: the wrapped route names the sell token at more than one offset, so a branch has to agree with itself. With several routes named, that is the cross product.

## The invariant that matters

**A single `token` is deliberately not `tokens` of length one.** It keeps the same rule order, the same chosen policy type (`UniversalActionPolicy`, not `ArgPolicy`) and therefore the same digest.

Verified rather than argued — same single-token scope, digest computed on this branch and on the base commit:

```
this branch : 0x526eab8fa15fd81c41e5d33a30577ea38c2ae20187f962df42768d5148a719cd
base commit : 0x526eab8fa15fd81c41e5d33a30577ea38c2ae20187f962df42768d5148a719cd
```

Identical, 5 actions either way. Moving the pin unconditionally would be a `HashMismatch` for every swap session already signed, which is why `sellPinsGoInAlternatives` exists instead of an always-OR.

Observed behaviour, for the record:

| | swapper actions | policy | approve actions |
| --- | --- | --- | --- |
| `sell: { token }` | 1 per entrypoint | `universal-action` | 1 |
| `sell: { tokens: [a,b,c] }` | 1 per entrypoint | `arg-policy` (evaluates OR) | 3 |

## Refusals

An empty list, a repeated token, and a sell token that is also the buy token. The first matters most: it would authorise nothing while looking like a restriction.

## Testing

7 new tests; the invariance one is confirmed to **fail** under a mutation that always takes the alternatives path (a pre-existing wrapped-route test catches it too). Swap suites 75/75, `tsc --noEmit` clean, full suite 988 tests passing.

Four unrelated test *files* fail to load on `main` as well — `Cannot find package 'solady'` — verified pre-existing by stashing this change.

Refs [RHI-6643](https://linear.app/rhinestone/issue/RHI-6643/scope-the-deposit-services-session-instead-of-granting-it-sudo)
