### PR TITLE
feat(intents): surface the bridge refund on an intent's status

### DIFF
--- a/.changeset/intent-status-refunds.md
+++ b/.changeset/intent-status-refunds.md
@@ -1,0 +1,9 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Surface the bridge refund on an intent's status, so a failed cross-chain intent can say where the funds went back to.
+
+The orchestrator reports `refunds: [{ chain, txHash }]` when a settlement layer returns the funds to the account instead of delivering them, but the SDK dropped it: `mapIntentStatusFromWire` builds an explicit object and the field was not among its keys. It now reaches `IntentStatus`, `TransactionStatus` and the value `waitForExecution` resolves to, with the new `IntentRefund` type exported.
+
+The key stays **absent** when the orchestrator knows of no refund, rather than defaulting to `[]`. A refund is recorded only where a layer evidences it with a transaction, so presence is a fact and absence is not a claim — defaulting would report that funds were kept on an intent we simply have no refund for yet.

--- a/.changeset/intent-status-refunds.md
+++ b/.changeset/intent-status-refunds.md
@@ -8,4 +8,6 @@ The orchestrator reports `refunds: [{ chain, txHash }]` when a settlement layer 
 
 It also rides `IntentFailedError.context`, which is the only path it has for the case it exists to answer: a refunded intent is still `FAILED`, so `waitForExecution` throws rather than returning a status, and a caller on that path would otherwise never see the refund.
 
+`FailureReason` also gains the three values the orchestrator has always been able to serialise but the published union omitted — `BRIDGE_REFUNDED`, `BRIDGE_TIMEOUT` and `DISPATCH_FAILED`. `BRIDGE_REFUNDED` is the per-operation half of `refunds`, so without it a consumer could not branch on the very thing this release surfaces without a cast.
+
 The key stays **absent** when the orchestrator knows of no refund, rather than defaulting to `[]`. A refund is recorded only where a layer evidences it with a transaction, so presence is a fact and absence is not a claim — defaulting would report that funds were kept on an intent we simply have no refund for yet.

--- a/.changeset/intent-status-refunds.md
+++ b/.changeset/intent-status-refunds.md
@@ -6,4 +6,6 @@ Surface the bridge refund on an intent's status, so a failed cross-chain intent 
 
 The orchestrator reports `refunds: [{ chain, txHash }]` when a settlement layer returns the funds to the account instead of delivering them, but the SDK dropped it: `mapIntentStatusFromWire` builds an explicit object and the field was not among its keys. It now reaches `IntentStatus`, `TransactionStatus` and the value `waitForExecution` resolves to, with the new `IntentRefund` type exported.
 
+It also rides `IntentFailedError.context`, which is the only path it has for the case it exists to answer: a refunded intent is still `FAILED`, so `waitForExecution` throws rather than returning a status, and a caller on that path would otherwise never see the refund.
+
 The key stays **absent** when the orchestrator knows of no refund, rather than defaulting to `[]`. A refund is recorded only where a layer evidences it with a transaction, so presence is a fact and absence is not a claim — defaulting would report that funds were kept on an intent we simply have no refund for yet.

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -318,7 +318,9 @@ export interface RhinestoneAccount {
   /**
    * Wait for a submitted transaction or user operation to execute onchain.
    * Polls the orchestrator until the intent reaches a terminal state; on failure
-   * an `IntentFailedError` is thrown.
+   * an `IntentFailedError` is thrown, whose `context` carries `operations` and,
+   * where a settlement layer returned the funds, `refunds` — a refunded intent
+   * is still a failed one, so that error is where the refund surfaces.
    * @param result The result returned by a submit/send call
    * @returns The per-chain operation status (for intents) or a UserOp receipt
    */

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -816,6 +816,7 @@ export function createAccountFacade(
             status: status.status as TransactionStatus['status'],
             accountAddress: status.account,
             operations: status.operations as TransactionStatus['operations'],
+            ...(status.refunds ? { refunds: [...status.refunds] } : {}),
           }))
       }
       const ctx = context('wait-for-execution')

--- a/src/api/project-mappers.test.ts
+++ b/src/api/project-mappers.test.ts
@@ -31,6 +31,29 @@ describe('SDK project boundary adapters', () => {
     })
   })
 
+  test('carries a bridge refund onto the public shape, and omits it when absent', () => {
+    const failed = {
+      traceId: 'trace-status',
+      intentId: 'intent-1',
+      status: 'FAILED',
+      account: address,
+      operations: [],
+      terminal: true,
+    } as const
+    const refund = {
+      chain: 8453,
+      txHash:
+        '0x8e483d74ff15e79f86e0c23e81444a5db5b2ce31c9ec28f84259dfc83f0bbc28',
+    }
+
+    expect(
+      toPublicTransactionStatus({ ...failed, refunds: [refund] }).refunds,
+    ).toEqual([refund])
+    // Absent, not `[]`: the orchestrator omits the key when it knows of no
+    // refund, and that is not the same fact as "there was none".
+    expect('refunds' in toPublicTransactionStatus(failed)).toBe(false)
+  })
+
   test('maps public split requests with and without settlement filters', () => {
     expect(
       toOrchestratorSplitRequest({

--- a/src/api/project-mappers.ts
+++ b/src/api/project-mappers.ts
@@ -19,6 +19,7 @@ export function toPublicTransactionStatus(
     status: status.status,
     accountAddress: status.account,
     operations: [...status.operations],
+    ...(status.refunds ? { refunds: [...status.refunds] } : {}),
   }
 }
 

--- a/src/clients/orchestrator/mappers.test.ts
+++ b/src/clients/orchestrator/mappers.test.ts
@@ -1,6 +1,10 @@
 import type { SignedAuthorization } from 'viem'
 import { describe, expect, test } from 'vitest'
-import { mapIntentRequestToWire, mapSignedIntentToWire } from './mappers'
+import {
+  mapIntentRequestToWire,
+  mapIntentStatusFromWire,
+  mapSignedIntentToWire,
+} from './mappers'
 import type { OrchestratorSignedIntent } from './types'
 
 const address = '0x0000000000000000000000000000000000000001' as const
@@ -204,5 +208,46 @@ describe('mapIntentRequestToWire — HyperCore action', () => {
       options?: { hyperCore?: unknown }
     }
     expect(wire.options?.hyperCore).toBeUndefined()
+  })
+})
+
+describe('mapIntentStatusFromWire refunds', () => {
+  const REFUND_TX =
+    '0x8e483d74ff15e79f86e0c23e81444a5db5b2ce31c9ec28f84259dfc83f0bbc28'
+
+  const status = (refunds?: unknown) => ({
+    traceId: 'trace-1',
+    status: 'FAILED',
+    accountAddress: address,
+    operations: [
+      { chain: 8453, items: [{ status: 'COMPLETED', txHash: '0xaa' }] },
+    ],
+    ...(refunds === undefined ? {} : { refunds }),
+  })
+
+  test('surfaces the refund transaction and chain', () => {
+    const mapped = mapIntentStatusFromWire(
+      'intent-1',
+      status([{ chain: 8453, txHash: REFUND_TX }]),
+    )
+    expect(mapped.refunds).toEqual([{ chain: 8453, txHash: REFUND_TX }])
+  })
+
+  test('leaves refunds absent when the orchestrator reports none', () => {
+    // Not `[]`. The key is omitted when no refund is KNOWN, which is a
+    // different fact from "there was none" — defaulting here would tell a
+    // caller reconciling a failed intent that the funds were kept.
+    const mapped = mapIntentStatusFromWire('intent-1', status())
+    expect('refunds' in mapped).toBe(false)
+  })
+
+  test('parses a CAIP-2 refund chain the way an operation chain is parsed', () => {
+    // `chain` is a number on today's wire, but it goes through the same helper
+    // as `operations[].chain`, so the two cannot diverge if that changes.
+    const mapped = mapIntentStatusFromWire(
+      'intent-1',
+      status([{ chain: 'eip155:42161', txHash: REFUND_TX }]),
+    )
+    expect(mapped.refunds).toEqual([{ chain: 42161, txHash: REFUND_TX }])
   })
 })

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -118,6 +118,10 @@ export function mapIntentStatusFromWire(
       readonly chain?: string | number
       readonly items?: readonly unknown[]
     }[]
+    readonly refunds?: readonly {
+      readonly chain?: string | number
+      readonly txHash: string
+    }[]
   }
   return {
     traceId: input.traceId ?? '',
@@ -134,6 +138,20 @@ export function mapIntentStatusFromWire(
             {}),
         }) as ChainOperation,
     ),
+    // Deliberately NOT `?? []`, unlike every field above it. The orchestrator
+    // omits the key when it knows of no refund, and that is not the same fact
+    // as "there were none" — a refund is recorded only where a settlement layer
+    // evidences it with a transaction. Defaulting would turn "we don't know"
+    // into "the funds were kept", which is the one reading the wire contract
+    // exists to prevent.
+    ...(input.refunds
+      ? {
+          refunds: input.refunds.map((refund) => ({
+            chain: parseChainValue(refund.chain),
+            txHash: refund.txHash,
+          })),
+        }
+      : {}),
   }
 }
 

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -69,9 +69,26 @@ type OperationStatus = 'PENDING' | 'COMPLETED' | 'FAILED'
  *
  * - `EXPIRED`          – the operation deadline passed without completion
  * - `REVERTED`         – the on-chain transaction reverted
- * - `RELAYER_FAILURE`  – the relayer could not submit the transaction
+ * - `RELAYER_FAILURE`  – the relayer reported failure, or none was available
+ * - `DISPATCH_FAILED`  – the orchestrator could not get the action to the
+ *                        relayer market at all, so no relayer ever saw it
+ * - `BRIDGE_TIMEOUT`   – the bridge neither delivered nor resolved in time
+ * - `BRIDGE_REFUNDED`  – the bridge returned the funds instead of delivering;
+ *                        pair it with `refunds` on the status for the
+ *                        transaction that returned them
+ *
+ * The orchestrator's own enum additionally has `NONE`, which it filters out
+ * before serialising, so it is deliberately not here. Closed rather than
+ * widened to `string` for the same reason as the settlement layers above: a
+ * new reason is a real code change, and consumers branch on these.
  */
-type FailureReason = 'EXPIRED' | 'REVERTED' | 'RELAYER_FAILURE'
+type FailureReason =
+  | 'EXPIRED'
+  | 'REVERTED'
+  | 'RELAYER_FAILURE'
+  | 'DISPATCH_FAILED'
+  | 'BRIDGE_TIMEOUT'
+  | 'BRIDGE_REFUNDED'
 
 /**
  * One operation per chain involved in the intent.

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -653,6 +653,24 @@ interface SplitIntentsResult {
 }
 
 /**
+ * A settlement layer returned the intent's funds to the account instead of
+ * delivering them.
+ *
+ * Not an operation: Rhinestone neither built nor broadcast this transaction,
+ * and a refund never makes the intent succeed — a refunded intent stays
+ * `FAILED`, because it did not do what was asked.
+ */
+interface IntentRefund {
+  /** Chain the refund landed on. */
+  chain: number
+  /**
+   * The refund transaction, in the chain's native form (EVM hex, Solana
+   * base58, Tron hex). Interpret it against `chain`.
+   */
+  txHash: string
+}
+
+/**
  * Full intent status as returned by the orchestrator (blanc API version).
  *
  * One operation per chain involved in the intent. The SDK flattens the
@@ -667,6 +685,16 @@ interface IntentOpStatus {
   accountAddress: Address
   /** Per-chain operation status. One entry per chain. */
   operations: ChainOperation[]
+  /**
+   * Bridge refunds observed for this intent.
+   *
+   * Undefined means no refund is KNOWN — never that the funds were kept. A
+   * refund is recorded only where a settlement layer evidences it with a
+   * transaction, so presence is a fact and absence is not a claim. Read it
+   * with the operations: a `FAILED` intent whose debiting operation never
+   * completed did not take the funds in the first place.
+   */
+  refunds?: IntentRefund[]
 }
 
 export type {
@@ -712,6 +740,7 @@ export type {
   IntentSubmitRequestInternal,
   IntentSubmitResponse,
   IntentOpStatus,
+  IntentRefund,
   IntentOptions,
   SponsorSettings,
   SignedAuthorization,

--- a/src/clients/orchestrator/types.ts
+++ b/src/clients/orchestrator/types.ts
@@ -9,6 +9,7 @@ import type {
   ChainOperation,
   Cost,
   HyperCoreAction,
+  IntentRefund,
   IntentStatus,
   SerializedIntentInput,
   SettlementLayer,
@@ -136,6 +137,7 @@ export interface OrchestratorIntentStatus {
   readonly status: IntentStatus
   readonly account: Address
   readonly operations: readonly ChainOperation[]
+  readonly refunds?: readonly IntentRefund[]
 }
 
 export interface OrchestratorPortfolioRequest {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export type {
   HyperCoreUpdateLeverageAction,
   IntentInput,
   IntentOpStatus,
+  IntentRefund,
   OperationStatus,
   OriginSignature,
   Portfolio,

--- a/src/transactions/intents/domain.test.ts
+++ b/src/transactions/intents/domain.test.ts
@@ -357,6 +357,38 @@ describe('intent domain', () => {
     expect(sleep).toHaveBeenCalledWith(2_000)
   })
 
+  test('accepts every failure reason the orchestrator serialises', () => {
+    // Not a runtime assertion so much as a compile-time one: each literal has
+    // to be assignable to the public `FailureReason`, so a union narrower than
+    // the wire fails the build here rather than forcing consumers to cast.
+    // Mirrors the orchestrator's enum minus `NONE`, which it filters out before
+    // serialising. `BRIDGE_REFUNDED` is the one this PR makes consumers want:
+    // it is the per-operation half of `refunds`.
+    const reasons = [
+      'EXPIRED',
+      'REVERTED',
+      'RELAYER_FAILURE',
+      'DISPATCH_FAILED',
+      'BRIDGE_TIMEOUT',
+      'BRIDGE_REFUNDED',
+    ] as const
+
+    const classified = classifyIntentStatus({
+      traceId: '',
+      intentId: 'intent',
+      status: 'FAILED',
+      account: address,
+      operations: reasons.map((failureReason, i) => ({
+        chain: i + 1,
+        status: 'FAILED' as const,
+        failureReason,
+      })),
+    })
+    expect(classified.operations.map((op) => op.failureReason)).toEqual([
+      ...reasons,
+    ])
+  })
+
   test('carries the refund on the failed-intent error, the only path it has', () => {
     // A refunded intent is still FAILED, so `waitForIntentStatus` throws and no
     // status is ever returned — the error context is the only place a

--- a/src/transactions/intents/domain.test.ts
+++ b/src/transactions/intents/domain.test.ts
@@ -280,6 +280,28 @@ describe('intent domain', () => {
     ).toBe(false)
   })
 
+  test('classifies a bridge refund through, and leaves it absent when unknown', () => {
+    const failed = {
+      traceId: '',
+      intentId: 'intent',
+      status: 'FAILED',
+      account: address,
+      operations: [],
+    } as const
+    const refund = {
+      chain: 8453,
+      txHash:
+        '0x8e483d74ff15e79f86e0c23e81444a5db5b2ce31c9ec28f84259dfc83f0bbc28',
+    }
+
+    expect(
+      classifyIntentStatus({ ...failed, refunds: [refund] }).refunds,
+    ).toEqual([refund])
+    // Absent, not `[]` — the distinction the field rests on: presence is a
+    // fact, absence is not a claim that the funds were kept.
+    expect('refunds' in classifyIntentStatus(failed)).toBe(false)
+  })
+
   test('classifies retry delays and terminal failures', async () => {
     const rateLimit = (retryAfter?: string) =>
       new RateLimitedError({

--- a/src/transactions/intents/domain.test.ts
+++ b/src/transactions/intents/domain.test.ts
@@ -356,4 +356,42 @@ describe('intent domain', () => {
     ).rejects.toBeInstanceOf(IntentFailedError)
     expect(sleep).toHaveBeenCalledWith(2_000)
   })
+
+  test('carries the refund on the failed-intent error, the only path it has', () => {
+    // A refunded intent is still FAILED, so `waitForIntentStatus` throws and no
+    // status is ever returned — the error context is the only place a
+    // `waitForExecution` caller can read the refund from.
+    const refund = {
+      chain: 8453,
+      txHash:
+        '0x8e483d74ff15e79f86e0c23e81444a5db5b2ce31c9ec28f84259dfc83f0bbc28',
+    }
+    const failing = (refunds?: readonly (typeof refund)[]) => ({
+      statusClient: {
+        getIntentStatus: vi.fn(async () => ({
+          traceId: 'trace',
+          intentId: 'intent',
+          status: 'FAILED' as const,
+          account: address,
+          operations: [],
+          ...(refunds ? { refunds } : {}),
+        })),
+      },
+      clock: {
+        now: vi.fn().mockReturnValueOnce(0).mockReturnValue(20_000),
+        sleep: vi.fn(async () => undefined),
+      },
+    })
+
+    return Promise.all([
+      waitForIntentStatus(failing([refund]), 'intent').catch((error) => {
+        expect(error.context.refunds).toEqual([refund])
+      }),
+      waitForIntentStatus(failing(), 'intent').catch((error) => {
+        // Absent, not `[]` — a failed intent we know of no refund for must not
+        // claim one came back.
+        expect('refunds' in error.context).toBe(false)
+      }),
+    ])
+  })
 })

--- a/src/transactions/intents/domain.test.ts
+++ b/src/transactions/intents/domain.test.ts
@@ -384,9 +384,14 @@ describe('intent domain', () => {
         failureReason,
       })),
     })
-    expect(classified.operations.map((op) => op.failureReason)).toEqual([
-      ...reasons,
-    ])
+    // Narrowed rather than indexed: `ChainOperation` is discriminated on
+    // `status`, and `failureReason` exists only on the FAILED member — which is
+    // itself part of what this pins.
+    expect(
+      classified.operations.map((op) =>
+        op.status === 'FAILED' ? op.failureReason : undefined,
+      ),
+    ).toEqual([...reasons])
   })
 
   test('carries the refund on the failed-intent error, the only path it has', () => {

--- a/src/transactions/intents/status-policy.ts
+++ b/src/transactions/intents/status-policy.ts
@@ -18,6 +18,9 @@ export function classifyIntentStatus(
     status: status.status,
     account: status.account,
     operations: status.operations,
+    // Spread so an unknown refund state stays an absent key rather than
+    // becoming `undefined` — the distinction the whole field rests on.
+    ...(status.refunds ? { refunds: status.refunds } : {}),
     terminal: status.status === 'COMPLETED' || status.status === 'FAILED',
   }
 }

--- a/src/transactions/intents/status.ts
+++ b/src/transactions/intents/status.ts
@@ -53,8 +53,17 @@ export async function waitForIntentStatus<CompatibilityConfig>(
     }
     if (!status.terminal) continue
     if (status.status === 'FAILED') {
+      // The refund rides the ERROR, because this is the only path it can take:
+      // a refunded intent is still `FAILED` — it did not do what was asked —
+      // so this throws and the caller never sees a returned status. Omitting
+      // it here would hide the refund from `waitForExecution` for the exact
+      // case the field exists to answer.
       throw new IntentFailedError({
-        context: { intentId, operations: status.operations },
+        context: {
+          intentId,
+          operations: status.operations,
+          ...(status.refunds ? { refunds: status.refunds } : {}),
+        },
       })
     }
     return status

--- a/src/transactions/intents/types.ts
+++ b/src/transactions/intents/types.ts
@@ -118,6 +118,8 @@ export interface IntentStatus {
   readonly status: IntentOpStatus['status']
   readonly account: Address
   readonly operations: readonly IntentOpStatus['operations'][number][]
+  /** Bridge refunds, if any are known. See {@link IntentOpStatus.refunds}. */
+  readonly refunds?: readonly NonNullable<IntentOpStatus['refunds']>[number][]
   readonly terminal: boolean
 }
 
@@ -187,4 +189,9 @@ export interface TransactionStatus {
   accountAddress: Address
   /** Per-chain operation status. One entry per chain. */
   operations: IntentOpStatus['operations']
+  /**
+   * Bridge refunds, if any are known. This is where a failed cross-chain
+   * transaction says the funds came back. See {@link IntentOpStatus.refunds}.
+   */
+  refunds?: IntentOpStatus['refunds']
 }


### PR DESCRIPTION
The orchestrator reports `refunds: [{ chain, txHash }]` on `GET /intents/:id` when a settlement layer returns the funds to the account instead of delivering them (RHI-6582). The SDK sends the blanc header and the generated wire types already carry the field — but `mapIntentStatusFromWire` builds an explicit object and `refunds` was not among its keys, so no consumer could read it. A failed cross-chain intent reported `FAILED` and nothing about where the money went.

It now reaches `IntentStatus`, `TransactionStatus`, and the value `waitForExecution` resolves to. `IntentRefund` is exported.

## The one judgment call

**The key stays absent when the orchestrator knows of no refund**, rather than defaulting to `[]` the way every neighbouring field in that mapper defaults (`traceId ?? ''`, `operations ?? []`).

A refund is recorded only where a settlement layer evidences it with a transaction, and layers differ in whether and when they report one — so absence means "no refund is known", never "the funds were kept". Defaulting to `[]` would collapse those two into the one reading the wire contract exists to prevent, and it is a caller reconciling a failed intent who would act on it.

Carried through every hop: the mapper spreads conditionally, `classifyIntentStatus` and `toPublicTransactionStatus` do the same, and a test pins `'refunds' in mapped === false` rather than checking for an empty array.

## Also

`chain` goes through the same `parseChainValue` as an operation's chain, so the two cannot diverge if the wire ever moves to CAIP-2 — pinned by a test that feeds it `eip155:42161`.

Changeset is a **minor**: additive public surface (a new exported type and a new optional field on three returned shapes), no behaviour change to anything that exists.

## Verification

`tsc --noEmit` clean, `biome check` clean, 1,020 tests pass (3 new).

The orchestrator half — the same field on the alps wire, which is the version Plasma reads — is rhinestonewtf/orchestrator#2066. The two are independent: this one needs nothing from it, since the SDK has always sent `x-api-version: 2026-04.blanc`.

Relates to [RHI-6761](https://linear.app/rhinestone/issue/RHI-6761)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
