### PR TITLE
feat(smart-sessions): export FYND_CHAIN_IDS

### DIFF
--- a/.changeset/export-fynd-chain-ids.md
+++ b/.changeset/export-fynd-chain-ids.md
@@ -1,0 +1,7 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Export `FYND_CHAIN_IDS` and its `FyndChainId` type from `@rhinestone/sdk/smart-sessions`.
+
+A caller composing venues has to know which chains fynd can serve — `scopeFynd` throws on the rest, and `fynd()` takes no chain, so the set could not be tested for. The only recourse was to copy the list, which then drifts as fynd gains chains.

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -37,7 +37,11 @@ import {
   readSessionEnabled,
   readSessionNonce,
 } from '../modules/validators/smart-sessions/state'
-import { fynd } from '../modules/validators/smart-sessions/swap/fynd'
+import type { FyndChainId } from '../modules/validators/smart-sessions/swap/fynd'
+import {
+  FYND_CHAIN_IDS,
+  fynd,
+} from '../modules/validators/smart-sessions/swap/fynd'
 import { rhinestoneSwap } from '../modules/validators/smart-sessions/swap/rhinestone'
 import type { SwapVenueFor } from '../modules/validators/smart-sessions/swap/scope'
 import type {
@@ -117,6 +121,7 @@ async function isSessionEnabled(
 
 export type {
   ChainDigest,
+  FyndChainId,
   FyndVenue,
   RhinestoneSwapVenue,
   SessionDetails,
@@ -128,6 +133,7 @@ export type {
 }
 export {
   ARG_POLICY_ADDRESS,
+  FYND_CHAIN_IDS,
   fynd,
   getPermissionId,
   getSessionData,


### PR DESCRIPTION
## What

Exports `FYND_CHAIN_IDS` and its `FyndChainId` companion type from `@rhinestone/sdk/smart-sessions`.

## Why

A caller composing venues has to know which chains fynd can actually serve — `scopeFynd` throws for the rest. Today it cannot find out:

- the constant is declared but not re-exported from the entrypoint,
- the package `exports` map blocks a deep import,
- `fynd()` takes no chain argument, so the set cannot be probed.

The only recourse is to copy the list, which then drifts as fynd gains chains. deposit-service carries exactly such a copy, and it was flagged in review there ([#746](https://github.com/rhinestonewtf/deposit-service-processor/pull/746)) as something that will get outdated. With this exported, that mirror and the drift-canary guarding it both go away.

## Testing

`tsc --noEmit` clean, biome clean, 84 smart-session unit tests pass, and the value resolves at runtime through the public entrypoint (`1,56,130,137,8453,9745,42161`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)