### PR TITLE
feat(smart-sessions): allow an optional spend cap with a pinned Settler

### DIFF
--- a/.changeset/pinned-settler-optional-cap.md
+++ b/.changeset/pinned-settler-optional-cap.md
@@ -1,0 +1,9 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Allow an optional `maxSpend` alongside a pinned 0x Settler, and export `ZEROX_CHAIN_IDS` from `@rhinestone/sdk/smart-sessions`.
+
+`ZeroExPinnedOptions.maxSpend` was typed `never`, so pinning the Settler and setting a spend ceiling were mutually exclusive. The pin is what bounds a compromised session key — a cap is mandatory only on the `anySettler` variant, where it is the sole bound — but a caller can still want a ceiling on its own terms, and `scopeZeroEx` already applied `ctx.cap` on both paths.
+
+`ZEROX_CHAIN_IDS` joins `FYND_CHAIN_IDS`: resolving a Settler means knowing which chains 0x serves first, and the alternative is duplicating the list downstream where it drifts.

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -231,6 +231,26 @@ describe('resolveSwapScope — 0x pinned settler', () => {
     expect(encoded).toContain(ZEROX_ALLOWANCE_HOLDER.toLowerCase().slice(2))
     expect(encoded).not.toContain(SETTLER.toLowerCase().slice(2))
   })
+
+  test('a pinned Settler accepts a cap without giving up its pins', () => {
+    const rules = rulesOf(
+      resolveSwapScope(
+        scope({ via: [zeroEx({ settler: SETTLER, maxSpend: 750n })] }),
+        PLASMA,
+      ).actions[0],
+    )
+    expect(ruleAt(rules, 0n)?.referenceValue).toBe(SETTLER) // operator
+    expect(ruleAt(rules, 96n)?.referenceValue).toBe(SETTLER) // target
+    expect(ruleAt(rules, 64n)?.usageLimit).toBe(750n)
+  })
+
+  test('a pinned Settler with no cap leaves the amount unbounded', () => {
+    const rules = rulesOf(
+      resolveSwapScope(scope({ via: [zeroEx({ settler: SETTLER })] }), PLASMA)
+        .actions[0],
+    )
+    expect(ruleAt(rules, 64n)).toBeUndefined()
+  })
 })
 
 describe('resolveSwapScope — 0x anySettler', () => {
@@ -253,26 +273,6 @@ describe('resolveSwapScope — 0x anySettler', () => {
       PLASMA,
     )
     expect(ruleAt(rulesOf(actions[0]), 64n)?.usageLimit).toBe(1000n)
-  })
-
-  test('a pinned Settler accepts a cap without giving up its pins', () => {
-    const rules = rulesOf(
-      resolveSwapScope(
-        scope({ via: [zeroEx({ settler: SETTLER, maxSpend: 750n })] }),
-        PLASMA,
-      ).actions[0],
-    )
-    expect(ruleAt(rules, 0n)?.referenceValue).toBe(SETTLER) // operator
-    expect(ruleAt(rules, 96n)?.referenceValue).toBe(SETTLER) // target
-    expect(ruleAt(rules, 64n)?.usageLimit).toBe(750n)
-  })
-
-  test('a pinned Settler with no cap leaves the amount unbounded', () => {
-    const rules = rulesOf(
-      resolveSwapScope(scope({ via: [zeroEx({ settler: SETTLER })] }), PLASMA)
-        .actions[0],
-    )
-    expect(ruleAt(rules, 64n)).toBeUndefined()
   })
 
   test('leaves operator/target free but still pins the sell token', () => {

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -255,6 +255,26 @@ describe('resolveSwapScope — 0x anySettler', () => {
     expect(ruleAt(rulesOf(actions[0]), 64n)?.usageLimit).toBe(1000n)
   })
 
+  test('a pinned Settler accepts a cap without giving up its pins', () => {
+    const rules = rulesOf(
+      resolveSwapScope(
+        scope({ via: [zeroEx({ settler: SETTLER, maxSpend: 750n })] }),
+        PLASMA,
+      ).actions[0],
+    )
+    expect(ruleAt(rules, 0n)?.referenceValue).toBe(SETTLER) // operator
+    expect(ruleAt(rules, 96n)?.referenceValue).toBe(SETTLER) // target
+    expect(ruleAt(rules, 64n)?.usageLimit).toBe(750n)
+  })
+
+  test('a pinned Settler with no cap leaves the amount unbounded', () => {
+    const rules = rulesOf(
+      resolveSwapScope(scope({ via: [zeroEx({ settler: SETTLER })] }), PLASMA)
+        .actions[0],
+    )
+    expect(ruleAt(rules, 64n)).toBeUndefined()
+  })
+
   test('leaves operator/target free but still pins the sell token', () => {
     // token@32 and amount@64 are consumed by AllowanceHolder itself, so they
     // remain meaningful even when the callee is unconstrained.

--- a/src/modules/validators/smart-sessions/swap/zero-ex.ts
+++ b/src/modules/validators/smart-sessions/swap/zero-ex.ts
@@ -155,7 +155,12 @@ export interface ZeroExPinnedOptions {
   /** The Settler to pin. Get the current one with {@link resolveZeroExSettler}. */
   settler: Address
   anySettler?: never
-  maxSpend?: never
+  /**
+   * Optional cumulative sell-token cap. Not needed to bound a compromised
+   * session key — the pinned Settler already does that — so omit it unless a
+   * spend ceiling is wanted for its own sake.
+   */
+  maxSpend?: bigint
 }
 
 /**

--- a/src/smart-sessions/index.ts
+++ b/src/smart-sessions/index.ts
@@ -50,6 +50,7 @@ import type {
 } from '../modules/validators/smart-sessions/swap/zero-ex'
 import {
   resolveZeroExSettler,
+  ZEROX_CHAIN_IDS,
   zeroEx,
 } from '../modules/validators/smart-sessions/swap/zero-ex'
 import type {
@@ -155,5 +156,6 @@ export {
   USAGE_LIMIT_POLICY_ADDRESS,
   VALUE_LIMIT_POLICY_ADDRESS,
   // Venue-scoped swap sessions (RHI-6286)
+  ZEROX_CHAIN_IDS,
   zeroEx,
 }


### PR DESCRIPTION
`ZeroExPinnedOptions.maxSpend` was typed `never`, so a caller that pinned 0x's Settler could not also set a spend ceiling — the two were mutually exclusive at the type level.

Pinning the Settler is what bounds a compromised session key, so a cap genuinely is not *needed* there; `maxSpend` is mandatory only on the `anySettler` variant, where it is the sole bound. But a caller can still want a ceiling on its own terms, and nothing stopped that except the type:

- `scopeZeroEx` already applies `ctx.cap` on both paths (`zero-ex.ts:244`), gated only on `ctx.cap !== undefined`.
- The `zeroEx()` builder already forwards `maxSpend` unconditionally.
- The runtime guard only demands a cap when `anySettler` is set (`zero-ex.ts:218`).

So this widens `maxSpend?: never` to `maxSpend?: bigint` on the pinned variant and adds tests for both shapes.

Also exports `ZEROX_CHAIN_IDS` from the `smart-sessions` entrypoint. `resolveZeroExSettler` is already exported, but a consumer resolving a Settler needs to know which chains 0x serves before calling it, and the alternative is duplicating the list downstream where it goes stale.

### Compatibility

No behaviour change for existing callers. Omitting `maxSpend` pushes no rule, so a pinned scope built without a cap produces the same policy set it did before, and no existing caller could have passed one — the field was `never`. Digests are unaffected.

### Verification

- `tsc --noEmit` on both `tsconfig.json` and `tsconfig.tests.json`: clean.
- `vitest run swap/scope.test.ts`: 78 pass, including the two new cases.
- Mutation-checked: reverting the type to `never` makes `scope.test.ts:261` fail to compile, so the new test is genuinely type-gated rather than passing vacuously.

