### PR TITLE
feat(smart-sessions): opt a restricted session's permissionId into a salt

### DIFF
--- a/.changeset/restricted-session-salt.md
+++ b/.changeset/restricted-session-salt.md
@@ -1,5 +1,5 @@
 ---
-'@rhinestone/sdk': minor
+'@rhinestone/sdk': major
 ---
 
 Salt a restricted session's permissionId by the actions it authorises.

--- a/.changeset/restricted-session-salt.md
+++ b/.changeset/restricted-session-salt.md
@@ -1,11 +1,15 @@
 ---
-'@rhinestone/sdk': major
+'@rhinestone/sdk': minor
 ---
 
-Salt a restricted session's permissionId by the actions it authorises.
+Add `saltMode` to opt a restricted session's permissionId into a salt.
 
-**This moves the digest and permissionId of every restricted (`restrictToActions` / `swap`-scoped) session.** Stored signatures for existing scoped sessions no longer cover the session they were collected for. Unrestricted sessions keep the zero salt and are byte-identical — their digests, permissionIds and stored signatures are unaffected.
+Additive and off by default: without it the salt stays `zeroHash`, so every existing session's digest, permissionId and stored signature are unchanged.
 
-The permissionId derives from the validator, its init data and the salt — not from the actions. With a constant salt, every session for the same signer shared one permissionId, and on-chain `enable` ADDS to the policy list rather than replacing it (`ConfigLibV2.enable`). So enabling a restricted session beside an existing one for that signer unioned the two: the earlier session's actions stayed authorised and the restriction silently bought nothing. A caller could believe a key was limited to, say, one swap venue while a previously enabled wildcard action remained usable.
+A session's permissionId is `keccak(sessionValidator, sessionValidatorInitData, salt)` — the actions are not in it. On-chain, `enable` ADDS to the policy list rather than replacing it (`ConfigLibV2.enable`), so two restricted sessions for one signer that share a permissionId union: the earlier session's actions stay authorised and the later restriction buys nothing, with no error. A caller can believe a key is limited to one swap venue while a previously enabled wildcard action is still live.
 
-Salting by the action set gives each distinct restriction its own permissionId, so it cannot merge into another. This restores the behaviour `1.x` has (`getRestrictedSessionSalt`), which `2.x` dropped.
+- `'none'` (default) — `zeroHash`, today's behaviour.
+- `'v1'` — hashes the actions in build order, matching the 1.x derivation, so a session built on 1.x can be rebuilt here.
+- `'strict'` — hashes every field enabled under the permissionId (actions, ERC-1271 policies, ERC-7739 content, claim policies), actions in canonical order.
+
+Unrestricted sessions stay on `zeroHash` in every mode: there is only one shape of them, so two for the same signer are the same session and sharing a permissionId is correct.

--- a/.changeset/restricted-session-salt.md
+++ b/.changeset/restricted-session-salt.md
@@ -1,0 +1,11 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Salt a restricted session's permissionId by the actions it authorises.
+
+**This moves the digest and permissionId of every restricted (`restrictToActions` / `swap`-scoped) session.** Stored signatures for existing scoped sessions no longer cover the session they were collected for. Unrestricted sessions keep the zero salt and are byte-identical — their digests, permissionIds and stored signatures are unaffected.
+
+The permissionId derives from the validator, its init data and the salt — not from the actions. With a constant salt, every session for the same signer shared one permissionId, and on-chain `enable` ADDS to the policy list rather than replacing it (`ConfigLibV2.enable`). So enabling a restricted session beside an existing one for that signer unioned the two: the earlier session's actions stayed authorised and the restriction silently bought nothing. A caller could believe a key was limited to, say, one swap venue while a previously enabled wildcard action remained usable.
+
+Salting by the action set gives each distinct restriction its own permissionId, so it cannot merge into another. This restores the behaviour `1.x` has (`getRestrictedSessionSalt`), which `2.x` dropped.

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -548,9 +548,8 @@ type SpendingLimitField<TFn extends AbiFunction> =
     ? { spendingLimit?: { token: Address; amount: bigint } }
     : { spendingLimit?: never }
 
-type ValueLimitField<TFn extends AbiFunction> = IsPayable<TFn> extends true
-  ? { valueLimit?: bigint }
-  : { valueLimit?: never }
+type ValueLimitField<TFn extends AbiFunction> =
+  IsPayable<TFn> extends true ? { valueLimit?: bigint } : { valueLimit?: never }
 
 type PermissionFunctionConfig<TFn extends AbiFunction> = {
   /** `valueLimitPerUse` embedded in universal/arg-policy `ActionConfig`. */
@@ -794,6 +793,29 @@ interface SessionDefinition<
    * has sessions enabled against them.
    */
   policyAddresses?: SessionPolicyAddresses
+  /**
+   * How a restricted session's salt is derived, which decides its permissionId.
+   *
+   * The permissionId is `keccak(validator, initData, salt)` — the actions are
+   * not in it. On-chain, `enable` ADDS to the policy list rather than replacing
+   * it, so two sessions for one signer that share a permissionId union: the
+   * earlier one's actions stay authorised and the later restriction buys
+   * nothing.
+   *
+   * - `'none'` (default) leaves the salt at `zeroHash`, which is what stored
+   *   signatures already cover. Restricted sessions for one signer therefore
+   *   share a permissionId.
+   * - `'v1'` hashes the actions in build order, matching the 1.x derivation, so
+   *   a session built there can be rebuilt here.
+   * - `'strict'` hashes every field enabled under the permissionId — actions,
+   *   ERC-1271 policies, ERC-7739 content and claim policies — with actions
+   *   ordered by value.
+   *
+   * Opt-in: anything other than `'none'` moves the permissionId and digest, so
+   * an existing session's stored signature no longer covers it. Unrestricted
+   * sessions stay on `zeroHash` in every mode.
+   */
+  saltMode?: 'none' | 'v1' | 'strict'
 }
 
 type SessionInput<TAbis extends readonly Abi[] = readonly Abi[]> = Omit<

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -548,8 +548,9 @@ type SpendingLimitField<TFn extends AbiFunction> =
     ? { spendingLimit?: { token: Address; amount: bigint } }
     : { spendingLimit?: never }
 
-type ValueLimitField<TFn extends AbiFunction> =
-  IsPayable<TFn> extends true ? { valueLimit?: bigint } : { valueLimit?: never }
+type ValueLimitField<TFn extends AbiFunction> = IsPayable<TFn> extends true
+  ? { valueLimit?: bigint }
+  : { valueLimit?: never }
 
 type PermissionFunctionConfig<TFn extends AbiFunction> = {
   /** `valueLimitPerUse` embedded in universal/arg-policy `ActionConfig`. */

--- a/src/modules/validators/smart-sessions/resolve.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.test.ts
@@ -11,6 +11,9 @@ import {
 import { buildSmartSessionMockSignature } from './mock-signature'
 import { SMART_SESSIONS_FALLBACK_TARGET_FLAG, toSession } from './resolve'
 
+const ZERO_SALT =
+  '0x0000000000000000000000000000000000000000000000000000000000000000'
+
 describe('Smart Sessions core', () => {
   test('matches the exact sudo session vector', () => {
     const session = toSession({
@@ -179,6 +182,52 @@ describe('restricted session guards', () => {
     ).toThrow(/at least one permission or action/)
   })
 
+  // The whole point of the option: leaving it off must reproduce what stored
+  // signatures already cover, or every restricted session ever registered breaks.
+  test('leaves the salt alone unless a mode is asked for', () => {
+    const built = (saltMode?: 'none' | 'v1' | 'strict') =>
+      toSession({
+        chain: base,
+        owners,
+        actions: [
+          {
+            target: TOKEN,
+            selector: '0x095ea7b3',
+            policies: [{ type: 'sudo' }],
+          },
+        ],
+        restrictToActions: true,
+        ...(saltMode ? { saltMode } : {}),
+      }).salt
+
+    expect(built()).toBe(ZERO_SALT)
+    expect(built('none')).toBe(ZERO_SALT)
+    expect(built('strict')).not.toBe(ZERO_SALT)
+  })
+
+  // `'v1'` reproduces the 1.x derivation so a session built there can be rebuilt
+  // here. It hashes the actions alone, in build order — deliberately NOT the
+  // canonical ordering `'strict'` uses, because matching is the point.
+  test("'v1' and 'strict' are different derivations", () => {
+    const built = (saltMode: 'v1' | 'strict') =>
+      toSession({
+        chain: base,
+        owners,
+        actions: [
+          {
+            target: TOKEN,
+            selector: '0x095ea7b3',
+            policies: [{ type: 'sudo' }],
+          },
+        ],
+        restrictToActions: true,
+        saltMode,
+      }).salt
+
+    expect(built('v1')).not.toBe(built('strict'))
+    expect(built('v1')).not.toBe(ZERO_SALT)
+  })
+
   // The permissionId comes from the validator, its init data and the salt — not
   // from the actions. On-chain `enable` ADDS to the policy list rather than
   // replacing it, so two restricted sessions sharing a permissionId would union:
@@ -190,6 +239,7 @@ describe('restricted session guards', () => {
       owners,
       actions: [{ target: TOKEN, selector, policies: [{ type: 'sudo' }] }],
       restrictToActions: true,
+      saltMode: 'strict',
     })
 
   test('gives restricted sessions with different actions different permissionIds', () => {
@@ -214,6 +264,7 @@ describe('restricted session guards', () => {
           },
         ],
         restrictToActions: true,
+        saltMode: 'strict',
         signing: { mode },
       }).permissionId
 
@@ -233,6 +284,7 @@ describe('restricted session guards', () => {
           policies: [{ type: 'sudo' as const }],
         })),
         restrictToActions: true,
+        saltMode: 'strict',
       }).permissionId
 
     expect(ordered(['0x095ea7b3', '0xa9059cbb'])).toBe(
@@ -241,16 +293,15 @@ describe('restricted session guards', () => {
   })
 
   test('salts a restricted session by its actions', () => {
-    expect(restricted('0x095ea7b3').salt).not.toBe(
-      '0x0000000000000000000000000000000000000000000000000000000000000000',
-    )
+    expect(restricted('0x095ea7b3').salt).not.toBe(ZERO_SALT)
   })
 
   // Unrestricted sessions keep the zero salt their stored signatures cover —
   // the pinned sudo vector above is the other half of this guarantee.
   test('leaves an unrestricted session on the zero salt', () => {
-    expect(toSession({ chain: base, owners }).salt).toBe(
-      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    expect(toSession({ chain: base, owners }).salt).toBe(ZERO_SALT)
+    expect(toSession({ chain: base, owners, saltMode: 'strict' }).salt).toBe(
+      ZERO_SALT,
     )
   })
 

--- a/src/modules/validators/smart-sessions/resolve.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.test.ts
@@ -1,5 +1,5 @@
 import fc from 'fast-check'
-import { size } from 'viem'
+import { size, zeroHash } from 'viem'
 import { base } from 'viem/chains'
 import { describe, expect, test } from 'vitest'
 import { accountA } from '../../../../test/consts'
@@ -10,9 +10,6 @@ import {
 } from './cross-chain-permits'
 import { buildSmartSessionMockSignature } from './mock-signature'
 import { SMART_SESSIONS_FALLBACK_TARGET_FLAG, toSession } from './resolve'
-
-const ZERO_SALT =
-  '0x0000000000000000000000000000000000000000000000000000000000000000'
 
 describe('Smart Sessions core', () => {
   test('matches the exact sudo session vector', () => {
@@ -200,9 +197,9 @@ describe('restricted session guards', () => {
         ...(saltMode ? { saltMode } : {}),
       }).salt
 
-    expect(built()).toBe(ZERO_SALT)
-    expect(built('none')).toBe(ZERO_SALT)
-    expect(built('strict')).not.toBe(ZERO_SALT)
+    expect(built()).toBe(zeroHash)
+    expect(built('none')).toBe(zeroHash)
+    expect(built('strict')).not.toBe(zeroHash)
   })
 
   // `'v1'` reproduces the 1.x derivation so a session built there can be rebuilt
@@ -225,7 +222,7 @@ describe('restricted session guards', () => {
       }).salt
 
     expect(built('v1')).not.toBe(built('strict'))
-    expect(built('v1')).not.toBe(ZERO_SALT)
+    expect(built('v1')).not.toBe(zeroHash)
   })
 
   // The permissionId comes from the validator, its init data and the salt — not
@@ -293,15 +290,15 @@ describe('restricted session guards', () => {
   })
 
   test('salts a restricted session by its actions', () => {
-    expect(restricted('0x095ea7b3').salt).not.toBe(ZERO_SALT)
+    expect(restricted('0x095ea7b3').salt).not.toBe(zeroHash)
   })
 
   // Unrestricted sessions keep the zero salt their stored signatures cover —
   // the pinned sudo vector above is the other half of this guarantee.
   test('leaves an unrestricted session on the zero salt', () => {
-    expect(toSession({ chain: base, owners }).salt).toBe(ZERO_SALT)
+    expect(toSession({ chain: base, owners }).salt).toBe(zeroHash)
     expect(toSession({ chain: base, owners, saltMode: 'strict' }).salt).toBe(
-      ZERO_SALT,
+      zeroHash,
     )
   })
 

--- a/src/modules/validators/smart-sessions/resolve.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.test.ts
@@ -198,6 +198,48 @@ describe('restricted session guards', () => {
     )
   })
 
+  // Every field `_enablePolicies` writes under the permissionId has to be in the
+  // salt, or that field alone still collides. Signing config lands in
+  // `erc7739Policies`, enabled under the same permissionId as the actions.
+  test('separates restricted sessions that differ only by signing', () => {
+    const withSigning = (mode: 'disabled' | 'unrestricted') =>
+      toSession({
+        chain: base,
+        owners,
+        actions: [
+          {
+            target: TOKEN,
+            selector: '0x095ea7b3',
+            policies: [{ type: 'sudo' }],
+          },
+        ],
+        restrictToActions: true,
+        signing: { mode },
+      }).permissionId
+
+    expect(withSigning('disabled')).not.toBe(withSigning('unrestricted'))
+  })
+
+  // On-chain, actions are keyed by action id, so the same set listed in a
+  // different order is the same authorisation and must not move the id.
+  test('is independent of the order actions are listed in', () => {
+    const ordered = (selectors: `0x${string}`[]) =>
+      toSession({
+        chain: base,
+        owners,
+        actions: selectors.map((selector) => ({
+          target: TOKEN,
+          selector,
+          policies: [{ type: 'sudo' as const }],
+        })),
+        restrictToActions: true,
+      }).permissionId
+
+    expect(ordered(['0x095ea7b3', '0xa9059cbb'])).toBe(
+      ordered(['0xa9059cbb', '0x095ea7b3']),
+    )
+  })
+
   test('salts a restricted session by its actions', () => {
     expect(restricted('0x095ea7b3').salt).not.toBe(
       '0x0000000000000000000000000000000000000000000000000000000000000000',

--- a/src/modules/validators/smart-sessions/resolve.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.test.ts
@@ -179,6 +179,39 @@ describe('restricted session guards', () => {
     ).toThrow(/at least one permission or action/)
   })
 
+  // The permissionId comes from the validator, its init data and the salt — not
+  // from the actions. On-chain `enable` ADDS to the policy list rather than
+  // replacing it, so two restricted sessions sharing a permissionId would union:
+  // the first session's actions stay authorised and the second's restriction
+  // buys nothing. Salting by the action set keeps them apart.
+  const restricted = (selector: `0x${string}`) =>
+    toSession({
+      chain: base,
+      owners,
+      actions: [{ target: TOKEN, selector, policies: [{ type: 'sudo' }] }],
+      restrictToActions: true,
+    })
+
+  test('gives restricted sessions with different actions different permissionIds', () => {
+    expect(restricted('0x095ea7b3').permissionId).not.toBe(
+      restricted('0xa9059cbb').permissionId,
+    )
+  })
+
+  test('salts a restricted session by its actions', () => {
+    expect(restricted('0x095ea7b3').salt).not.toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    )
+  })
+
+  // Unrestricted sessions keep the zero salt their stored signatures cover —
+  // the pinned sudo vector above is the other half of this guarantee.
+  test('leaves an unrestricted session on the zero salt', () => {
+    expect(toSession({ chain: base, owners }).salt).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    )
+  })
+
   test('rejects two actions colliding on one (target, selector)', () => {
     // Both map to the same on-chain action id, so one would overwrite the
     // other's policies without warning.

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -28,6 +28,8 @@ import { resolveSessionSigning } from './signing'
 import { resolveSwapScope } from './swap/scope'
 import type {
   ResolvedAction,
+  ResolvedERC7739Policies,
+  ResolvedPolicy,
   ScopedAction,
   Session,
   SessionAction,
@@ -254,28 +256,60 @@ export function resolveSessionData(
   return {
     sessionValidator: validator.address,
     sessionValidatorInitData: validator.initData,
-    salt: restricted ? restrictedSessionSalt(actions) : zeroHash,
+    salt: restricted
+      ? restrictedSessionSalt({ actions, erc7739Policies, claimPolicies })
+      : zeroHash,
     erc7739Policies,
     actions,
     claimPolicies,
   }
 }
 
+const POLICY_COMPONENTS = [
+  { name: 'policy', type: 'address' },
+  { name: 'initData', type: 'bytes' },
+] as const
+
 /**
- * Bind a restricted session's permissionId to the actions it authorises.
+ * Bind a restricted session's permissionId to everything it authorises.
  *
- * The permissionId is derived from the validator, its init data and this salt —
- * not from the actions. With a constant salt every session for the same signer
- * shares one permissionId, and `enable` on-chain ADDS to the policy list rather
- * than replacing it (`ConfigLibV2.enable`). So enabling a restricted session
- * beside an existing one for that signer unions the two: the earlier session's
- * actions stay authorised and the restriction silently buys nothing.
+ * The permissionId derives from the validator, its init data and this salt —
+ * not from the permissions. With a constant salt every session for the same
+ * signer shares one permissionId, and `enable` on-chain ADDS to each list
+ * rather than replacing it (`ConfigLibV2.enable`). So enabling a restricted
+ * session beside an existing one for that signer unions the two: the earlier
+ * session's permissions stay authorised and the restriction silently buys
+ * nothing.
  *
- * Salting by the action set gives each distinct restriction its own
- * permissionId, so it cannot merge into another. Unrestricted sessions keep
- * `zeroHash`, which is what their stored signatures already cover.
+ * Every field `_enablePolicies` writes under the permissionId has to be in
+ * here, or that field alone can still collide — actions, the ERC-1271 policies
+ * and 7739 content behind them, and the claim policies.
+ *
+ * Actions are sorted by (target, selector) so the salt is a function of the
+ * authorised SET: on-chain they are keyed by action id, so listing the same
+ * ones in a different order is the same authorisation and must not change the
+ * permissionId.
+ *
+ * Unrestricted sessions keep `zeroHash`, which is what their stored signatures
+ * already cover.
  */
-function restrictedSessionSalt(actions: readonly ResolvedAction[]): Hex {
+function restrictedSessionSalt(session: {
+  actions: readonly ResolvedAction[]
+  erc7739Policies: ResolvedERC7739Policies
+  claimPolicies: readonly ResolvedPolicy[]
+}): Hex {
+  const actions = [...session.actions]
+    .sort((a, b) =>
+      `${a.actionTarget}:${a.actionTargetSelector}`.localeCompare(
+        `${b.actionTarget}:${b.actionTargetSelector}`,
+      ),
+    )
+    .map((action) => ({
+      actionTargetSelector: action.actionTargetSelector,
+      actionTarget: action.actionTarget,
+      actionPolicies: action.actionPolicies.map((policy) => ({ ...policy })),
+    }))
+
   return keccak256(
     encodeAbiParameters(
       [
@@ -288,15 +322,40 @@ function restrictedSessionSalt(actions: readonly ResolvedAction[]): Hex {
             {
               name: 'actionPolicies',
               type: 'tuple[]',
-              components: [
-                { name: 'policy', type: 'address' },
-                { name: 'initData', type: 'bytes' },
-              ],
+              components: POLICY_COMPONENTS,
             },
           ],
         },
+        {
+          name: 'erc1271Policies',
+          type: 'tuple[]',
+          components: POLICY_COMPONENTS,
+        },
+        {
+          name: 'allowedERC7739Content',
+          type: 'tuple[]',
+          components: [
+            { name: 'appDomainSeparator', type: 'bytes32' },
+            { name: 'contentNames', type: 'string[]' },
+          ],
+        },
+        {
+          name: 'claimPolicies',
+          type: 'tuple[]',
+          components: POLICY_COMPONENTS,
+        },
       ],
-      [actions as never],
+      [
+        actions,
+        session.erc7739Policies.erc1271Policies.map((policy) => ({
+          ...policy,
+        })),
+        session.erc7739Policies.allowedERC7739Content.map((content) => ({
+          appDomainSeparator: content.appDomainSeparator,
+          contentNames: [...content.contentNames],
+        })),
+        session.claimPolicies.map((policy) => ({ ...policy })),
+      ],
     ),
   )
 }

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -1,4 +1,11 @@
-import { type Address, type Hex, toFunctionSelector, zeroHash } from 'viem'
+import {
+  type Address,
+  encodeAbiParameters,
+  type Hex,
+  keccak256,
+  toFunctionSelector,
+  zeroHash,
+} from 'viem'
 import { defineValidator } from '../definition'
 import { resolvePermissions } from '../permissions'
 import {
@@ -247,11 +254,51 @@ export function resolveSessionData(
   return {
     sessionValidator: validator.address,
     sessionValidatorInitData: validator.initData,
-    salt: zeroHash,
+    salt: restricted ? restrictedSessionSalt(actions) : zeroHash,
     erc7739Policies,
     actions,
     claimPolicies,
   }
+}
+
+/**
+ * Bind a restricted session's permissionId to the actions it authorises.
+ *
+ * The permissionId is derived from the validator, its init data and this salt —
+ * not from the actions. With a constant salt every session for the same signer
+ * shares one permissionId, and `enable` on-chain ADDS to the policy list rather
+ * than replacing it (`ConfigLibV2.enable`). So enabling a restricted session
+ * beside an existing one for that signer unions the two: the earlier session's
+ * actions stay authorised and the restriction silently buys nothing.
+ *
+ * Salting by the action set gives each distinct restriction its own
+ * permissionId, so it cannot merge into another. Unrestricted sessions keep
+ * `zeroHash`, which is what their stored signatures already cover.
+ */
+function restrictedSessionSalt(actions: readonly ResolvedAction[]): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        {
+          name: 'actions',
+          type: 'tuple[]',
+          components: [
+            { name: 'actionTargetSelector', type: 'bytes4' },
+            { name: 'actionTarget', type: 'address' },
+            {
+              name: 'actionPolicies',
+              type: 'tuple[]',
+              components: [
+                { name: 'policy', type: 'address' },
+                { name: 'initData', type: 'bytes' },
+              ],
+            },
+          ],
+        },
+      ],
+      [actions as never],
+    ),
+  )
 }
 
 export function toSession(

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -7,6 +7,7 @@ import {
   zeroHash,
 } from 'viem'
 import { defineValidator } from '../definition'
+import { compareHexValues } from '../ordering'
 import { resolvePermissions } from '../permissions'
 import {
   encodePermit2ClaimPolicyInitData,
@@ -299,10 +300,13 @@ function restrictedSessionSalt(session: {
   claimPolicies: readonly ResolvedPolicy[]
 }): Hex {
   const actions = [...session.actions]
-    .sort((a, b) =>
-      `${a.actionTarget}:${a.actionTargetSelector}`.localeCompare(
-        `${b.actionTarget}:${b.actionTargetSelector}`,
-      ),
+    // By value, never host collation: `localeCompare` orders `0xaa…` after
+    // `0xb1…` on Danish-family locales, which would make the salt — and so the
+    // permissionId — depend on where it was derived.
+    .sort(
+      (a, b) =>
+        compareHexValues(a.actionTarget, b.actionTarget) ||
+        compareHexValues(a.actionTargetSelector, b.actionTargetSelector),
     )
     .map((action) => ({
       actionTargetSelector: action.actionTargetSelector,

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -257,9 +257,11 @@ export function resolveSessionData(
   return {
     sessionValidator: validator.address,
     sessionValidatorInitData: validator.initData,
-    salt: restricted
-      ? restrictedSessionSalt({ actions, erc7739Policies, claimPolicies })
-      : zeroHash,
+    salt: sessionSalt(definition.saltMode, restricted, {
+      actions,
+      erc7739Policies,
+      claimPolicies,
+    }),
     erc7739Policies,
     actions,
     claimPolicies,
@@ -294,7 +296,68 @@ const POLICY_COMPONENTS = [
  * Unrestricted sessions keep `zeroHash`, which is what their stored signatures
  * already cover.
  */
-function restrictedSessionSalt(session: {
+/**
+ * Pick the salt for a session, defaulting to the historical `zeroHash`.
+ *
+ * Unrestricted sessions are always `zeroHash`: there is only one shape of them,
+ * so two for the same signer are the same session and sharing a permissionId is
+ * correct. Restricted ones can differ, which is what makes a salt necessary.
+ */
+function sessionSalt(
+  mode: 'none' | 'v1' | 'strict' | undefined,
+  restricted: boolean,
+  session: {
+    actions: readonly ResolvedAction[]
+    erc7739Policies: ResolvedERC7739Policies
+    claimPolicies: readonly ResolvedPolicy[]
+  },
+): Hex {
+  if (!restricted || mode === undefined || mode === 'none') {
+    return zeroHash
+  }
+  return mode === 'v1'
+    ? v1RestrictedSalt(session.actions)
+    : strictSessionSalt(session)
+}
+
+/**
+ * The 1.x derivation: the actions alone, in the order they were built.
+ *
+ * Reproduced rather than improved. It exists so a session built on 1.x can be
+ * rebuilt here byte for byte — sorting or widening it would defeat that.
+ */
+function v1RestrictedSalt(actions: readonly ResolvedAction[]): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        {
+          name: 'actions',
+          type: 'tuple[]',
+          components: [
+            { name: 'actionTargetSelector', type: 'bytes4' },
+            { name: 'actionTarget', type: 'address' },
+            {
+              name: 'actionPolicies',
+              type: 'tuple[]',
+              components: POLICY_COMPONENTS,
+            },
+          ],
+        },
+      ],
+      [
+        actions.map((action) => ({
+          actionTargetSelector: action.actionTargetSelector,
+          actionTarget: action.actionTarget,
+          actionPolicies: action.actionPolicies.map((policy) => ({
+            ...policy,
+          })),
+        })),
+      ],
+    ),
+  )
+}
+
+function strictSessionSalt(session: {
   actions: readonly ResolvedAction[]
   erc7739Policies: ResolvedERC7739Policies
   claimPolicies: readonly ResolvedPolicy[]

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -274,29 +274,6 @@ const POLICY_COMPONENTS = [
 ] as const
 
 /**
- * Bind a restricted session's permissionId to everything it authorises.
- *
- * The permissionId derives from the validator, its init data and this salt —
- * not from the permissions. With a constant salt every session for the same
- * signer shares one permissionId, and `enable` on-chain ADDS to each list
- * rather than replacing it (`ConfigLibV2.enable`). So enabling a restricted
- * session beside an existing one for that signer unions the two: the earlier
- * session's permissions stay authorised and the restriction silently buys
- * nothing.
- *
- * Every field `_enablePolicies` writes under the permissionId has to be in
- * here, or that field alone can still collide — actions, the ERC-1271 policies
- * and 7739 content behind them, and the claim policies.
- *
- * Actions are sorted by (target, selector) so the salt is a function of the
- * authorised SET: on-chain they are keyed by action id, so listing the same
- * ones in a different order is the same authorisation and must not change the
- * permissionId.
- *
- * Unrestricted sessions keep `zeroHash`, which is what their stored signatures
- * already cover.
- */
-/**
  * Pick the salt for a session, defaulting to the historical `zeroHash`.
  *
  * Unrestricted sessions are always `zeroHash`: there is only one shape of them,
@@ -357,6 +334,29 @@ function v1RestrictedSalt(actions: readonly ResolvedAction[]): Hex {
   )
 }
 
+/**
+ * Bind a restricted session's permissionId to everything it authorises.
+ *
+ * The permissionId derives from the validator, its init data and this salt —
+ * not from the permissions. With a constant salt every session for the same
+ * signer shares one permissionId, and `enable` on-chain ADDS to each list
+ * rather than replacing it (`ConfigLibV2.enable`). So enabling a restricted
+ * session beside an existing one for that signer unions the two: the earlier
+ * session's permissions stay authorised and the restriction silently buys
+ * nothing.
+ *
+ * Every field `_enablePolicies` writes under the permissionId has to be in
+ * here, or that field alone can still collide — actions, the ERC-1271 policies
+ * and 7739 content behind them, and the claim policies.
+ *
+ * Actions are sorted by (target, selector) so the salt is a function of the
+ * authorised SET: on-chain they are keyed by action id, so listing the same
+ * ones in a different order is the same authorisation and must not change the
+ * permissionId.
+ *
+ * Unrestricted sessions keep `zeroHash`, which is what their stored signatures
+ * already cover.
+ */
 function strictSessionSalt(session: {
   actions: readonly ResolvedAction[]
   erc7739Policies: ResolvedERC7739Policies

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -279,6 +279,28 @@ export interface SessionDefinition {
   // aggregator (RHI-6286). Requires at least one permission or action.
   restrictToActions?: boolean
   /**
+   * How a restricted session's salt is derived, which decides its permissionId.
+   *
+   * The permissionId is `keccak(validator, initData, salt)` — the actions are
+   * not in it. On-chain, `enable` ADDS to the policy list rather than replacing
+   * it, so two sessions for one signer that share a permissionId union: the
+   * earlier one's actions stay authorised and the later restriction buys
+   * nothing.
+   *
+   * - `'none'` (default) leaves the salt at `zeroHash`, which is what stored
+   *   signatures already cover. Restricted sessions for one signer therefore
+   *   share a permissionId.
+   * - `'v1'` hashes the actions, matching the 1.x derivation. Use it to
+   *   reproduce a session built there.
+   * - `'strict'` hashes every field enabled under the permissionId — actions,
+   *   ERC-1271 policies, ERC-7739 content and claim policies — with actions in
+   *   a canonical order.
+   *
+   * Opt-in: anything other than `'none'` moves the permissionId and digest, so
+   * an existing session's stored signature no longer covers it.
+   */
+  saltMode?: 'none' | 'v1' | 'strict'
+  /**
    * Venue-scoped swap permissions. Compiles to a merged approve plus one scoped
    * swap action per venue, and implies `restrictToActions`.
    */

--- a/test/types/swap-sessions.ts
+++ b/test/types/swap-sessions.ts
@@ -87,3 +87,22 @@ onPlasma({ sell, to: ACCOUNT, via: [fynd()] })
 
 // @ts-expect-error a swap scope must name a sell token.
 onPlasma({ buy, to: ACCOUNT, via: [fynd()] })
+
+// `saltMode` has to be reachable on the PUBLIC definition, not just the
+// module-local one: `toSession` here takes `SessionDefinition` from
+// `src/config/account.ts`, so adding the field only to the resolver's own type
+// leaves integrators unable to pass it without a cast — the opt-in would exist
+// but be unusable on the documented path.
+const saltedSession = toSession({
+  chain: base,
+  owners,
+  actions: [
+    { target: ACCOUNT, selector: '0x095ea7b3', policies: [{ type: 'sudo' }] },
+  ],
+  restrictToActions: true,
+  saltMode: 'strict',
+})
+saltedSession.salt satisfies `0x${string}`
+
+// @ts-expect-error - only the three documented modes
+toSession({ chain: base, owners, restrictToActions: true, saltMode: 'v3' })


### PR DESCRIPTION
A session's permissionId is `keccak(sessionValidator, sessionValidatorInitData, salt)` — the actions are not in it. On-chain, `enable` **adds** to the policy list rather than replacing it, so two restricted sessions for one signer that share a permissionId **union**: the earlier session's actions stay authorised, the later restriction buys nothing, and nothing errors. A caller can believe a key is limited to one swap venue while a previously enabled wildcard action is still live.

Verified at the contract level, on both code paths the manager can bind to:

```solidity
// src/lib/ConfigLibV2.sol:146
$policy.policyList[permissionId].add({ account: account, value: policy });
// node_modules/smartsessions/contracts/lib/ConfigLib.sol:24
$policy.policyList[permissionId].add({ account: msg.sender, value: policy });
```

Measured before this change — four different sessions, one permissionId:

```
unscoped                  0xe5fb6459…
scoped USDC→USDT0         0xe5fb6459…
scoped USDC→other token   0xe5fb6459…
scoped, fewer venues      0xe5fb6459…
```

## The change

Adds `saltMode`, **off by default**. Three modes, because reproducing a 1.x-built session needs a different derivation from the one that fixes the collision:

| mode | salt | for |
|---|---|---|
| `'none'` *(default)* | `zeroHash` | today's behaviour, unchanged |
| `'v1'` | actions alone, in build order | rebuilding a session built on 1.x |
| `'strict'` | actions + ERC-1271 policies + 7739 content + claim policies, actions ordered by value | the actual fix |

`'strict'` covers exactly the four things `_enablePolicies` writes under the permissionId — that list comes from the contract, not from taste. Actions are ordered with `compareHexValues`, never `localeCompare`: on-chain they are keyed by action id so order carries no meaning, and host collation must not enter a derived value.

`'v1'` is deliberately *not* canonicalised. Matching 1.x byte for byte is the point; improving it would defeat it.

Unrestricted sessions stay on `zeroHash` in every mode. There is only one shape of them, so two for the same signer are the same session and sharing a permissionId is correct — which is why `zeroHash` was only ever a problem for restricted ones.

## Compatibility

**Nothing breaks.** Without `saltMode` the salt is `zeroHash`, so every existing digest, permissionId and stored signature is untouched. Changeset is a minor.

Measured, against real production values:

- default → `0x7b9a48d854545c17…`, the pre-change scoped digest
- `'v1'` + 1.x's policy addresses → `0x4a2ffc5644e274ba…`, identical to a natively 1.x-built session
- `'strict'` + 1.x's policy addresses → `0x7a21b03ea2e0cd50…`, identical to 1.x under its own `saltMode: 'strict'` (rhinestonewtf/sdk#862)
- an unscoped session on a live production account → unchanged

That third line is the one that matters downstream: it lets the deposit service rebuild a scoped session a client built on 1.x, which it currently cannot.

## Verification

- `tsc --noEmit` clean on `tsconfig.json` and `tsconfig.tests.json`
- `vitest run src/modules/validators/` — 17 files, 354 tests
- Mutation-checked: making `'strict'` the default fails "leaves the salt alone unless a mode is asked for"; collapsing `'v1'` into `'strict'` fails "'v1' and 'strict' are different derivations"; dropping the erc7739 or claim inputs fails the signing test; removing the ordering fails the order test

[skip-linear] — follow-on to the customer thread behind [RHI-6343](https://linear.app/rhinestone/issue/RHI-6343/0x-settler-address-rotates-scoped-sessions-must-pin-an-address-that); the deposit-service side is [RHI-6931](https://linear.app/rhinestone/issue/RHI-6931/deposit-service-rebuild-v1-built-scoped-sessions).
