### PR TITLE
fix(smart-sessions): order an action's policies as 1.x does under saltMode 'v1'

### DIFF
--- a/.changeset/v1-shape-policy-order.md
+++ b/.changeset/v1-shape-policy-order.md
@@ -2,8 +2,14 @@
 '@rhinestone/sdk': patch
 ---
 
-`saltMode: 'v1'` now reproduces a 1.x digest when the scope carries a spend
-cap. The cap adds a second policy to the approve action, and it was emitted
-ahead of the params policy rather than after it as 1.x does. Uncapped scopes
-were already correct and are unchanged, as is any session that does not set
-`saltMode`.
+`saltMode: 'v1'` now reproduces a 1.x digest in two cases it missed.
+
+With a spend cap: the cap adds a second policy to the approve action, and it
+was emitted ahead of the params policy rather than after it as 1.x does.
+
+On dev: 1.x salts a swap-scoped session over its production venues whatever
+environment it was built for, so the permissionId does not move between them.
+The salt now does the same; the session keeps its dev venues.
+
+Uncapped production scopes were already correct and are unchanged, as is any
+session that does not set `saltMode`.

--- a/.changeset/v1-shape-policy-order.md
+++ b/.changeset/v1-shape-policy-order.md
@@ -2,17 +2,8 @@
 '@rhinestone/sdk': patch
 ---
 
-Emit an action's policies in 1.x's order under `saltMode: 'v1'`.
-
-Reproducing a session the 1.x SDK built takes more than the salt. 1.x builds an
-approve action as `[arg policy, spending limits]`; here the `spendingLimit`
-sugar expands before `params` compiles, so the pair came out reversed. Action
-policies are hashed in array order, so the rebuilt digest diverged.
-
-Only visible once the scope carries a spend cap — with no cap the action has a
-single policy and nothing to order — which is why the pinned uncapped fixtures
-agreed and a capped scope did not. Verified both ways against sessions built by
-a real `@rhinestone/sdk@1.18.0`: capped and uncapped digests now match it
-exactly.
-
-Scoped to `saltMode: 'v1'`, so no session that does not opt in changes.
+`saltMode: 'v1'` now reproduces a 1.x digest when the scope carries a spend
+cap. The cap adds a second policy to the approve action, and it was emitted
+ahead of the params policy rather than after it as 1.x does. Uncapped scopes
+were already correct and are unchanged, as is any session that does not set
+`saltMode`.

--- a/.changeset/v1-shape-policy-order.md
+++ b/.changeset/v1-shape-policy-order.md
@@ -1,0 +1,18 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Emit an action's policies in 1.x's order under `saltMode: 'v1'`.
+
+Reproducing a session the 1.x SDK built takes more than the salt. 1.x builds an
+approve action as `[arg policy, spending limits]`; here the `spendingLimit`
+sugar expands before `params` compiles, so the pair came out reversed. Action
+policies are hashed in array order, so the rebuilt digest diverged.
+
+Only visible once the scope carries a spend cap — with no cap the action has a
+single policy and nothing to order — which is why the pinned uncapped fixtures
+agreed and a capped scope did not. Verified both ways against sessions built by
+a real `@rhinestone/sdk@1.18.0`: capped and uncapped digests now match it
+exactly.
+
+Scoped to `saltMode: 'v1'`, so no session that does not opt in changes.

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -807,9 +807,10 @@ interface SessionDefinition<
    *   signatures already cover. Restricted sessions for one signer therefore
    *   share a permissionId.
    * - `'v1'` reproduces a session the 1.x SDK built: the salt hashes the
-   *   actions in build order, and an action's policies are emitted in 1.x's
-   *   order rather than this one's. Both are digest inputs, so rebuilding a
-   *   1.x session here needs both.
+   *   actions in build order, and a permission-derived action's policies are
+   *   emitted in 1.x's order rather than this one's. Both are digest inputs.
+   *   A raw `actions` entry is left in the order you gave it, which is what
+   *   1.x does with one too.
    * - `'strict'` hashes every field enabled under the permissionId — actions,
    *   ERC-1271 policies, ERC-7739 content and claim policies — with actions
    *   ordered by value.

--- a/src/config/account.ts
+++ b/src/config/account.ts
@@ -806,8 +806,10 @@ interface SessionDefinition<
    * - `'none'` (default) leaves the salt at `zeroHash`, which is what stored
    *   signatures already cover. Restricted sessions for one signer therefore
    *   share a permissionId.
-   * - `'v1'` hashes the actions in build order, matching the 1.x derivation, so
-   *   a session built there can be rebuilt here.
+   * - `'v1'` reproduces a session the 1.x SDK built: the salt hashes the
+   *   actions in build order, and an action's policies are emitted in 1.x's
+   *   order rather than this one's. Both are digest inputs, so rebuilding a
+   *   1.x session here needs both.
    * - `'strict'` hashes every field enabled under the permissionId — actions,
    *   ERC-1271 policies, ERC-7739 content and claim policies — with actions
    *   ordered by value.

--- a/src/modules/validators/smart-sessions/resolve.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.test.ts
@@ -202,6 +202,51 @@ describe('restricted session guards', () => {
     expect(built('strict')).not.toBe(zeroHash)
   })
 
+  // Reproducing 1.x is not only about the salt. 1.x builds an approve action as
+  // [arg policy, spending limits]; the `spendingLimit` sugar expands before
+  // `params` here, so without this the pair comes out reversed and the digest
+  // diverges — but ONLY once a cap exists, which is why an uncapped fixture
+  // cannot catch it. Measured against a session built by a real 1.18.0.
+  test("'v1' emits an action's policies in the order 1.x does", () => {
+    const built = (saltMode?: 'v1') =>
+      toSession({
+        chain: base,
+        owners,
+        permissions: [
+          {
+            abi: [
+              {
+                type: 'function',
+                name: 'approve',
+                stateMutability: 'nonpayable',
+                inputs: [
+                  { name: 'spender', type: 'address' },
+                  { name: 'amount', type: 'uint256' },
+                ],
+                outputs: [{ type: 'bool' }],
+              },
+            ],
+            address: TOKEN,
+            functions: {
+              approve: {
+                spendingLimit: { token: TOKEN, amount: 5_000_000n },
+                params: { spender: { condition: 'equal', value: TOKEN } },
+              },
+            },
+          },
+        ],
+        restrictToActions: true,
+        ...(saltMode ? { saltMode } : {}),
+      }).actions[0].actionPolicies.map((entry) => entry.policy)
+
+    const [firstDefault, secondDefault] = built()
+    const [firstV1, secondV1] = built('v1')
+
+    // Same two policies, opposite order — and the default is untouched, so no
+    // existing digest moves.
+    expect([firstV1, secondV1]).toEqual([secondDefault, firstDefault])
+  })
+
   // `'v1'` reproduces the 1.x derivation so a session built there can be rebuilt
   // here. It hashes the actions alone, in build order — deliberately NOT the
   // canonical ordering `'strict'` uses, because matching is the point.

--- a/src/modules/validators/smart-sessions/resolve.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.test.ts
@@ -10,6 +10,7 @@ import {
 } from './cross-chain-permits'
 import { buildSmartSessionMockSignature } from './mock-signature'
 import { SMART_SESSIONS_FALLBACK_TARGET_FLAG, toSession } from './resolve'
+import type { SessionPolicy } from './types'
 
 describe('Smart Sessions core', () => {
   test('matches the exact sudo session vector', () => {
@@ -262,7 +263,7 @@ describe('restricted session guards', () => {
           { condition: 'equal', calldataOffset: 0n, referenceValue: TOKEN },
         ],
       },
-    ] as const
+    ] satisfies SessionPolicy[]
 
     const built = (saltMode?: 'v1') =>
       toSession({

--- a/src/modules/validators/smart-sessions/resolve.test.ts
+++ b/src/modules/validators/smart-sessions/resolve.test.ts
@@ -247,6 +247,37 @@ describe('restricted session guards', () => {
     expect([firstV1, secondV1]).toEqual([secondDefault, firstDefault])
   })
 
+  // 1.x passes a raw action's policies through in the order given, so the
+  // reordering must not reach them: it exists to undo this SDK's own sugar
+  // expansion, and applying it to a hand-written action would invent a
+  // difference rather than remove one.
+  test("'v1' leaves a raw action's policy order alone", () => {
+    const policies = [
+      { type: 'spending-limits', limits: [{ token: TOKEN, amount: 1n }] },
+      { type: 'usage-limit', limit: 2n },
+      {
+        type: 'universal-action',
+        valueLimitPerUse: 0n,
+        rules: [
+          { condition: 'equal', calldataOffset: 0n, referenceValue: TOKEN },
+        ],
+      },
+    ] as const
+
+    const built = (saltMode?: 'v1') =>
+      toSession({
+        chain: base,
+        owners,
+        actions: [{ target: TOKEN, selector: '0x095ea7b3', policies }],
+        restrictToActions: true,
+        ...(saltMode ? { saltMode } : {}),
+      })
+
+    expect(built('v1').actions[0].actionPolicies).toEqual(
+      built().actions[0].actionPolicies,
+    )
+  })
+
   // `'v1'` reproduces the 1.x derivation so a session built there can be rebuilt
   // here. It hashes the actions alone, in build order — deliberately NOT the
   // canonical ordering `'strict'` uses, because matching is the point.

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -217,9 +217,19 @@ export function resolveSessionData(
     }
     seen.add(key)
   }
+  // Only the permission-derived actions: a raw action is passed through in the
+  // order it was given, on both majors, so reordering one would invent a
+  // difference rather than remove one.
+  const v1CompatibleActions =
+    definition.saltMode === 'v1'
+      ? userActions.map((action) => ({
+          ...action,
+          policies: v1PolicyOrder(action.policies),
+        }))
+      : userActions
   const actions =
     userActions.length || rawActions.length || permitFallbackPolicies.length
-      ? [...userActions, ...rawActions, ...injectedActions].map(
+      ? [...v1CompatibleActions, ...rawActions, ...injectedActions].map(
           (action): ResolvedAction => ({
             actionTargetSelector:
               'selector' in action
@@ -229,10 +239,7 @@ export function resolveSessionData(
               'target' in action
                 ? action.target
                 : SMART_SESSIONS_FALLBACK_TARGET_FLAG,
-            actionPolicies: (definition.saltMode === 'v1'
-              ? v1PolicyOrder(action.policies)
-              : action.policies
-            )?.map((policy) =>
+            actionPolicies: action.policies?.map((policy) =>
               encodeSessionPolicy(policy, environment, addresses),
             ) ?? [{ policy: addresses.sudo, initData: '0x' }],
           }),
@@ -310,7 +317,9 @@ function sessionSalt(
  * and diverge with one, which is what makes this worth doing rather than
  * documenting.
  *
- * Stable: only the params policy moves, and anything else keeps its position.
+ * Stable in the sense that matters: the params policy moves to the front and
+ * everything else keeps its order relative to the rest, though its index
+ * shifts.
  */
 const PARAMS_POLICY_TYPES = new Set(['arg-policy', 'universal-action'])
 

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -245,6 +245,22 @@ export function resolveSessionData(
           }),
         )
       : [sudoAction]
+  // 1.x salts a swap-scoped session over its PRODUCTION venues even when built
+  // for dev, so the salt — and the permissionId with it — does not move between
+  // environments. Reproducing one means reproducing that, and the cheapest
+  // faithful way is to resolve the same definition again at production and salt
+  // over those actions. The session itself keeps its dev venues; only the salt
+  // changes. Terminates: the recursive call resolves at production, where this
+  // is skipped.
+  const v1SaltActions =
+    definition.saltMode === 'v1' &&
+    environment === 'development' &&
+    definition.swap !== undefined
+      ? resolveSessionData(definition, {
+          ...options,
+          environment: 'production',
+        }).actions
+      : undefined
   const claimPolicies = [
     ...(definition.claimPolicies ?? []),
     ...expandedPermits.map(({ claim }) => claim),
@@ -268,7 +284,7 @@ export function resolveSessionData(
     sessionValidator: validator.address,
     sessionValidatorInitData: validator.initData,
     salt: sessionSalt(definition.saltMode, restricted, {
-      actions,
+      actions: v1SaltActions ?? actions,
       erc7739Policies,
       claimPolicies,
     }),

--- a/src/modules/validators/smart-sessions/resolve.ts
+++ b/src/modules/validators/smart-sessions/resolve.ts
@@ -229,7 +229,10 @@ export function resolveSessionData(
               'target' in action
                 ? action.target
                 : SMART_SESSIONS_FALLBACK_TARGET_FLAG,
-            actionPolicies: action.policies?.map((policy) =>
+            actionPolicies: (definition.saltMode === 'v1'
+              ? v1PolicyOrder(action.policies)
+              : action.policies
+            )?.map((policy) =>
               encodeSessionPolicy(policy, environment, addresses),
             ) ?? [{ policy: addresses.sudo, initData: '0x' }],
           }),
@@ -295,6 +298,36 @@ function sessionSalt(
   return mode === 'v1'
     ? v1RestrictedSalt(session.actions)
     : strictSessionSalt(session)
+}
+
+/**
+ * The order 1.x puts an action's policies in.
+ *
+ * 1.x builds an approve action as `[arg policy, spending limits]`; here the
+ * `spendingLimit` sugar expands before `params` compiles, so the pair comes
+ * out reversed. Policies are hashed in their array order, so a 1.x session
+ * only reproduces here if the order does too — the digests agree without a cap
+ * and diverge with one, which is what makes this worth doing rather than
+ * documenting.
+ *
+ * Stable: only the params policy moves, and anything else keeps its position.
+ */
+const PARAMS_POLICY_TYPES = new Set(['arg-policy', 'universal-action'])
+
+function v1PolicyOrder<T extends { readonly type: string }>(
+  policies: readonly T[] | undefined,
+): readonly T[] | undefined {
+  if (!policies) return policies
+  const fromParams = policies.filter((policy) =>
+    PARAMS_POLICY_TYPES.has(policy.type),
+  )
+  if (fromParams.length === 0 || fromParams.length === policies.length) {
+    return policies
+  }
+  return [
+    ...fromParams,
+    ...policies.filter((policy) => !PARAMS_POLICY_TYPES.has(policy.type)),
+  ]
 }
 
 /**

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -1105,3 +1105,30 @@ describe('resolveSwapScope — several sell tokens', () => {
     expect(() => scopeFor({ tokens: [USDC, USDT0] })).toThrow(/same address/)
   })
 })
+
+describe("saltMode 'v1' across environments", () => {
+  const SELL = '0x2d661C89D812261039AF9764eceaAee884f5F67F' as Address
+  const BUY = '0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb' as Address
+  const TO = '0x6e82374c4e39b766a892e215e67fa17202cd0e58' as Address
+
+  const salt = (environment: 'production' | 'development') =>
+    getSessionData(
+      toSession(
+        {
+          chain: { id: 9745 } as Chain,
+          owners: { type: 'ecdsa', accounts: [accountA] },
+          saltMode: 'v1',
+          swap: { sell: { token: SELL }, buy: { token: BUY }, to: TO },
+        } as never,
+        { environment },
+      ),
+    ).salt
+
+  // 1.x salts a swap-scoped session over its production venues whatever it was
+  // built for, so the permissionId does not move between environments. A dev
+  // session that salted over dev venues could not be rebuilt from a 1.x
+  // registration, which is the whole purpose of this mode.
+  test('salts over production venues even when built for dev', () => {
+    expect(salt('development')).toBe(salt('production'))
+  })
+})

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -290,8 +290,9 @@ export interface SessionDefinition {
    * - `'none'` (default) leaves the salt at `zeroHash`, which is what stored
    *   signatures already cover. Restricted sessions for one signer therefore
    *   share a permissionId.
-   * - `'v1'` hashes the actions, matching the 1.x derivation. Use it to
-   *   reproduce a session built there.
+   * - `'v1'` reproduces a session the 1.x SDK built: the salt hashes the
+   *   actions in build order, and an action's policies are emitted in 1.x's
+   *   order rather than this one's. Both are digest inputs.
    * - `'strict'` hashes every field enabled under the permissionId — actions,
    *   ERC-1271 policies, ERC-7739 content and claim policies — with actions in
    *   a canonical order.

--- a/src/modules/validators/smart-sessions/types.ts
+++ b/src/modules/validators/smart-sessions/types.ts
@@ -291,8 +291,9 @@ export interface SessionDefinition {
    *   signatures already cover. Restricted sessions for one signer therefore
    *   share a permissionId.
    * - `'v1'` reproduces a session the 1.x SDK built: the salt hashes the
-   *   actions in build order, and an action's policies are emitted in 1.x's
-   *   order rather than this one's. Both are digest inputs.
+   *   actions in build order, and a permission-derived action's policies are
+   *   emitted in 1.x's order rather than this one's. Both are digest inputs.
+   *   A raw `actions` entry keeps the order you gave it, as it does on 1.x.
    * - `'strict'` hashes every field enabled under the permissionId — actions,
    *   ERC-1271 policies, ERC-7739 content and claim policies — with actions in
    *   a canonical order.


### PR DESCRIPTION
`saltMode: 'v1'` exists so a scoped session built by the 1.x SDK can be rebuilt here — the deposit service does this to settle for clients on that major. It only aligned the salt, and that turned out not to be enough.

1.x builds an approve action's policies as `[arg policy, spending limits]`. Here the `spendingLimit` sugar expands before `params` compiles, so the pair came out reversed. Policies are hashed in array order, so the rebuilt digest diverged from the one the owner signed.

### Why no test caught it

It only appears once the scope carries a spend cap. Without one the action has a single policy and there is no order to disagree about. Every pinned digest fixture is uncapped, so they all agreed — including `V1_DIGEST`, the one that exists to prove this path works.

Found by building a session with a real `@rhinestone/sdk@1.18.0` and feeding its digest to the rebuild, rather than comparing two fixtures to each other.

### Verification

Measured against sessions built by a real `1.18.0` install:

| scope | 1.18.0 | this branch, `saltMode: 'v1'` |
| --- | --- | --- |
| with cap | `0x33fbfa35…` | `0x33fbfa35…` ✅ (was `0x4fded4c0…`) |
| no cap | `0x4a2ffc56…` | `0x4a2ffc56…` ✅ unchanged |

The reorder is gated on the mode, so no session that has not opted in moves. Full validator suite green (355), `tsc` clean.

The new test pins the ordering offline — no RPC, so it cannot be skipped the way the digest fixtures are.

### Note on naming

`saltMode` now governs more than the salt. It was published in 2.15.0 today and has no users, so renaming it to something like `compat: 'v1'` is cheap if preferred — flagging rather than doing it, since it widens the change.


Closes [RHI-6981](https://linear.app/rhinestone/issue/RHI-6981/scoped-sessions-built-on-the-1x-sdk-cannot-be-settled)
