### PR TITLE
feat!: remove saltMode

### DIFF
--- a/.changeset/drop-v1-salt-mode.md
+++ b/.changeset/drop-v1-salt-mode.md
@@ -2,16 +2,19 @@
 '@rhinestone/sdk': minor
 ---
 
-Deprecate `saltMode`; it is now ignored. A restricted session's salt always
-hashes the actions alone, which is what it did by default; an unrestricted one
-stays on `zeroHash`.
+Remove `saltMode`. A restricted session's salt hashes the actions alone, which
+is what it did by default; an unrestricted one stays on `zeroHash`.
 
 `'v1'` only ever named that default. `'strict'` was meant to let a session
 built here be rebuilt on 2.x, but the majors also pin different policy
 addresses, so matching the salt still left the digest different — and a
 session built with it matched neither shape the deposit service rebuilds,
-failing every deposit for that account. Anything set to `'strict'` now
-produces a session that can be rebuilt.
+failing every deposit for that account.
 
-The option stays in the type so 1.18.0 callers keep compiling; it is removed
-in the next major.
+**This is a breaking type change shipped in a minor, deliberately.** Removing
+an exported field warrants a major, and this line has none left: a major from
+1.x is 2.0.0, which is published and belongs to the next major. The option was
+released this morning in 1.18.0, produces sessions that cannot be settled, and
+has no adopters, so removing it is judged safer than leaving it reachable.
+Anyone who did set it should drop it; the default was always the behaviour
+they wanted.

--- a/.changeset/drop-v1-salt-mode.md
+++ b/.changeset/drop-v1-salt-mode.md
@@ -1,0 +1,20 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Remove `saltMode`.
+
+It was added in 1.18.0 on a premise that does not hold. `'v1'` was already the
+default — an alias for the actions-only hash this SDK has always produced — and
+`'strict'` was meant to let a session built here be rebuilt on 2.x, which it
+cannot do: the two majors also pin different policy addresses, so aligning the
+salt closes one of two gaps and the digest still differs.
+
+Worse than useless in practice. A restricted session built with `'strict'`
+matches neither shape the deposit service rebuilds — not 2.x, whose policy
+addresses differ, and not the 1.x shape, which derives the salt the default
+way. Every deposit for such an account would fail.
+
+Nothing is affected that did not set it: `'v1'` was a no-op, the default
+derivation is unchanged and pinned by test, and cross-major reproduction is
+handled where it belongs, on the 2.x side, which rebuilds a session built here.

--- a/.changeset/drop-v1-salt-mode.md
+++ b/.changeset/drop-v1-salt-mode.md
@@ -2,19 +2,15 @@
 '@rhinestone/sdk': minor
 ---
 
-Remove `saltMode`.
+Deprecate `saltMode`; it is now ignored. The salt always hashes the actions
+alone, which is what it did by default.
 
-It was added in 1.18.0 on a premise that does not hold. `'v1'` was already the
-default — an alias for the actions-only hash this SDK has always produced — and
-`'strict'` was meant to let a session built here be rebuilt on 2.x, which it
-cannot do: the two majors also pin different policy addresses, so aligning the
-salt closes one of two gaps and the digest still differs.
+`'v1'` only ever named that default. `'strict'` was meant to let a session
+built here be rebuilt on 2.x, but the majors also pin different policy
+addresses, so matching the salt still left the digest different — and a
+session built with it matched neither shape the deposit service rebuilds,
+failing every deposit for that account. Anything set to `'strict'` now
+produces a session that can be rebuilt.
 
-Worse than useless in practice. A restricted session built with `'strict'`
-matches neither shape the deposit service rebuilds — not 2.x, whose policy
-addresses differ, and not the 1.x shape, which derives the salt the default
-way. Every deposit for such an account would fail.
-
-Nothing is affected that did not set it: `'v1'` was a no-op, the default
-derivation is unchanged and pinned by test, and cross-major reproduction is
-handled where it belongs, on the 2.x side, which rebuilds a session built here.
+The option stays in the type so 1.18.0 callers keep compiling; it is removed
+in the next major.

--- a/.changeset/drop-v1-salt-mode.md
+++ b/.changeset/drop-v1-salt-mode.md
@@ -2,8 +2,9 @@
 '@rhinestone/sdk': minor
 ---
 
-Deprecate `saltMode`; it is now ignored. The salt always hashes the actions
-alone, which is what it did by default.
+Deprecate `saltMode`; it is now ignored. A restricted session's salt always
+hashes the actions alone, which is what it did by default; an unrestricted one
+stays on `zeroHash`.
 
 `'v1'` only ever named that default. `'strict'` was meant to let a session
 built here be rebuilt on 2.x, but the majors also pin different policy

--- a/src/modules/validators/smart-sessions.ts
+++ b/src/modules/validators/smart-sessions.ts
@@ -56,7 +56,6 @@ import {
   SMART_SESSION_EMISSARY_ADDRESS,
   SMART_SESSION_EMISSARY_ADDRESS_DEV,
 } from './core'
-import { compareHexValues } from './ordering'
 import {
   encodePermit2ClaimPolicyInitData,
   PERMIT2_CLAIM_POLICY_ADDRESS,
@@ -796,11 +795,7 @@ function getSessionData(
 
   return {
     sessionValidator: validator.address,
-    salt: restricted
-      ? session.saltMode === 'strict'
-        ? getStrictSessionSalt(saltActions, erc7739Data, claimPolicies)
-        : getRestrictedSessionSalt(saltActions)
-      : zeroHash,
+    salt: restricted ? getRestrictedSessionSalt(saltActions) : zeroHash,
     sessionValidatorInitData: validator.initData,
     erc7739Policies: erc7739Data,
     actions,
@@ -828,93 +823,6 @@ function resolveActionData(
       },
     ],
   }
-}
-
-const STRICT_SALT_POLICY_COMPONENTS = [
-  { name: 'policy', type: 'address' },
-  { name: 'initData', type: 'bytes' },
-] as const
-
-/**
- * Salt covering everything `_enablePolicies` writes under the permissionId.
- *
- * `getRestrictedSessionSalt` hashes actions only, so two restricted sessions
- * differing just by `signing` share a permissionId and union on enable. This
- * mirrors the 2.x derivation exactly, so the same session built on either major
- * lands on the same permissionId — provided the policy addresses match too.
- *
- * Actions are sorted by (target, selector): on-chain they are keyed by action
- * id, so the same set listed in a different order is the same authorisation.
- */
-function getStrictSessionSalt(
-  actions: readonly ActionData[],
-  erc7739Policies: {
-    allowedERC7739Content: readonly {
-      appDomainSeparator: Hex
-      contentNames: readonly string[]
-    }[]
-    erc1271Policies: readonly { policy: Address; initData: Hex }[]
-  },
-  claimPolicies: readonly { policy: Address; initData: Hex }[],
-): Hex {
-  const sorted = [...actions]
-    .sort(
-      (a, b) =>
-        compareHexValues(a.actionTarget, b.actionTarget) ||
-        compareHexValues(a.actionTargetSelector, b.actionTargetSelector),
-    )
-    .map((action) => ({
-      actionTargetSelector: action.actionTargetSelector,
-      actionTarget: action.actionTarget,
-      actionPolicies: action.actionPolicies.map((policy) => ({ ...policy })),
-    }))
-
-  return keccak256(
-    encodeAbiParameters(
-      [
-        {
-          name: 'actions',
-          type: 'tuple[]',
-          components: [
-            { name: 'actionTargetSelector', type: 'bytes4' },
-            { name: 'actionTarget', type: 'address' },
-            {
-              name: 'actionPolicies',
-              type: 'tuple[]',
-              components: STRICT_SALT_POLICY_COMPONENTS,
-            },
-          ],
-        },
-        {
-          name: 'erc1271Policies',
-          type: 'tuple[]',
-          components: STRICT_SALT_POLICY_COMPONENTS,
-        },
-        {
-          name: 'allowedERC7739Content',
-          type: 'tuple[]',
-          components: [
-            { name: 'appDomainSeparator', type: 'bytes32' },
-            { name: 'contentNames', type: 'string[]' },
-          ],
-        },
-        {
-          name: 'claimPolicies',
-          type: 'tuple[]',
-          components: STRICT_SALT_POLICY_COMPONENTS,
-        },
-      ],
-      [
-        sorted,
-        erc7739Policies.erc1271Policies.map((policy) => ({ ...policy })),
-        erc7739Policies.allowedERC7739Content.map((content) => ({
-          appDomainSeparator: content.appDomainSeparator,
-          contentNames: [...content.contentNames],
-        })),
-        claimPolicies.map((policy) => ({ ...policy })),
-      ] as never,
-    ),
-  )
 }
 
 function getRestrictedSessionSalt(actions: readonly ActionData[]): Hex {

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -265,6 +265,14 @@ describe('restricted session salt', () => {
     expect(getSessionData(reversed).salt).not.toBe(V1_SALT)
   })
 
+  // `saltMode` still type-checks so a 1.18.0 caller keeps compiling, but it
+  // no longer selects anything: 'strict' produced a session neither shape the
+  // deposit service builds could rebuild.
+  test('ignores saltMode whatever it is set to', () => {
+    expect(getSessionData(scoped({ saltMode: 'v1' })).salt).toBe(V1_SALT)
+    expect(getSessionData(scoped({ saltMode: 'strict' })).salt).toBe(V1_SALT)
+  })
+
   test('stays on zeroHash when the session is unrestricted', () => {
     expect(getSessionData(scoped({ restrictToActions: false })).salt).toBe(
       zeroHash,

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -265,14 +265,6 @@ describe('restricted session salt', () => {
     expect(getSessionData(reversed).salt).not.toBe(V1_SALT)
   })
 
-  // `saltMode` still type-checks so a 1.18.0 caller keeps compiling, but it
-  // no longer selects anything: 'strict' produced a session neither shape the
-  // deposit service builds could rebuild.
-  test('ignores saltMode whatever it is set to', () => {
-    expect(getSessionData(scoped({ saltMode: 'v1' })).salt).toBe(V1_SALT)
-    expect(getSessionData(scoped({ saltMode: 'strict' })).salt).toBe(V1_SALT)
-  })
-
   test('stays on zeroHash when the session is unrestricted', () => {
     expect(getSessionData(scoped({ restrictToActions: false })).salt).toBe(
       zeroHash,

--- a/src/modules/validators/smart-sessions/swap/scope.test.ts
+++ b/src/modules/validators/smart-sessions/swap/scope.test.ts
@@ -234,7 +234,7 @@ describe('restricted v1 sessions', () => {
   })
 })
 
-describe('saltMode', () => {
+describe('restricted session salt', () => {
   const scoped = (extra?: Partial<Session>): Session => ({
     chain: base,
     owners: { type: 'ecdsa', accounts: [accountA] },
@@ -250,42 +250,24 @@ describe('saltMode', () => {
     ...extra,
   })
 
-  // Frozen derivations: a change here strands every already-signed session.
+  // Frozen derivation: a change here strands every already-signed session.
   const V1_SALT =
     '0x08060e7ab6e41dfa09c11798c60d867716c8a5fa1308f6ac6c55d8bff0a70cab'
-  const STRICT_SALT =
-    '0xd30be60c8217a07e1dd8b97153810e0b637940b8db29162f63d1bc644675f146'
 
-  test("default and explicit 'v1' keep the actions-only salt byte-for-byte", () => {
+  test('hashes the actions alone, byte-for-byte', () => {
     expect(getSessionData(scoped()).salt).toBe(V1_SALT)
-    expect(getSessionData(scoped({ saltMode: 'v1' })).salt).toBe(V1_SALT)
   })
 
-  test("'strict' lands on a different salt and permissionId", () => {
-    expect(getSessionData(scoped({ saltMode: 'strict' })).salt).toBe(
-      STRICT_SALT,
-    )
-    expect(getPermissionId(scoped({ saltMode: 'strict' }))).not.toBe(
-      getPermissionId(scoped()),
-    )
-  })
-
-  // v1 cannot reach the fields 'strict' adds: a restricted session throws on
-  // claimPolicies and has its 1271/7739 config forced empty. So here the two
-  // modes differ only by canonical action ordering. The wider coverage exists
-  // for parity with 2.x, where those fields ARE reachable — it is what lets a
-  // session built here be rebuilt there.
-  test("'strict' is independent of action listing order; 'v1' is not", () => {
+  // Deliberately order-sensitive: the salt hashes the actions as listed, and
+  // the deposit service reproduces a session by building it the same way.
+  test('depends on the order the actions were listed in', () => {
     const reversed = scoped({ actions: [...scoped().actions!].reverse() })
-    expect(getSessionData({ ...reversed, saltMode: 'strict' }).salt).toBe(
-      STRICT_SALT,
-    )
     expect(getSessionData(reversed).salt).not.toBe(V1_SALT)
   })
 
-  test('unrestricted sessions stay on zeroHash in both modes', () => {
-    const open = scoped({ restrictToActions: false })
-    expect(getSessionData({ ...open, saltMode: 'strict' }).salt).toBe(zeroHash)
-    expect(getSessionData({ ...open, saltMode: 'v1' }).salt).toBe(zeroHash)
+  test('stays on zeroHash when the session is unrestricted', () => {
+    expect(getSessionData(scoped({ restrictToActions: false })).salt).toBe(
+      zeroHash,
+    )
   })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,22 +319,6 @@ interface SessionInput {
   restrictToActions?: boolean
   /** Restrict this session to swaps matching the declared tokens and recipient. */
   swap?: SwapScope
-  /**
-   * @deprecated Ignored. A restricted session's salt always hashes the actions
-   * alone — what it did by default, and what stored signatures cover. An
-   * unrestricted session stays on `zeroHash` as before.
-   *
-   * `'v1'` only ever named that default. `'strict'` was meant to let a
-   * session built here be rebuilt on 2.x, but the majors also pin different
-   * policy addresses, so matching the salt left the digest different anyway —
-   * and a session built with it matched neither shape the deposit service
-   * rebuilds, failing every deposit for that account. Reproducing a 1.x
-   * session is handled on the 2.x side, which is the side doing the rebuild.
-   *
-   * Kept in the type rather than removed because this major line cannot take
-   * a breaking release: 2.0.0 belongs to the next one. It goes away there.
-   */
-  saltMode?: 'v1' | 'strict'
 }
 
 interface Session extends SessionInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,8 +320,9 @@ interface SessionInput {
   /** Restrict this session to swaps matching the declared tokens and recipient. */
   swap?: SwapScope
   /**
-   * @deprecated Ignored. The salt always hashes the actions alone, which is
-   * what it did by default and what stored signatures cover.
+   * @deprecated Ignored. A restricted session's salt always hashes the actions
+   * alone — what it did by default, and what stored signatures cover. An
+   * unrestricted session stays on `zeroHash` as before.
    *
    * `'v1'` only ever named that default. `'strict'` was meant to let a
    * session built here be rebuilt on 2.x, but the majors also pin different

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,24 +319,6 @@ interface SessionInput {
   restrictToActions?: boolean
   /** Restrict this session to swaps matching the declared tokens and recipient. */
   swap?: SwapScope
-  /**
-   * How a restricted session's salt is derived, which decides its permissionId.
-   *
-   * - `'v1'` (default) hashes the actions alone.
-   * - `'strict'` hashes every field enabled under the permissionId (actions,
-   *   ERC-1271 policies, 7739 content, claim policies) with actions in a
-   *   canonical order.
-   *
-   * A restricted session here throws on `claimPolicies` and has its 1271/7739
-   * config forced empty, so those extra fields are always empty and the two
-   * modes differ only by action ordering. `'strict'` exists for parity with
-   * 2.x, where the same derivation covers fields that ARE reachable — it is
-   * what lets a session built here be rebuilt there.
-   *
-   * Opt-in: changing it moves the permissionId and digest, so an existing
-   * session's stored signature no longer covers it.
-   */
-  saltMode?: 'v1' | 'strict'
 }
 
 interface Session extends SessionInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,6 +319,21 @@ interface SessionInput {
   restrictToActions?: boolean
   /** Restrict this session to swaps matching the declared tokens and recipient. */
   swap?: SwapScope
+  /**
+   * @deprecated Ignored. The salt always hashes the actions alone, which is
+   * what it did by default and what stored signatures cover.
+   *
+   * `'v1'` only ever named that default. `'strict'` was meant to let a
+   * session built here be rebuilt on 2.x, but the majors also pin different
+   * policy addresses, so matching the salt left the digest different anyway —
+   * and a session built with it matched neither shape the deposit service
+   * rebuilds, failing every deposit for that account. Reproducing a 1.x
+   * session is handled on the 2.x side, which is the side doing the rebuild.
+   *
+   * Kept in the type rather than removed because this major line cannot take
+   * a breaking release: 2.0.0 belongs to the next one. It goes away there.
+   */
+  saltMode?: 'v1' | 'strict'
 }
 
 interface Session extends SessionInput {


### PR DESCRIPTION
Reverts the `saltMode` option added in 1.18.0. It was built on a premise that does not hold.

### Why it has no use

- **`'v1'` was already the default.** An alias for the actions-only hash this SDK has always produced — setting it changed nothing.
- **`'strict'` cannot do what it claimed.** It was meant to let a session built here be rebuilt on 2.x with the same digest. The salt is only one of two things that differ between the majors; they also pin different policy addresses, so aligning the salt still leaves the digest different. The published 1.18.0 changelog says otherwise, and that is wrong.
- **The collision it guarded is unreachable here.** A 1.x restricted session is already salted by default, so it never shares a permissionId with the unscoped session. That collision is a 2.x artifact of its `zeroHash` default, and `saltMode: 'strict'` on **2.x** — which stays — is the fix for it.

### Why it is worth removing rather than leaving

A restricted session built with `'strict'` matches **neither** shape the deposit service rebuilds: not 2.x, whose policy addresses differ, and not the 1.x shape, which derives the salt the default way. Every deposit for that account would fail. Leaving a published option that breaks anyone who sets it is worse than deleting it.

### Blast radius

Nothing that did not set it changes. `'v1'` was a no-op; the default derivation is untouched and still pinned byte-for-byte by the test kept alongside (`V1_SALT`), along with its order-sensitivity and the unrestricted `zeroHash` case. The `'strict'`-only cases and the now-dead `getStrictSessionSalt` go with it.

Full unit suite green (390), `tsc` clean.

Cross-major reproduction is handled where it belongs — on the 2.x side, which is the one doing the rebuilding. See rhinestonewtf/sdk#866.


Closes [RHI-6981](https://linear.app/rhinestone/issue/RHI-6981/scoped-sessions-built-on-the-1x-sdk-cannot-be-settled)
