### PR TITLE
feat(hypercore): expose the trade outcome on intent status

### DIFF
--- a/.changeset/intent-status-hypercore-outcome.md
+++ b/.changeset/intent-status-hypercore-outcome.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': minor
+---
+
+Expose the HyperCore trade outcome as `hyperCore` (the new `IntentHyperCoreResult` type) on intent status and on a failed intent's `IntentFailedError` context, so integrators can tell a refused trade from a partial one, whose placed orders a retry would send twice.

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -320,7 +320,10 @@ export interface RhinestoneAccount {
    * Polls the orchestrator until the intent reaches a terminal state; on failure
    * an `IntentFailedError` is thrown, whose `context` carries `operations` and,
    * where a settlement layer returned the funds, `refunds` — a refunded intent
-   * is still a failed one, so that error is where the refund surfaces.
+   * is still a failed one, so that error is where the refund surfaces. An
+   * intent that carried a HyperCore action also carries `hyperCore` there,
+   * which tells a refused trade (safe to retry) from a partial one (check the
+   * account first).
    * @param result The result returned by a submit/send call
    * @returns The per-chain operation status (for intents) or a UserOp receipt
    */
@@ -819,6 +822,7 @@ export function createAccountFacade(
             accountAddress: status.account,
             operations: status.operations as TransactionStatus['operations'],
             ...(status.refunds ? { refunds: [...status.refunds] } : {}),
+            ...(status.hyperCore ? { hyperCore: status.hyperCore } : {}),
           }))
       }
       const ctx = context('wait-for-execution')

--- a/src/api/project-mappers.test.ts
+++ b/src/api/project-mappers.test.ts
@@ -54,6 +54,26 @@ describe('SDK project boundary adapters', () => {
     expect('refunds' in toPublicTransactionStatus(failed)).toBe(false)
   })
 
+  test('carries the HyperCore outcome onto the public shape, and omits it when absent', () => {
+    const failed = {
+      traceId: 'trace-status',
+      intentId: 'intent-1',
+      status: 'FAILED',
+      account: address,
+      operations: [],
+      terminal: true,
+    } as const
+    const hyperCore = {
+      outcome: 'partial',
+      reason: 'action 0 accepted; action 1 refused: Insufficient margin.',
+    } as const
+
+    expect(
+      toPublicTransactionStatus({ ...failed, hyperCore }).hyperCore,
+    ).toEqual(hyperCore)
+    expect('hyperCore' in toPublicTransactionStatus(failed)).toBe(false)
+  })
+
   test('maps public split requests with and without settlement filters', () => {
     expect(
       toOrchestratorSplitRequest({

--- a/src/api/project-mappers.ts
+++ b/src/api/project-mappers.ts
@@ -20,6 +20,7 @@ export function toPublicTransactionStatus(
     accountAddress: status.account,
     operations: [...status.operations],
     ...(status.refunds ? { refunds: [...status.refunds] } : {}),
+    ...(status.hyperCore ? { hyperCore: status.hyperCore } : {}),
   }
 }
 

--- a/src/clients/orchestrator/mappers.test.ts
+++ b/src/clients/orchestrator/mappers.test.ts
@@ -251,3 +251,57 @@ describe('mapIntentStatusFromWire refunds', () => {
     expect(mapped.refunds).toEqual([{ chain: 42161, txHash: REFUND_TX }])
   })
 })
+
+describe('mapIntentStatusFromWire hyperCore', () => {
+  const status = (hyperCore?: unknown) => ({
+    traceId: 'trace-1',
+    status: 'FAILED',
+    accountAddress: address,
+    operations: [
+      { chain: 8453, items: [{ status: 'COMPLETED', txHash: '0xaa' }] },
+    ],
+    ...(hyperCore === undefined ? {} : { hyperCore }),
+  })
+
+  test('surfaces the outcome and its reason', () => {
+    const mapped = mapIntentStatusFromWire(
+      'intent-1',
+      status({ outcome: 'refused', reason: 'Insufficient margin.' }),
+    )
+    expect(mapped.hyperCore).toEqual({
+      outcome: 'refused',
+      reason: 'Insufficient margin.',
+    })
+  })
+
+  test('surfaces an outcome that carries no reason', () => {
+    const mapped = mapIntentStatusFromWire(
+      'intent-1',
+      status({ outcome: 'accepted' }),
+    )
+    expect(mapped.hyperCore).toEqual({ outcome: 'accepted' })
+  })
+
+  test('leaves hyperCore absent when the intent carried no action', () => {
+    const mapped = mapIntentStatusFromWire('intent-1', status())
+    expect('hyperCore' in mapped).toBe(false)
+  })
+
+  test('keeps a partial outcome distinct from a refused one', () => {
+    // A partial placed orders and must not be re-sent; a refusal placed none
+    // and is safe to retry. Both arrive with every operation COMPLETED.
+    const partial = mapIntentStatusFromWire(
+      'intent-1',
+      status({
+        outcome: 'partial',
+        reason: 'action 0 accepted; action 1 refused: Insufficient margin.',
+      }),
+    )
+    const refused = mapIntentStatusFromWire(
+      'intent-1',
+      status({ outcome: 'refused', reason: 'Insufficient margin.' }),
+    )
+    expect(partial.hyperCore?.outcome).toBe('partial')
+    expect(refused.hyperCore?.outcome).toBe('refused')
+  })
+})

--- a/src/clients/orchestrator/mappers.ts
+++ b/src/clients/orchestrator/mappers.ts
@@ -122,6 +122,7 @@ export function mapIntentStatusFromWire(
       readonly chain?: string | number
       readonly txHash: string
     }[]
+    readonly hyperCore?: OrchestratorIntentStatus['hyperCore']
   }
   return {
     traceId: input.traceId ?? '',
@@ -150,6 +151,16 @@ export function mapIntentStatusFromWire(
             chain: parseChainValue(refund.chain),
             txHash: refund.txHash,
           })),
+        }
+      : {}),
+    ...(input.hyperCore
+      ? {
+          hyperCore: {
+            outcome: input.hyperCore.outcome,
+            ...(input.hyperCore.reason === undefined
+              ? {}
+              : { reason: input.hyperCore.reason }),
+          },
         }
       : {}),
   }

--- a/src/clients/orchestrator/public.ts
+++ b/src/clients/orchestrator/public.ts
@@ -688,6 +688,32 @@ interface IntentRefund {
 }
 
 /**
+ * What became of the HyperCore action an intent carried.
+ *
+ * A refused action leaves the intent `FAILED` with every operation
+ * `COMPLETED`: the onchain half succeeded and Hyperliquid's answer is what
+ * failed, so the operations cannot say whether sending it again is safe.
+ *
+ * - `pending`  – no result yet
+ * - `accepted` – Hyperliquid accepted the action
+ * - `refused`  – Hyperliquid refused the action, so it was not placed; with
+ *                several actions, `reason` says which were accepted before it
+ * - `partial`  – some orders were placed; check the account before retrying,
+ *                or the placed orders are sent twice
+ * - `error`    – no definite answer; check the account before retrying
+ * - `unknown`  – no definite answer; check the account before retrying
+ */
+interface IntentHyperCoreResult {
+  outcome: 'pending' | 'accepted' | 'refused' | 'error' | 'unknown' | 'partial'
+  /**
+   * Why the action did not simply succeed. Present on `refused`, `error`,
+   * `unknown` and `partial`. With several actions it says which action failed
+   * and which were accepted.
+   */
+  reason?: string
+}
+
+/**
  * Full intent status as returned by the orchestrator (blanc API version).
  *
  * One operation per chain involved in the intent. The SDK flattens the
@@ -712,6 +738,13 @@ interface IntentOpStatus {
    * completed did not take the funds in the first place.
    */
   refunds?: IntentRefund[]
+  /**
+   * What became of the HyperCore action this intent carried; absent when it
+   * carried none. A refused action leaves the intent `FAILED` with every
+   * operation `COMPLETED`, so this is what says why, and whether a retry is
+   * safe.
+   */
+  hyperCore?: IntentHyperCoreResult
 }
 
 export type {
@@ -758,6 +791,7 @@ export type {
   IntentSubmitResponse,
   IntentOpStatus,
   IntentRefund,
+  IntentHyperCoreResult,
   IntentOptions,
   SponsorSettings,
   SignedAuthorization,

--- a/src/clients/orchestrator/types.ts
+++ b/src/clients/orchestrator/types.ts
@@ -9,6 +9,7 @@ import type {
   ChainOperation,
   Cost,
   HyperCoreAction,
+  IntentHyperCoreResult,
   IntentRefund,
   IntentStatus,
   SerializedIntentInput,
@@ -138,6 +139,7 @@ export interface OrchestratorIntentStatus {
   readonly account: Address
   readonly operations: readonly ChainOperation[]
   readonly refunds?: readonly IntentRefund[]
+  readonly hyperCore?: IntentHyperCoreResult
 }
 
 export interface OrchestratorPortfolioRequest {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export type {
   HyperCoreTimeInForce,
   HyperCoreUpdateIsolatedMarginAction,
   HyperCoreUpdateLeverageAction,
+  IntentHyperCoreResult,
   IntentInput,
   IntentOpStatus,
   IntentRefund,

--- a/src/transactions/intents/domain.test.ts
+++ b/src/transactions/intents/domain.test.ts
@@ -302,6 +302,25 @@ describe('intent domain', () => {
     expect('refunds' in classifyIntentStatus(failed)).toBe(false)
   })
 
+  test('classifies a HyperCore outcome through, and leaves it absent when none was carried', () => {
+    const failed = {
+      traceId: '',
+      intentId: 'intent',
+      status: 'FAILED',
+      account: address,
+      operations: [],
+    } as const
+    const hyperCore = {
+      outcome: 'refused',
+      reason: 'Insufficient margin.',
+    } as const
+
+    expect(classifyIntentStatus({ ...failed, hyperCore }).hyperCore).toEqual(
+      hyperCore,
+    )
+    expect('hyperCore' in classifyIntentStatus(failed)).toBe(false)
+  })
+
   test('classifies retry delays and terminal failures', async () => {
     const rateLimit = (retryAfter?: string) =>
       new RateLimitedError({
@@ -430,5 +449,58 @@ describe('intent domain', () => {
         expect('refunds' in error.context).toBe(false)
       }),
     ])
+  })
+
+  test('carries the HyperCore outcome on the failed-intent error while every operation completed', async () => {
+    // The onchain half succeeded, so the operations cannot say whether a
+    // re-send is safe: only `hyperCore` tells a partial from a refusal.
+    const failing = (hyperCore?: {
+      readonly outcome: 'partial' | 'refused'
+      readonly reason: string
+    }) => ({
+      statusClient: {
+        getIntentStatus: vi.fn(async () => ({
+          traceId: 'trace',
+          intentId: 'intent',
+          status: 'FAILED' as const,
+          account: address,
+          operations: [
+            {
+              chain: 8453,
+              status: 'COMPLETED' as const,
+              txHash: '0xaa' as const,
+              timestamp: 1,
+            },
+          ],
+          ...(hyperCore ? { hyperCore } : {}),
+        })),
+      },
+      clock: {
+        now: vi.fn().mockReturnValueOnce(0).mockReturnValue(20_000),
+        sleep: vi.fn(async () => undefined),
+      },
+    })
+    const partial = {
+      outcome: 'partial',
+      reason: 'action 0 accepted; action 1 refused: Insufficient margin.',
+    } as const
+    const refused = {
+      outcome: 'refused',
+      reason: 'Insufficient margin.',
+    } as const
+
+    for (const hyperCore of [partial, refused]) {
+      await expect(
+        waitForIntentStatus(failing(hyperCore), 'intent'),
+      ).rejects.toMatchObject({
+        context: { operations: [{ status: 'COMPLETED' }], hyperCore },
+      })
+    }
+
+    const error = await waitForIntentStatus(failing(), 'intent').catch(
+      (caught) => caught,
+    )
+    expect(error).toBeInstanceOf(IntentFailedError)
+    expect('hyperCore' in error.context).toBe(false)
   })
 })

--- a/src/transactions/intents/status-policy.ts
+++ b/src/transactions/intents/status-policy.ts
@@ -21,6 +21,7 @@ export function classifyIntentStatus(
     // Spread so an unknown refund state stays an absent key rather than
     // becoming `undefined` — the distinction the whole field rests on.
     ...(status.refunds ? { refunds: status.refunds } : {}),
+    ...(status.hyperCore ? { hyperCore: status.hyperCore } : {}),
     terminal: status.status === 'COMPLETED' || status.status === 'FAILED',
   }
 }

--- a/src/transactions/intents/status.ts
+++ b/src/transactions/intents/status.ts
@@ -53,16 +53,19 @@ export async function waitForIntentStatus<CompatibilityConfig>(
     }
     if (!status.terminal) continue
     if (status.status === 'FAILED') {
-      // The refund rides the ERROR, because this is the only path it can take:
-      // a refunded intent is still `FAILED` — it did not do what was asked —
+      // The refund and the HyperCore outcome ride the ERROR, because this is
+      // the only path they can take: a refunded intent, or one whose HyperCore
+      // action was refused, is still `FAILED` — it did not do what was asked —
       // so this throws and the caller never sees a returned status. Omitting
-      // it here would hide the refund from `waitForExecution` for the exact
-      // case the field exists to answer.
+      // them here would hide both from `waitForExecution` for the exact cases
+      // the fields exist to answer; a refused trade's operations all read
+      // COMPLETED, so nothing else says whether a retry is safe.
       throw new IntentFailedError({
         context: {
           intentId,
           operations: status.operations,
           ...(status.refunds ? { refunds: status.refunds } : {}),
+          ...(status.hyperCore ? { hyperCore: status.hyperCore } : {}),
         },
       })
     }

--- a/src/transactions/intents/types.ts
+++ b/src/transactions/intents/types.ts
@@ -120,6 +120,11 @@ export interface IntentStatus {
   readonly operations: readonly IntentOpStatus['operations'][number][]
   /** Bridge refunds, if any are known. See {@link IntentOpStatus.refunds}. */
   readonly refunds?: readonly NonNullable<IntentOpStatus['refunds']>[number][]
+  /**
+   * The HyperCore action's outcome, if the intent carried one. See
+   * {@link IntentOpStatus.hyperCore}.
+   */
+  readonly hyperCore?: NonNullable<IntentOpStatus['hyperCore']>
   readonly terminal: boolean
 }
 
@@ -194,4 +199,10 @@ export interface TransactionStatus {
    * transaction says the funds came back. See {@link IntentOpStatus.refunds}.
    */
   refunds?: IntentOpStatus['refunds']
+  /**
+   * The HyperCore action's outcome, if the transaction carried one. This is
+   * what tells a refused trade from a partial one when every operation
+   * completed. See {@link IntentOpStatus.hyperCore}.
+   */
+  hyperCore?: IntentOpStatus['hyperCore']
 }


### PR DESCRIPTION
RHI-6783

The orchestrator's intent status carries `hyperCore: { outcome, reason? }` for an intent with a HyperCore action, but `mapIntentStatusFromWire` dropped it. A refused trade therefore reached integrators as a bare `FAILED` with every operation `COMPLETED`, and a `partial` — whose placed orders a retry would send twice — could not be told from a `refused`.

`hyperCore` now rides `IntentOpStatus` and a failed intent's `IntentFailedError` context, exactly where `refunds` does, with a new public `IntentHyperCoreResult` type (hence the minor changeset). It is widened at the mapper boundary like `refunds`, so it needs no `.openapi-ref` bump.

`bun run typecheck`, `check`, `test:types`, `test:unit` (1057), `generate:reference` and `build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
