### PR TITLE
fix: stop sending placeholder x-api-key header in bearer auth mode

### DIFF
--- a/.changeset/bearer-no-api-key-placeholder.md
+++ b/.changeset/bearer-no-api-key-placeholder.md
@@ -1,0 +1,5 @@
+---
+'@rhinestone/sdk': patch
+---
+
+Stop sending the placeholder `x-api-key: jwt` header alongside the bearer credential in `experimental_jwt` auth mode. Requests now present only the access token, which every Rhinestone orchestrator environment accepts.

--- a/src/clients/orchestrator/auth.test.ts
+++ b/src/clients/orchestrator/auth.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createOrchestratorAuth } from './auth'
+import type { SerializedIntentInput } from './public'
+
+const address = '0x0000000000000000000000000000000000000001' as const
+const intentInput = {
+  account: { address, accountType: 'ERC7579' },
+  destinationChainId: 1,
+  destinationExecutions: [],
+  tokenRequests: [],
+  options: {},
+} satisfies SerializedIntentInput
+
+describe('orchestrator auth', () => {
+  test('sends the configured api key on requests and submissions', async () => {
+    const auth = createOrchestratorAuth({ kind: 'api-key', apiKey: 'secret' })
+
+    expect(await auth.getHeaders()).toEqual({ 'x-api-key': 'secret' })
+    expect(await auth.getSubmitHeaders(intentInput, true)).toEqual({
+      'x-api-key': 'secret',
+    })
+  })
+
+  test('sends only the bearer credential in jwt mode', async () => {
+    const auth = createOrchestratorAuth({
+      kind: 'jwt',
+      accessToken: 'access',
+    })
+
+    expect(await auth.getHeaders()).toEqual({ Authorization: 'Bearer access' })
+    expect(await auth.getSubmitHeaders(intentInput, false)).toEqual({
+      Authorization: 'Bearer access',
+    })
+  })
+
+  test('adds the intent extension only for sponsored submissions', async () => {
+    const getIntentExtensionToken = vi.fn(async () => 'extension')
+    const auth = createOrchestratorAuth({
+      kind: 'jwt',
+      accessToken: async () => 'access',
+      getIntentExtensionToken,
+    })
+
+    expect(await auth.getSubmitHeaders(intentInput, true)).toEqual({
+      Authorization: 'Bearer access',
+      'X-Intent-Extension': 'Bearer extension',
+    })
+    expect(getIntentExtensionToken).toHaveBeenCalledWith(intentInput)
+
+    expect(await auth.getSubmitHeaders(intentInput, false)).toEqual({
+      Authorization: 'Bearer access',
+    })
+    expect(getIntentExtensionToken).toHaveBeenCalledTimes(1)
+  })
+
+  test('omits the intent extension when no token getter is configured', async () => {
+    const auth = createOrchestratorAuth({
+      kind: 'jwt',
+      accessToken: 'access',
+    })
+
+    expect(await auth.getSubmitHeaders(intentInput, true)).toEqual({
+      Authorization: 'Bearer access',
+    })
+  })
+
+  test('resolves the access token on every request', async () => {
+    const accessToken = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second')
+    const auth = createOrchestratorAuth({ kind: 'jwt', accessToken })
+
+    expect(await auth.getHeaders()).toEqual({ Authorization: 'Bearer first' })
+    expect(await auth.getHeaders()).toEqual({ Authorization: 'Bearer second' })
+    expect(accessToken).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/clients/orchestrator/auth.ts
+++ b/src/clients/orchestrator/auth.ts
@@ -26,7 +26,6 @@ export function createOrchestratorAuth(
       : auth.accessToken
   const headers = async (): Promise<Record<string, string>> => ({
     Authorization: `Bearer ${await accessToken()}`,
-    'x-api-key': 'jwt',
   })
   return {
     getHeaders: headers,

--- a/src/clients/orchestrator/client.test.ts
+++ b/src/clients/orchestrator/client.test.ts
@@ -199,6 +199,7 @@ describe('orchestrator client', () => {
           Authorization: 'Bearer access',
           'X-Intent-Extension': 'Bearer extension',
         })
+        expect(init?.headers).not.toHaveProperty('x-api-key')
         expect(JSON.parse(String(init?.body))).toMatchObject({
           authorizations: {
             sponsor: [{ chainId: 'eip155:8453' }],


### PR DESCRIPTION
- Drop the placeholder `x-api-key: jwt` header from bearer (`experimental_jwt`) auth — requests now present only the access token.
- API-key mode, per-request token resolution, and the sponsored `X-Intent-Extension` header are unchanged.
- New `src/clients/orchestrator/auth.test.ts` asserts exact header sets for both auth modes (the existing `toMatchObject` assertions could not catch an extra header); `client.test.ts` gains an absence assertion on the JWT request.
- Patch changeset.

The orchestrator no longer requires the header for authenticated callers, and that change is live in dev and prod.

Closes [RHI-6899](https://linear.app/rhinestone/issue/RHI-6899/sdk-stop-adding-the-placeholder-api-key-header-to-bearer-requests)
